### PR TITLE
Single instance test objects now declare their instance.

### DIFF
--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -551,18 +551,21 @@ int main(int argc, char *argv[])
             {
                 reboot_time = tv.tv_sec + 5;
             }
-            if (reboot_time < tv.tv_sec) {
+            if (reboot_time < tv.tv_sec)
+            {
                 /*
                  * Message should normally be lost with reboot ...
                  */
                 fprintf(stderr, "reboot time expired, rebooting ...");
                 system_reboot();
             }
-            else {
+            else
+            {
                 tv.tv_sec = reboot_time - tv.tv_sec;
             }
         }
-        else {
+        else
+        {
             update_battery_level(lwm2mH, batterylevelchanging);
             tv.tv_sec = 5;
         }

--- a/tests/client/object_connectivity_moni.c
+++ b/tests/client/object_connectivity_moni.c
@@ -43,8 +43,6 @@
 #include <ctype.h>
 
 // related to TS RC 20131210-C (ATTENTION changes in -D!)
-// Object Id
-#define OBJ_DEVICE_ID                   4
 // Resource Id's:
 #define RES_M_NETWORK_BEARER            0
 #define RES_M_AVL_NETWORK_BEARER        1
@@ -334,11 +332,25 @@ lwm2m_object_t * get_object_conn_m()
         memset(connObj, 0, sizeof(lwm2m_object_t));
 
         /*
-         * It assign his unique ID
-         * The 3 is the standard ID for the mandatory object "Object device".
+         * It assigns his unique ID
          */
-        connObj->objID = OBJ_DEVICE_ID;
-
+        connObj->objID = LWM2M_CONN_MONITOR_OBJECT_ID;
+        
+        /*
+         * and its unique instance
+         *
+         */
+        connObj->instanceList = (lwm2m_list_t *)lwm2m_malloc(sizeof(lwm2m_list_t));
+        if (NULL != connObj->instanceList)
+        {
+            memset(connObj->instanceList, 0, sizeof(lwm2m_list_t));
+        }
+        else
+        {
+            lwm2m_free(connObj);
+            return NULL;
+        }
+        
         /*
          * And the private function that will access the object.
          * Those function will be called when a read/write/execute query is made by the server. In fact the library don't need to

--- a/tests/client/object_device.c
+++ b/tests/client/object_device.c
@@ -83,8 +83,6 @@
 #define PRV_TLV_BUFFER_SIZE 128
 
 // related to TS RC 20131210-C (ATTENTION changes in -D!)
-// Object Id
-#define OBJ_DEVICE_ID              3
 // Resource Id's:
 #define RES_O_MANUFACTURER         0
 #define RES_O_MODEL_NUMBER         1
@@ -515,11 +513,26 @@ lwm2m_object_t * get_object_device()
         memset(deviceObj, 0, sizeof(lwm2m_object_t));
 
         /*
-         * It assign his unique ID
+         * It assigns his unique ID
          * The 3 is the standard ID for the mandatory object "Object device".
          */
-        deviceObj->objID = OBJ_DEVICE_ID;
+        deviceObj->objID = LWM2M_DEVICE_OBJECT_ID;
 
+        /*
+         * and its unique instance
+         *
+         */
+        deviceObj->instanceList = (lwm2m_list_t *)lwm2m_malloc(sizeof(lwm2m_list_t));
+        if (NULL != deviceObj->instanceList)
+        {
+            memset(deviceObj->instanceList, 0, sizeof(lwm2m_list_t));
+        }
+        else
+        {
+            lwm2m_free(deviceObj);
+            return NULL;
+        }
+        
         /*
          * And the private function that will access the object.
          * Those function will be called when a read/write/execute query is made by the server. In fact the library don't need to

--- a/tests/client/object_firmware.c
+++ b/tests/client/object_firmware.c
@@ -205,7 +205,9 @@ static uint8_t prv_firmware_execute(uint16_t instanceId,
             // trigger your firmware download and update logic
             data->state = 2;
             return COAP_204_CHANGED;
-        } else {
+        }
+        else
+        {
             // firmware update already running
             return COAP_400_BAD_REQUEST;
         }

--- a/tests/client/object_firmware.c
+++ b/tests/client/object_firmware.c
@@ -228,10 +228,25 @@ lwm2m_object_t * get_object_firmware()
         memset(firmwareObj, 0, sizeof(lwm2m_object_t));
 
         /*
-         * It assign his unique ID
+         * It assigns its unique ID
          * The 5 is the standard ID for the optional object "Object firmware".
          */
-        firmwareObj->objID = 5;
+        firmwareObj->objID = LWM2M_FIRMWARE_UPDATE_OBJECT_ID;
+
+        /*
+         * and its unique instance
+         *
+         */
+        firmwareObj->instanceList = (lwm2m_list_t *)lwm2m_malloc(sizeof(lwm2m_list_t));
+        if (NULL != firmwareObj->instanceList)
+        {
+            memset(firmwareObj->instanceList, 0, sizeof(lwm2m_list_t));
+        }
+        else
+        {
+            lwm2m_free(firmwareObj);
+            return NULL;
+        }
 
         /*
          * And the private function that will access the object.

--- a/tests/client/object_location.c
+++ b/tests/client/object_location.c
@@ -47,8 +47,6 @@
 
 
 // ---- private "object location" specific defines ----
-// Object Id
-#define OBJ_LOCATION       6
 // Resource Id's:
 #define RES_LATITUDE       0
 #define RES_LONGITUDE      1
@@ -236,7 +234,19 @@ lwm2m_object_t * get_object_location() {
 
     // It assigns its unique ID
     // The 6 is the standard ID for the optional object "Object location".
-    locationObj->objID = OBJ_LOCATION;
+    locationObj->objID = LWM2M_LOCATION_OBJECT_ID;
+        
+    // and its unique instance
+    locationObj->instanceList = (lwm2m_list_t *)lwm2m_malloc(sizeof(lwm2m_list_t));
+    if (NULL != locationObj->instanceList)
+    {
+        memset(locationObj->instanceList, 0, sizeof(lwm2m_list_t));
+    }
+    else
+    {
+        lwm2m_free(locationObj);
+        return NULL;
+    }
 
     // And the private function that will access the object.
     // Those function will be called when a read/write/execute query is made by the server.

--- a/tests/client/system_api.c
+++ b/tests/client/system_api.c
@@ -32,14 +32,20 @@
 
 #ifdef LWM2M_EMBEDDED_MODE
 
-static void prv_value_change(void* context, const char* uriPath, const char * value, size_t valueLength) {
+static void prv_value_change(void* context,
+                             const char* uriPath,
+                             const char * value,
+                             size_t valueLength)
+{
     lwm2m_uri_t uri;
-    if (lwm2m_stringToUri(uriPath, strlen(uriPath), &uri)) {
+    if (lwm2m_stringToUri(uriPath, strlen(uriPath), &uri))
+    {
         handle_value_changed(context, &uri, value, valueLength);
     }
 }
 
-void init_value_change(lwm2m_context_t * lwm2m) {
+void init_value_change(lwm2m_context_t * lwm2m)
+{
     system_setValueChangedHandler(lwm2m, prv_value_change);
 }
 
@@ -49,7 +55,8 @@ void init_value_change(lwm2m_context_t * lwm2m)
 {
 }
 
-void system_reboot() {
+void system_reboot()
+{
     exit(1);
 }
 

--- a/tests/client/test_object.c
+++ b/tests/client/test_object.c
@@ -147,15 +147,18 @@ static uint8_t prv_read(uint16_t instanceId,
 
     if (*numDataP != 1) return COAP_404_NOT_FOUND;
 
-    if ((*dataArrayP)->id == 1) {
+    if ((*dataArrayP)->id == 1)
+    {
         lwm2m_tlv_encode_int(targetP->test, *dataArrayP);
     }
-    else if ((*dataArrayP)->id == 3) {
+    else if ((*dataArrayP)->id == 3)
+    {
         (*dataArrayP)->value = malloc(PRV_RESOURCE_3_SIZE);
         (*dataArrayP)->length = PRV_RESOURCE_3_SIZE;
         memset((*dataArrayP)->value, '0' + targetP->counter, PRV_RESOURCE_3_SIZE);
     }
-    else {
+    else
+    {
         return COAP_404_NOT_FOUND;
     }
 
@@ -188,14 +191,16 @@ static uint8_t prv_write(uint16_t instanceId,
         }
         targetP->test = (uint8_t)value;
     }
-    else if (dataArray->id == 3) {
+    else if (dataArray->id == 3)
+    {
         if (1 != lwm2m_tlv_decode_int(dataArray, &value) || value < 0 || value > 9)
         {
             return COAP_400_BAD_REQUEST;
         }
         targetP->counter = (uint8_t)value;
     }
-    else {
+    else
+    {
         return COAP_404_NOT_FOUND;
     }
 


### PR DESCRIPTION
This fixes the registration payload being /1/0, /3, /4, /5, /6, /1024/10, /1024/11, /1024/12
instead of /1/0, /3/0, /4/0, /5/0, /6/0, /1024/10, /1024/11, /1024/12