### PR TITLE
New object implementation: Connectivity Statistics.

### DIFF
--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -64,6 +64,7 @@
 #define lwm2m_strdup strdup
 #else
 int lwm2m_gettimeofday(struct timeval *tv, void *p);
+char *lwm2m_strdup(const char* str);
 void *lwm2m_malloc(size_t s);
 void lwm2m_free(void *p);
 #endif

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -61,6 +61,7 @@
 #define lwm2m_gettimeofday gettimeofday
 #define lwm2m_malloc malloc
 #define lwm2m_free free
+#define lwm2m_strdup strdup
 #else
 int lwm2m_gettimeofday(struct timeval *tv, void *p);
 void *lwm2m_malloc(size_t s);

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(SOURCES
     object_firmware.c
     object_location.c
     object_connectivity_moni.c
+    object_connectivity_stat.c
     test_object.c)
 
 add_executable(lwm2mclient ${SOURCES} ${CORE_SOURCES})

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -380,14 +380,12 @@ static void update_battery_level(lwm2m_context_t * context)
     }
 }
 
-//#define OBJ_COUNT 8
 
 int main(int argc, char *argv[])
 {
     client_data_t data;
     int result;
     lwm2m_context_t * lwm2mH = NULL;
-//  lwm2m_object_t * objArray[OBJ_COUNT];   // now global defined for conn_s!
     int i;
     const char * localPort = "56830";
     const char * server = "localhost";

--- a/tests/client/lwm2mclient.h
+++ b/tests/client/lwm2mclient.h
@@ -59,6 +59,12 @@ extern lwm2m_object_t * get_object_conn_m();
 uint8_t connectivity_moni_change(lwm2m_tlv_t * dataArray, lwm2m_object_t * objectP);
 
 /*
+ * object_connectivity_stat.c
+ */
+extern lwm2m_object_t * get_object_conn_s();
+extern void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint txDataByte, bool smsBased);
+extern void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint rxDataByte, bool smsBased);
+/*
  * lwm2mclient.c
  */
 extern void handle_value_changed(lwm2m_context_t* lwm2mH, lwm2m_uri_t* uri, const char * value, size_t valueLength);

--- a/tests/client/lwm2mclient.h
+++ b/tests/client/lwm2mclient.h
@@ -62,8 +62,8 @@ uint8_t connectivity_moni_change(lwm2m_tlv_t * dataArray, lwm2m_object_t * objec
  * object_connectivity_stat.c
  */
 extern lwm2m_object_t * get_object_conn_s();
-extern void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint txDataByte, bool smsBased);
-extern void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint rxDataByte, bool smsBased);
+extern void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint16_t txDataByte, bool smsBased);
+extern void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint16_t rxDataByte, bool smsBased);
 /*
  * lwm2mclient.c
  */

--- a/tests/client/object_connectivity_moni.c
+++ b/tests/client/object_connectivity_moni.c
@@ -86,7 +86,7 @@ typedef struct
 
 static uint8_t prv_set_value(lwm2m_tlv_t * tlvP,
                              conn_m_data_t * connDataP)
-{   //-------------------------------------------------------------------- JH --
+{
     switch (tlvP->id)
     {
     case RES_M_NETWORK_BEARER:
@@ -110,17 +110,6 @@ static uint8_t prv_set_value(lwm2m_tlv_t * tlvP,
             lwm2m_tlv_free(riCnt, subTlvP);
             return COAP_500_INTERNAL_SERVER_ERROR ;
         }
-        /*
-        subTlvP[1].flags = 0;
-        subTlvP[1].id    = 1;
-        subTlvP[1].type  = LWM2M_TYPE_RESSOURCE_INSTANCE;
-        lwm2m_tlv_encode_int(VALUE_AVL_NETWORK_BEARER_2, subTlvP + 1);
-        if (0 == subTlvP[1].length)
-        {
-            lwm2m_tlv_free(riCnt, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR ;
-        }
-        */
         tlvP->flags  = 0;
         tlvP->type   = LWM2M_TYPE_MULTIPLE_RESSOURCE;
         tlvP->length = riCnt;
@@ -219,18 +208,6 @@ static uint8_t prv_set_value(lwm2m_tlv_t * tlvP,
             lwm2m_tlv_free(riCnt, subTlvP);
             return COAP_500_INTERNAL_SERVER_ERROR ;
         }
-        /* wait for blockwise implementation!
-        subTlvP[1].flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        subTlvP[1].id     = 1;
-        subTlvP[1].type   = LWM2M_TYPE_RESSOURCE_INSTANCE;
-        subTlvP[1].value  = (uint8_t*) VALUE_APN_2;
-        subTlvP[1].length = strlen(VALUE_APN_2);
-        if (0 == subTlvP[1].length)
-        {
-            lwm2m_tlv_free(riCnt, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR ;
-        }
-        */
         tlvP->flags  = 0;
         tlvP->type   = LWM2M_TYPE_MULTIPLE_RESSOURCE;
         tlvP->length = riCnt;
@@ -269,7 +246,7 @@ static uint8_t prv_read(uint16_t instanceId,
                         int * numDataP,
                         lwm2m_tlv_t ** dataArrayP,
                         lwm2m_object_t * objectP)
-{   //-------------------------------------------------------------------- JH --
+{
     uint8_t result;
     int i;
 
@@ -318,12 +295,12 @@ static uint8_t prv_read(uint16_t instanceId,
 }
 
 static void prv_close(lwm2m_object_t * objectP)
-{	//-------------------------------------------------------------------- JH --
+{
     lwm2m_free(objectP->userData);
 }
 
 lwm2m_object_t * get_object_conn_m()
-{   //-------------------------------------------------------------------- JH --
+{
     /*
      * The get_object_conn_m() function create the object itself and return a pointer to the structure that represent it.
      */

--- a/tests/client/object_connectivity_stat.c
+++ b/tests/client/object_connectivity_stat.c
@@ -179,7 +179,7 @@ static void prv_close(lwm2m_object_t * objectP)
     lwm2m_free(objectP->userData);
 }
 
-void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint txDataByte, bool smsBased)
+void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint16_t txDataByte, bool smsBased)
 {
     conn_s_data_t* myData = (conn_s_data_t*) (objectP->userData);
     if (myData->collectDataStarted) {
@@ -193,7 +193,7 @@ void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint txDataByte, bool sm
     }
 }
 
-void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint rxDataByte, bool smsBased)
+void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint16_t rxDataByte, bool smsBased)
 {
     conn_s_data_t* myData = (conn_s_data_t*) (objectP->userData);
     if (myData->collectDataStarted) {

--- a/tests/client/object_connectivity_stat.c
+++ b/tests/client/object_connectivity_stat.c
@@ -59,7 +59,7 @@ typedef struct
 } conn_s_data_t;
 
 static uint8_t prv_set_tlv(lwm2m_tlv_t * tlvP, conn_s_data_t * connStDataP)
-{   //-------------------------------------------------------------------- JH --
+{
     switch (tlvP->id) {
     case RES_O_SMS_TX_COUNTER:
         lwm2m_tlv_encode_int(connStDataP->smsTxCounter, tlvP);
@@ -97,7 +97,7 @@ static uint8_t prv_set_tlv(lwm2m_tlv_t * tlvP, conn_s_data_t * connStDataP)
 }
 
 static uint8_t prv_read(uint16_t instanceId, int * numDataP, lwm2m_tlv_t** dataArrayP, lwm2m_object_t * objectP)
-{   //-------------------------------------------------------------------- JH --
+{
     uint8_t result;
     int i;
 
@@ -141,7 +141,7 @@ static uint8_t prv_read(uint16_t instanceId, int * numDataP, lwm2m_tlv_t** dataA
 }
 
 static void prv_resetCounter(lwm2m_object_t* objectP, bool start)
-{   //-------------------------------------------------------------------- JH --
+{
     conn_s_data_t *myData = (conn_s_data_t*) objectP->userData;
     myData->smsTxCounter        = 0;
     myData->smsRxCounter        = 0;
@@ -155,7 +155,7 @@ static void prv_resetCounter(lwm2m_object_t* objectP, bool start)
 
 static uint8_t prv_exec(uint16_t instanceId, uint16_t resourceId,
                         char * buffer, int length, lwm2m_object_t * objectP)
-{   //-------------------------------------------------------------------- JH --
+{
     // this is a single instance object
     if (instanceId != 0)
     {
@@ -175,12 +175,12 @@ static uint8_t prv_exec(uint16_t instanceId, uint16_t resourceId,
 }
 
 static void prv_close(lwm2m_object_t * objectP)
-{   //-------------------------------------------------------------------- JH --
+{
     lwm2m_free(objectP->userData);
 }
 
 void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint txDataByte, bool smsBased)
-{   //-------------------------------------------------------------------- JH --
+{
     conn_s_data_t* myData = (conn_s_data_t*) (objectP->userData);
     if (myData->collectDataStarted) {
         myData->txDataByte += txDataByte;
@@ -194,7 +194,7 @@ void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint txDataByte, bool sm
 }
 
 void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint rxDataByte, bool smsBased)
-{   //-------------------------------------------------------------------- JH --
+{
     conn_s_data_t* myData = (conn_s_data_t*) (objectP->userData);
     if (myData->collectDataStarted) {
         myData->rxDataByte += rxDataByte;
@@ -210,7 +210,7 @@ void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint rxDataByte, bool sm
 
 
 lwm2m_object_t * get_object_conn_s()
-{   //-------------------------------------------------------------------- JH --
+{
     /*
      * The get_object_conn_s() function create the object itself and return
      * a pointer to the structure that represent it.

--- a/tests/client/object_connectivity_stat.c
+++ b/tests/client/object_connectivity_stat.c
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innovations GmbH Germany.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Please refer to git log
+ *    
+ *******************************************************************************/
+
+/*
+ * This connectivity statistics object is optional and single instance only
+ * 
+ *  Resources:
+ *
+ *          Name         | ID | Oper. | Inst. | Mand.|  Type   | Range | Units | Descripton |
+ *  SMS Tx Counter       |  0 |   R   | Single|  No  | Integer |       |       |            |
+ *  SMS Rx Counter       |  1 |   R   | Single|  No  | Integer |       |       |            |
+ *  Tx Data              |  2 |   R   | Single|  No  | Integer |       | kByte |            |
+ *  Rx Data              |  3 |   R   | Single|  No  | Integer |       | kByte |            |
+ *  Max Message Size     |  4 |   R   | Single|  No  | Integer |       | Byte  |            |
+ *  Average Message Size |  5 |   R   | Single|  No  | Integer |       | Byte  |            |
+ *  StartOrReset         |  6 |   E   | Single|  Yes | Integer |       |       |            |
+ */
+
+#include "liblwm2m.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+// Resource Id's:
+#define RES_O_SMS_TX_COUNTER            0
+#define RES_O_SMS_RX_COUNTER            1
+#define RES_O_TX_DATA                   2
+#define RES_O_RX_DATA                   3
+#define RES_O_MAX_MESSAGE_SIZE          4
+#define RES_O_AVERAGE_MESSAGE_SIZE      5
+#define RES_M_START_OR_RESET            6
+
+typedef struct
+{
+    int64_t   smsTxCounter;
+    int64_t   smsRxCounter;
+    int64_t   txDataByte;             // report in kByte!
+    int64_t   rxDataByte;             // report in kByte!
+    int64_t   maxMessageSize;
+    int64_t   avrMessageSize;
+    int64_t   messageCount;           // private for incremental average calc.
+    bool      collectDataStarted;
+} conn_s_data_t;
+
+static uint8_t prv_set_tlv(lwm2m_tlv_t * tlvP, conn_s_data_t * connStDataP)
+{   //-------------------------------------------------------------------- JH --
+    switch (tlvP->id) {
+    case RES_O_SMS_TX_COUNTER:
+        lwm2m_tlv_encode_int(connStDataP->smsTxCounter, tlvP);
+        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        return (0 != tlvP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        break;
+    case RES_O_SMS_RX_COUNTER:
+        lwm2m_tlv_encode_int(connStDataP->smsRxCounter, tlvP);
+        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        return (0 != tlvP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        break;
+    case RES_O_TX_DATA:
+        lwm2m_tlv_encode_int(connStDataP->txDataByte/1024, tlvP);
+        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        return (0 != tlvP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        break;
+    case RES_O_RX_DATA:
+        lwm2m_tlv_encode_int(connStDataP->rxDataByte/1024, tlvP);
+        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        return (0 != tlvP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        break;
+    case RES_O_MAX_MESSAGE_SIZE:
+        lwm2m_tlv_encode_int(connStDataP->maxMessageSize, tlvP);
+        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        return (0 != tlvP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        break;
+    case RES_O_AVERAGE_MESSAGE_SIZE:
+        lwm2m_tlv_encode_int(connStDataP->avrMessageSize, tlvP);
+        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        return (0 != tlvP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        break;
+    default:
+        return COAP_404_NOT_FOUND ;
+    }
+}
+
+static uint8_t prv_read(uint16_t instanceId, int * numDataP, lwm2m_tlv_t** dataArrayP, lwm2m_object_t * objectP)
+{   //-------------------------------------------------------------------- JH --
+    uint8_t result;
+    int i;
+
+    // this is a single instance object
+    if (instanceId != 0)
+    {
+        return COAP_404_NOT_FOUND ;
+    }
+
+    // is the server asking for the full object ?
+    if (*numDataP == 0)
+    {
+        uint16_t resList[] = {
+                RES_O_SMS_TX_COUNTER,
+                RES_O_SMS_RX_COUNTER,
+                RES_O_TX_DATA,
+                RES_O_RX_DATA,
+                RES_O_MAX_MESSAGE_SIZE,
+                RES_O_AVERAGE_MESSAGE_SIZE
+        };
+        int nbRes = sizeof(resList) / sizeof(uint16_t);
+
+        *dataArrayP = lwm2m_tlv_new(nbRes);
+        if (*dataArrayP == NULL)
+            return COAP_500_INTERNAL_SERVER_ERROR ;
+        *numDataP = nbRes;
+        for (i = 0; i < nbRes; i++)
+        {
+            (*dataArrayP)[i].id = resList[i];
+        }
+    }
+
+    i = 0;
+    do
+    {
+        result = prv_set_tlv((*dataArrayP) + i, (conn_s_data_t*) (objectP->userData));
+        i++;
+    } while (i < *numDataP && result == COAP_205_CONTENT );
+
+    return result;
+}
+
+static void prv_resetCounter(lwm2m_object_t* objectP, bool start)
+{   //-------------------------------------------------------------------- JH --
+    conn_s_data_t *myData = (conn_s_data_t*) objectP->userData;
+    myData->smsTxCounter        = 0;
+    myData->smsRxCounter        = 0;
+    myData->txDataByte          = 0;
+    myData->rxDataByte          = 0;
+    myData->maxMessageSize      = 0;
+    myData->avrMessageSize      = 0;
+    myData->messageCount        = 0;
+    myData->collectDataStarted  = start;
+}
+
+static uint8_t prv_exec(uint16_t instanceId, uint16_t resourceId,
+                        char * buffer, int length, lwm2m_object_t * objectP)
+{   //-------------------------------------------------------------------- JH --
+    // this is a single instance object
+    if (instanceId != 0)
+    {
+        return COAP_404_NOT_FOUND;
+    }
+
+    if (length != 0) return COAP_400_BAD_REQUEST;
+
+    switch (resourceId)
+    {
+    case RES_M_START_OR_RESET:
+        prv_resetCounter(objectP, true);
+        return COAP_204_CHANGED;
+    default:
+        return COAP_405_METHOD_NOT_ALLOWED;
+    }
+}
+
+static void prv_close(lwm2m_object_t * objectP)
+{   //-------------------------------------------------------------------- JH --
+    lwm2m_free(objectP->userData);
+}
+
+void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint txDataByte, bool smsBased)
+{   //-------------------------------------------------------------------- JH --
+    conn_s_data_t* myData = (conn_s_data_t*) (objectP->userData);
+    if (myData->collectDataStarted) {
+        myData->txDataByte += txDataByte;
+        myData->messageCount++;
+        myData->avrMessageSize = (myData->txDataByte+myData->rxDataByte) /
+                                  myData->messageCount;
+        if (txDataByte > myData->maxMessageSize)
+            myData->maxMessageSize = txDataByte;
+        if (smsBased) myData->smsTxCounter++;
+    }
+}
+
+void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint rxDataByte, bool smsBased)
+{   //-------------------------------------------------------------------- JH --
+    conn_s_data_t* myData = (conn_s_data_t*) (objectP->userData);
+    if (myData->collectDataStarted) {
+        myData->rxDataByte += rxDataByte;
+        myData->messageCount++;
+        myData->avrMessageSize = (myData->txDataByte+myData->rxDataByte) /
+                                  myData->messageCount;
+        if (rxDataByte > myData->maxMessageSize)
+            myData->maxMessageSize = rxDataByte;
+        myData->txDataByte += rxDataByte;
+        if (smsBased) myData->smsRxCounter++;
+    }
+}
+
+
+lwm2m_object_t * get_object_conn_s()
+{   //-------------------------------------------------------------------- JH --
+    /*
+     * The get_object_conn_s() function create the object itself and return
+     * a pointer to the structure that represent it.
+     */
+    lwm2m_object_t * connObj;
+
+    connObj = (lwm2m_object_t *) lwm2m_malloc(sizeof(lwm2m_object_t));
+
+    if (NULL != connObj)
+    {
+        memset(connObj, 0, sizeof(lwm2m_object_t));
+
+        /*
+         * It assign his unique ID
+         * The 7 is the standard ID for the optional object "Connectivity Statistics".
+         */
+        connObj->objID = LWM2M_CONN_STATS_OBJECT_ID;
+        connObj->instanceList = lwm2m_malloc(sizeof(lwm2m_list_t));
+        if (NULL != connObj->instanceList)
+        {
+            memset(connObj->instanceList, 0, sizeof(lwm2m_list_t));
+        }
+        else {
+            lwm2m_free(connObj);
+            return NULL;
+        }
+
+        /*
+         * And the private function that will access the object.
+         * Those function will be called when a read/execute/close
+         * query is made by the server or core. In fact the library don't need
+         * to know the resources of the object, only the server does.
+         */
+        connObj->readFunc     = prv_read;
+        connObj->executeFunc  = prv_exec;
+        connObj->closeFunc    = prv_close;
+        connObj->userData     = lwm2m_malloc(sizeof(conn_s_data_t));
+
+        /*
+         * Also some user data can be stored in the object with a private
+         * structure containing the needed variables.
+         */
+        if (NULL != connObj->userData)
+        {
+            prv_resetCounter(connObj, false);
+        }
+        else
+        {
+            lwm2m_free(connObj);
+            connObj = NULL;
+        }
+    }
+    return connObj;
+}

--- a/tests/client/object_device.c
+++ b/tests/client/object_device.c
@@ -82,25 +82,31 @@
 #define PRV_OFFSET_MAXLEN   7 //+HH:MM\0 at max
 #define PRV_TLV_BUFFER_SIZE 128
 
-// related to TS RC 20131210-C (ATTENTION changes in -D!)
 // Resource Id's:
-#define RES_O_MANUFACTURER         0
-#define RES_O_MODEL_NUMBER         1
-#define RES_O_SERIAL_NUMBER        2
-#define RES_O_FIRMWARE_VERSION     3
-#define RES_M_REBOOT               4
-#define RES_O_FACTORY_RESET        5
-#define RES_O_AVL_POWER_SOURCES    6
-#define RES_O_POWER_SOURCE_VOLTAGE 7
-#define RES_O_POWER_SOURCE_CURRENT 8
-#define RES_O_BATTERY_LEVEL        9
-#define RES_O_MEMORY_FREE          10
-#define RES_M_ERROR_CODE           11
-#define RES_O_RESET_ERROR_CODE     12
-#define RES_O_CURRENT_TIME         13
-#define RES_O_UTC_OFFSET           14
-#define RES_O_TIMEZONE             15
-#define RES_M_BINDING_MODES        16
+#define RES_O_MANUFACTURER          0
+#define RES_O_MODEL_NUMBER          1
+#define RES_O_SERIAL_NUMBER         2
+#define RES_O_FIRMWARE_VERSION      3
+#define RES_M_REBOOT                4
+#define RES_O_FACTORY_RESET         5
+#define RES_O_AVL_POWER_SOURCES     6
+#define RES_O_POWER_SOURCE_VOLTAGE  7
+#define RES_O_POWER_SOURCE_CURRENT  8
+#define RES_O_BATTERY_LEVEL         9
+#define RES_O_MEMORY_FREE           10
+#define RES_M_ERROR_CODE            11
+#define RES_O_RESET_ERROR_CODE      12
+#define RES_O_CURRENT_TIME          13
+#define RES_O_UTC_OFFSET            14
+#define RES_O_TIMEZONE              15
+#define RES_M_BINDING_MODES         16
+// since TS 20141126-C:
+#define RES_O_DEVICE_TYPE           17
+#define RES_O_HARDWARE_VERSION      18
+#define RES_O_SOFTWARE_VERSION      19
+#define RES_O_BATTERY_STATUS        20
+#define RES_O_MEMORY_TOTAL          21
+
 
 typedef struct
 {
@@ -160,31 +166,31 @@ static uint8_t prv_set_value(lwm2m_tlv_t * tlvP,
     switch (tlvP->id)
     {
     case RES_O_MANUFACTURER:
-        tlvP->value = PRV_MANUFACTURER;
+        tlvP->value  = (uint8_t*)PRV_MANUFACTURER;
         tlvP->length = strlen(PRV_MANUFACTURER);
-        tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
+        tlvP->type   = LWM2M_TYPE_RESSOURCE;
         return COAP_205_CONTENT;
 
     case RES_O_MODEL_NUMBER:
-        tlvP->value = PRV_MODEL_NUMBER;
+        tlvP->value  = (uint8_t*)PRV_MODEL_NUMBER;
         tlvP->length = strlen(PRV_MODEL_NUMBER);
-        tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
+        tlvP->type   = LWM2M_TYPE_RESSOURCE;
         return COAP_205_CONTENT;
 
     case RES_O_SERIAL_NUMBER:
-        tlvP->value = PRV_SERIAL_NUMBER;
+        tlvP->value  = (uint8_t*)PRV_SERIAL_NUMBER;
         tlvP->length = strlen(PRV_SERIAL_NUMBER);
-        tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
+        tlvP->type   = LWM2M_TYPE_RESSOURCE;
         return COAP_205_CONTENT;
 
     case RES_O_FIRMWARE_VERSION:
-        tlvP->value = PRV_FIRMWARE_VERSION;
+        tlvP->value  = (uint8_t*)PRV_FIRMWARE_VERSION;
         tlvP->length = strlen(PRV_FIRMWARE_VERSION);
-        tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
+        tlvP->type   = LWM2M_TYPE_RESSOURCE;
         return COAP_205_CONTENT;
 
     case RES_M_REBOOT:
@@ -343,24 +349,24 @@ static uint8_t prv_set_value(lwm2m_tlv_t * tlvP,
         else return COAP_500_INTERNAL_SERVER_ERROR;
 
     case RES_O_UTC_OFFSET:
-        tlvP->value = devDataP->time_offset;
+        tlvP->value  = (uint8_t*)devDataP->time_offset;
         tlvP->length = strlen(devDataP->time_offset);
-        tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
+        tlvP->type   = LWM2M_TYPE_RESSOURCE;
         return COAP_205_CONTENT;
 
     case RES_O_TIMEZONE:
-        tlvP->value  = PRV_TIME_ZONE;
+        tlvP->value  = (uint8_t*)PRV_TIME_ZONE;
         tlvP->length = strlen(PRV_TIME_ZONE);
         tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
         tlvP->type   = LWM2M_TYPE_RESSOURCE;
         return COAP_205_CONTENT;
       
     case RES_M_BINDING_MODES:
-        tlvP->value = PRV_BINDING_MODE;
+        tlvP->value  = (uint8_t*)PRV_BINDING_MODE;
         tlvP->length = strlen(PRV_BINDING_MODE);
-        tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP->type = LWM2M_TYPE_RESSOURCE;
+        tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
+        tlvP->type   = LWM2M_TYPE_RESSOURCE;
         return COAP_205_CONTENT;
 
     default:
@@ -385,7 +391,25 @@ static uint8_t prv_device_read(uint16_t instanceId,
     // is the server asking for the full object ?
     if (*numDataP == 0)
     {
-        uint16_t resList[] = {0, 1, 2, 3, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16};
+        uint16_t resList[] = {
+                RES_O_MANUFACTURER,
+                RES_O_MODEL_NUMBER,
+                RES_O_SERIAL_NUMBER,
+                RES_O_FIRMWARE_VERSION,
+                //E: RES_M_REBOOT,
+                //E: RES_O_FACTORY_RESET,
+                RES_O_AVL_POWER_SOURCES,
+                RES_O_POWER_SOURCE_VOLTAGE,
+                RES_O_POWER_SOURCE_CURRENT,
+                RES_O_BATTERY_LEVEL,
+                RES_O_MEMORY_FREE,
+                RES_M_ERROR_CODE,
+                //E: RES_O_RESET_ERROR_CODE,
+                RES_O_CURRENT_TIME,
+                RES_O_UTC_OFFSET,
+                RES_O_TIMEZONE,
+                RES_M_BINDING_MODES
+        };
         int nbRes = sizeof(resList)/sizeof(uint16_t);
 
         *dataArrayP = lwm2m_tlv_new(nbRes);
@@ -440,9 +464,9 @@ static uint8_t prv_device_write(uint16_t instanceId,
             break;
 
         case RES_O_UTC_OFFSET:
-            if (1 == prv_check_time_offset(dataArray[i].value, dataArray[i].length))
+            if (1 == prv_check_time_offset((char*)dataArray[i].value, dataArray[i].length))
             {
-                strncpy(((device_data_t*)(objectP->userData))->time_offset, dataArray[i].value, dataArray[i].length);
+                strncpy(((device_data_t*)(objectP->userData))->time_offset, (char*)dataArray[i].value, dataArray[i].length);
                 ((device_data_t*)(objectP->userData))->time_offset[dataArray[i].length] = 0;
                 result = COAP_204_CHANGED;
             }
@@ -499,6 +523,11 @@ static uint8_t prv_device_execute(uint16_t instanceId,
     }
 }
 
+static void prv_device_close(lwm2m_object_t * objectP)
+{
+    lwm2m_free(objectP->userData);
+}
+
 lwm2m_object_t * get_object_device()
 {
     /*
@@ -538,10 +567,11 @@ lwm2m_object_t * get_object_device()
          * Those function will be called when a read/write/execute query is made by the server. In fact the library don't need to
          * know the resources of the object, only the server does.
          */
-        deviceObj->readFunc = prv_device_read;
-        deviceObj->writeFunc = prv_device_write;
+        deviceObj->readFunc    = prv_device_read;
+        deviceObj->writeFunc   = prv_device_write;
         deviceObj->executeFunc = prv_device_execute;
-        deviceObj->userData = lwm2m_malloc(sizeof(device_data_t));
+        deviceObj->closeFunc   = prv_device_close;
+        deviceObj->userData    = lwm2m_malloc(sizeof(device_data_t));
 
         /*
          * Also some user data can be stored in the object with a private structure containing the needed variables 
@@ -549,9 +579,9 @@ lwm2m_object_t * get_object_device()
         if (NULL != deviceObj->userData)
         {
             ((device_data_t*)deviceObj->userData)->battery_level = PRV_BATTERY_LEVEL;
-            ((device_data_t*)deviceObj->userData)->free_memory = PRV_MEMORY_FREE;
+            ((device_data_t*)deviceObj->userData)->free_memory   = PRV_MEMORY_FREE;
             ((device_data_t*)deviceObj->userData)->error = PRV_ERROR_CODE;
-            ((device_data_t*)deviceObj->userData)->time = 1367491215;
+            ((device_data_t*)deviceObj->userData)->time  = 1367491215;
             strcpy(((device_data_t*)deviceObj->userData)->time_offset, "+01:00");
         }
         else

--- a/tests/client/object_location.c
+++ b/tests/client/object_location.c
@@ -1,4 +1,4 @@
-/*********************************************************************************
+/*******************************************************************************
  * 
  * Copyright (c) 2014 Bosch Software Innovations GmbH, Germany.
  *
@@ -14,7 +14,7 @@
  * Contributors:
  *    Bosch Software Innovations GmbH - Please refer to git log
  *    
- *******************************************************************************/
+ ******************************************************************************/
 /*! \file
   LWM2M object "Location" implementation
 
@@ -25,19 +25,18 @@
  *  Object     |      | Multiple  |     | Description                   |
  *  Name       |  ID  | Instances |Mand.|                               |
  *-------------+------+-----------+-----+-------------------------------+
- *  Location   |   6  |    No     |  No |  see TS E.7 page 92           |
+ *  Location   |   6  |    No     |  No |  see TS E.7 page 101          |
  *
  *  Resources:
  *  Name        | ID  | Oper.|Instances|Mand.|  Type   | Range | Units | Description                                                                      |
  * -------------+-----+------+---------+-----+---------+-------+-------+----------------------------------------------------------------------------------+
- *  Latitude    |  0  |  R   | Single  | Yes | String  |       |  Deg  | The decimal notation of latitude  e.g. -  45.5723  [Worls Geodetic System 1984]. |
- *  Longitude   |  1  |  R   | Single  | Yes | String  |       |  Deg  | The decimal notation of longitude e.g. - 153.21760 [Worls Geodetic System 1984]. |
- *  Altidude    |  2  |  R   | Single  | No  | Stringr |       |   m   | The decimal notation of altidude in meters above sea level.                      |
+ *  Latitude    |  0  |  R   | Single  | Yes | String  |       |  Deg  | The decimal notation of latitude  e.g. -  45.5723  [Worlds Geodetic System 1984].|
+ *  Longitude   |  1  |  R   | Single  | Yes | String  |       |  Deg  | The decimal notation of longitude e.g. - 153.21760 [Worlds Geodetic System 1984].| *  Altidude    |  2  |  R   | Single  | No  | String  |       |   m   | The decimal notation of altidude in meters above sea level.                      |
  *  Uncertainty |  3  |  R   | Single  | No  | Integer |       |   m   | The accuracy of the position in meters.                                          |
  *  Velocity    |  4  |  R   | Single  | No  | Opaque  |       |   *   | The velocity of the device as defined in 3GPP 23.032 GAD specification(*).       |
  *              |     |      |         |     |         |       |       | This set of values may not be available if the device is static.                 |
  *              |     |      |         |     |         |       |       | opaque: see OMA_TS 6.3.2                                                         |
- *  Timestamp   |  5  |  R   | Single  | Yes | Time    |       |   s   | The timestamp wen the location meassurement was performed.                       |
+ *  Timestamp   |  5  |  R   | Single  | Yes | Time    |       |   s   | The timestamp when the location measurement was performed.                       |
  */
 
 #include "liblwm2m.h"
@@ -51,14 +50,12 @@
 
 // ---- private "object location" specific defines ----
 // Resource Id's:
-#define RES_LATITUDE       0
-#define RES_LONGITUDE      1
-#define RES_ALTITUDE       2
-#define RES_UNCERTAINTY    3
-#define RES_VELOCITY       4
-#define RES_TIMESTAMP      5
-// allways the last one!
-#define RES_COUNT          6  
+#define RES_M_LATITUDE     0
+#define RES_M_LONGITUDE    1
+#define RES_O_ALTITUDE     2
+#define RES_O_UNCERTAINTY  3
+#define RES_O_VELOCITY     4
+#define RES_M_TIMESTAMP    5
 
 //-----  3GPP TS 23.032 V11.0.0(2012-09) ---------
 #define HORIZONTAL_VELOCITY                  0  // for Octet-1 upper half(..<<4)
@@ -78,55 +75,52 @@ typedef struct
     unsigned long timestamp;
 } location_data_t;
 
-// => TLV buffer len: 4x11 + 5 + 4 + .. < 64
-#define PRV_TLV_BUFFER_SIZE     64
-
 /**
-implementtaion for all read-able resources
+implementation for all read-able resources
 */
 static uint8_t prv_res2tlv(lwm2m_tlv_t* tlvP,
                            location_data_t* locDataP)
 {
-    //----------------------------------------------------------------------- JH --
+    //-------------------------------------------------------------------- JH --
     uint8_t ret = COAP_205_CONTENT;  
     switch (tlvP->id)     // location resourceId
     {
-    case RES_LATITUDE:    //0
-        tlvP->value  = locDataP->latitude;
+    case RES_M_LATITUDE:
+        tlvP->value  = (uint8_t*)locDataP->latitude;
         tlvP->length = strlen(locDataP->latitude);
         tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
         tlvP->type   = LWM2M_TYPE_RESSOURCE;
         break;
-    case RES_LONGITUDE:   //1
-        tlvP->value  = locDataP->longitude;
+    case RES_M_LONGITUDE:
+        tlvP->value  = (uint8_t*)locDataP->longitude;
         tlvP->length = strlen(locDataP->latitude);
         tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
         tlvP->type   = LWM2M_TYPE_RESSOURCE;
         break;
-    case RES_ALTITUDE:    //2
-        tlvP->value  = locDataP->altitude;
+    case RES_O_ALTITUDE:
+        tlvP->value  = (uint8_t*)locDataP->altitude;
         tlvP->length = strlen(locDataP->altitude);
         tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
         tlvP->type   = LWM2M_TYPE_RESSOURCE;
         break;
-    case RES_UNCERTAINTY: //3
-        tlvP->value  = locDataP->uncertainty;
+    case RES_O_UNCERTAINTY:
+        tlvP->value  = (uint8_t*)locDataP->uncertainty;
         tlvP->length = strlen(locDataP->uncertainty);
         tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
         tlvP->type   = LWM2M_TYPE_RESSOURCE;
         break;
-    case RES_VELOCITY:    //4
+    case RES_O_VELOCITY:
         tlvP->value  = locDataP->velocity;
         tlvP->length = VELOCITY_OCTETS;
         tlvP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
         tlvP->type   = LWM2M_TYPE_RESSOURCE;
         break;
-    case RES_TIMESTAMP:   //6
+    case RES_M_TIMESTAMP:
         lwm2m_tlv_encode_int(locDataP->timestamp, tlvP);
-        tlvP->type   = LWM2M_TYPE_RESSOURCE;    
+        tlvP->type   = LWM2M_TYPE_RESSOURCE;
         break;
     default:
-        ret = COAP_404_NOT_FOUND;  
+        ret = COAP_404_NOT_FOUND;
         break;
     }
   
@@ -135,14 +129,14 @@ static uint8_t prv_res2tlv(lwm2m_tlv_t* tlvP,
 
 
 /**
-  * Implementation (callback-) function of reading object resoures. For whole 
+  * Implementation (callback-) function of reading object resources. For whole
   * object, single resources or a sequence of resources
   * see 3GPP TS 23.032 V11.0.0(2012-09) page 23,24.
   * implemented for: HORIZONTAL_VELOCITY_WITH_UNCERTAINT
   * @param objInstId    in,     instances ID of the location object to read
-  * @param numDataP     in/out, ponter to the number of resource to read. 0 is the 
-  *                             exeption for all readable resource of onject instance
-  * @param tlvArrayP    in/out, TLV data sequnce with intialized resource ID to read
+  * @param numDataP     in/out, pointer to the number of resource to read. 0 is the
+  *                             exception for all readable resource of object instance
+  * @param tlvArrayP    in/out, TLV data sequence with initialized resource ID to read
   * @param objectP      in,     private location data structure
   */
 static uint8_t prv_location_read(uint16_t objInstId,
@@ -150,7 +144,7 @@ static uint8_t prv_location_read(uint16_t objInstId,
                                  lwm2m_tlv_t** tlvArrayP,
                                  lwm2m_object_t*  objectP)
 {   
-    //------------------------------------------------------------------- JH --
+    //-------------------------------------------------------------------- JH --
     int     i;
     uint8_t result = COAP_500_INTERNAL_SERVER_ERROR;
     location_data_t* locDataP = (location_data_t*)(objectP->userData);
@@ -160,7 +154,14 @@ static uint8_t prv_location_read(uint16_t objInstId,
 
     if (*numDataP == 0)     // full object, readable resources!
     {
-        uint16_t readResIds[] = {0,1,2,3,4,5}; // readable resources!
+        uint16_t readResIds[] = {
+                RES_M_LATITUDE,
+                RES_M_LONGITUDE,
+                RES_O_ALTITUDE,
+                RES_O_UNCERTAINTY,
+                RES_O_VELOCITY,
+                RES_M_TIMESTAMP
+        }; // readable resources!
         
         *numDataP  = sizeof(readResIds)/sizeof(uint16_t);
         *tlvArrayP = lwm2m_tlv_new(*numDataP);
@@ -196,7 +197,7 @@ void location_setVelocity(lwm2m_object_t* locationObj,
                           uint16_t horizontalSpeed,
                           uint8_t speedUncertainty)
 {
-    //------------------------------------------------------------------------ JH --
+    //-------------------------------------------------------------------- JH --
     location_data_t* pData = locationObj->userData;
     pData->velocity[0] = HORIZONTAL_VELOCITY_WITH_UNCERTAINTY << 4;
     pData->velocity[0] = (bearing & 0x100) >> 8;
@@ -206,14 +207,19 @@ void location_setVelocity(lwm2m_object_t* locationObj,
     pData->velocity[4] = speedUncertainty;
 }
 
+static void prv_location_close(lwm2m_object_t * objectP)
+{
+    lwm2m_free(objectP->userData);
+}
+
 /**
-  * A convenience functon to set the location coordinates with its timestamp.
+  * A convenience function to set the location coordinates with its timestamp.
   * @see testMe()
   * @param locationObj location object reference (to be casted!)
   * @param latitude  the second argument.
   * @param longitude the second argument.
   * @param altitude  the second argument.
-  * @param limestamp the related timestamp. Seconds since 1970.
+  * @param timestamp the related timestamp. Seconds since 1970.
   */
 void location_setLocationAtTime(lwm2m_object_t* locationObj,
                              float latitude,
@@ -221,7 +227,7 @@ void location_setLocationAtTime(lwm2m_object_t* locationObj,
                              float altitude,
                              uint64_t timestamp)
 {
-    //------------------------------------------------------------------------ JH --
+    //-------------------------------------------------------------------- JH --
     location_data_t* pData = locationObj->userData;
 
 #if defined(ARDUINO)
@@ -229,7 +235,6 @@ void location_setLocationAtTime(lwm2m_object_t* locationObj,
     dtostrf (longitude, -8, 6, pData->longitude);
     dtostrf (altitude,  -8, 4, pData->altitude);
 #else
-//#elif defined(SPARK)
     snprintf(pData->latitude, 5+DEG_DECIMAL_PLACES, "%-8.6f", (double)latitude);
     snprintf(pData->longitude,5+DEG_DECIMAL_PLACES, "%-8.6f", (double)longitude);
     snprintf(pData->altitude, 5+DEG_DECIMAL_PLACES, "%-8.4f", (double)altitude);
@@ -245,7 +250,7 @@ void location_setLocationAtTime(lwm2m_object_t* locationObj,
   */
 lwm2m_object_t * get_object_location()
 {
-    //---------------------------------------------------------------------- JH --
+    //-------------------------------------------------------------------- JH --
     lwm2m_object_t * locationObj;
 
     locationObj = (lwm2m_object_t *)lwm2m_malloc(sizeof(lwm2m_object_t));
@@ -254,7 +259,7 @@ lwm2m_object_t * get_object_location()
         memset(locationObj, 0, sizeof(lwm2m_object_t));
 
         // It assigns its unique ID
-        // The 6 is the standard ID for the optional object "Object location".
+        // The 6 is the standard ID for the optional object "Location".
         locationObj->objID = LWM2M_LOCATION_OBJECT_ID;
         
         // and its unique instance
@@ -270,14 +275,11 @@ lwm2m_object_t * get_object_location()
         }
 
         // And the private function that will access the object.
-        // Those function will be called when a read/write/execute query is made by the server.
+        // Those function will be called when a read query is made by the server.
         // In fact the library don't need to know the resources of the object, only the server does.
         //
         locationObj->readFunc    = prv_location_read;
-        //locationObj->writeFunc   = prv_location_write;
-        //locationObj->executeFunc = prv_location_execute;
-        //locationObj->createFunc  = prv_location_create;
-        //locationObj->deleteFunc  = prv_location_delete;
+        locationObj->closeFunc   = prv_location_close;
         locationObj->userData    = lwm2m_malloc(sizeof(location_data_t));
 
         // initialize private data structure containing the needed variables

--- a/tests/client/object_security.c
+++ b/tests/client/object_security.c
@@ -76,7 +76,7 @@ static uint8_t prv_get_value(lwm2m_tlv_t * tlvP,
     switch (tlvP->id)
     {
     case LWM2M_SECURITY_URI_ID:
-        tlvP->value = targetP->uri;
+        tlvP->value = (uint8_t*)targetP->uri;
         tlvP->length = strlen(targetP->uri);
         tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
         return COAP_205_CONTENT;
@@ -93,21 +93,21 @@ static uint8_t prv_get_value(lwm2m_tlv_t * tlvP,
 
     case LWM2M_SECURITY_PUBLIC_KEY_ID:
         // Here we return an opaque of 1 byte containing 0
-        tlvP->value = "";
+        tlvP->value = (uint8_t*)"";
         tlvP->length = 1;
         tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SERVER_PUBLIC_KEY_ID:
         // Here we return an opaque of 1 byte containing 0
-        tlvP->value = "";
+        tlvP->value = (uint8_t*)"";
         tlvP->length = 1;
         tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SECRET_KEY_ID:
         // Here we return an opaque of 1 byte containing 0
-        tlvP->value = "";
+        tlvP->value = (uint8_t*)"";
         tlvP->length = 1;
         tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
         return COAP_205_CONTENT;
@@ -119,14 +119,14 @@ static uint8_t prv_get_value(lwm2m_tlv_t * tlvP,
 
     case LWM2M_SECURITY_SMS_KEY_PARAM_ID:
         // Here we return an opaque of 6 bytes containing a buggy value
-        tlvP->value = "12345";
+        tlvP->value = (uint8_t*)"12345";
         tlvP->length = 6;
         tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SMS_SECRET_KEY_ID:
         // Here we return an opaque of 32 bytes containing a buggy value
-        tlvP->value = "1234567890abcdefghijklmnopqrstu";
+        tlvP->value = (uint8_t*)"1234567890abcdefghijklmnopqrstu";
         tlvP->length = 32;
         tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
         return COAP_205_CONTENT;
@@ -221,7 +221,7 @@ static uint8_t prv_security_write(uint16_t instanceId,
             targetP->uri = (char *)lwm2m_malloc(dataArray[i].length + 1);
             if (targetP->uri != NULL)
             {
-                strncpy(targetP->uri, dataArray[i].value, dataArray[i].length);
+                strncpy(targetP->uri, (char*)dataArray[i].value, dataArray[i].length);
                 result = COAP_204_CHANGED;
             }
             else
@@ -426,8 +426,9 @@ char * get_server_uri(lwm2m_object_t * objectP,
     {
         if (targetP->shortID == serverID)
         {
-            return strdup(targetP->uri);
+            return lwm2m_strdup(targetP->uri);
         }
+        targetP = (security_instance_t*)targetP->next;
     }
 
     return NULL;

--- a/tests/client/object_server.c
+++ b/tests/client/object_server.c
@@ -46,6 +46,9 @@ typedef struct _server_instance_
     uint16_t    instanceId;            // matches lwm2m_list_t::id
     uint16_t    shortServerId;
     uint32_t    lifetime;
+    uint32_t    defMinPeriod;
+    uint32_t    defMaxPeriod;
+    uint32_t    disableTimeout;
     bool        storing;
     char        binding[4];
 } server_instance_t;
@@ -53,7 +56,7 @@ typedef struct _server_instance_
 static uint8_t prv_get_value(lwm2m_tlv_t * tlvP,
                              server_instance_t * targetP)
 {
-    // There are no multiple instance ressources
+    // There are no multiple instance resources
     tlvP->type = LWM2M_TYPE_RESSOURCE;
 
     switch (tlvP->id)
@@ -69,16 +72,22 @@ static uint8_t prv_get_value(lwm2m_tlv_t * tlvP,
         else return COAP_500_INTERNAL_SERVER_ERROR;
 
     case LWM2M_SERVER_MIN_PERIOD_ID:
-        return COAP_404_NOT_FOUND;
+        lwm2m_tlv_encode_int(targetP->defMinPeriod, tlvP);
+        if (0 != tlvP->length) return COAP_205_CONTENT;
+        else return COAP_500_INTERNAL_SERVER_ERROR;
 
     case LWM2M_SERVER_MAX_PERIOD_ID:
-        return COAP_404_NOT_FOUND;
+        lwm2m_tlv_encode_int(targetP->defMaxPeriod, tlvP);
+        if (0 != tlvP->length) return COAP_205_CONTENT;
+        else return COAP_500_INTERNAL_SERVER_ERROR;
 
     case LWM2M_SERVER_DISABLE_ID:
         return COAP_405_METHOD_NOT_ALLOWED;
 
     case LWM2M_SERVER_TIMEOUT_ID:
-        return COAP_404_NOT_FOUND;
+        lwm2m_tlv_encode_int(targetP->disableTimeout, tlvP);
+        if (0 != tlvP->length) return COAP_205_CONTENT;
+        else return COAP_500_INTERNAL_SERVER_ERROR;
 
     case LWM2M_SERVER_STORING_ID:
         lwm2m_tlv_encode_bool(targetP->storing, tlvP);
@@ -86,7 +95,7 @@ static uint8_t prv_get_value(lwm2m_tlv_t * tlvP,
         else return COAP_500_INTERNAL_SERVER_ERROR;
 
     case LWM2M_SERVER_BINDING_ID:
-        tlvP->value = targetP->binding;
+        tlvP->value = (uint8_t*)targetP->binding;
         tlvP->length = strlen(targetP->binding);
         tlvP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
         return COAP_205_CONTENT;
@@ -114,7 +123,15 @@ static uint8_t prv_server_read(uint16_t instanceId,
     // is the server asking for the full instance ?
     if (*numDataP == 0)
     {
-        uint16_t resList[] = {LWM2M_SERVER_SHORT_ID_ID, LWM2M_SERVER_LIFETIME_ID, LWM2M_SERVER_STORING_ID, LWM2M_SERVER_BINDING_ID};
+        uint16_t resList[] = {
+                LWM2M_SERVER_SHORT_ID_ID,
+                LWM2M_SERVER_LIFETIME_ID,
+                LWM2M_SERVER_MIN_PERIOD_ID,
+                LWM2M_SERVER_MAX_PERIOD_ID,
+                LWM2M_SERVER_TIMEOUT_ID,
+                LWM2M_SERVER_STORING_ID,
+                LWM2M_SERVER_BINDING_ID
+        };
         int nbRes = sizeof(resList)/sizeof(uint16_t);
 
         *dataArrayP = lwm2m_tlv_new(nbRes);
@@ -181,20 +198,77 @@ static uint8_t prv_server_write(uint16_t instanceId,
         break;
 
         case LWM2M_SERVER_MIN_PERIOD_ID:
-            result = COAP_404_NOT_FOUND;
-            break;
+        {
+            int64_t value;
+
+            if (1 == lwm2m_tlv_decode_int(dataArray + i, &value))
+            {
+                if (value >= 0 && value <= 0xFFFFFFFF)
+                {
+                    targetP->defMinPeriod = value;
+                    result = COAP_204_CHANGED;
+                }
+                else
+                {
+                    result = COAP_406_NOT_ACCEPTABLE;
+                }
+            }
+            else
+            {
+                result = COAP_400_BAD_REQUEST;
+            }
+        }
+        break;
 
         case LWM2M_SERVER_MAX_PERIOD_ID:
-            result = COAP_404_NOT_FOUND;
-            break;
+        {
+            int64_t value;
+
+            if (1 == lwm2m_tlv_decode_int(dataArray + i, &value))
+            {
+                if (value >= 0 && value <= 0xFFFFFFFF)
+                {
+                    targetP->defMaxPeriod = value;
+                    result = COAP_204_CHANGED;
+                }
+                else
+                {
+                    result = COAP_406_NOT_ACCEPTABLE;
+                }
+            }
+            else
+            {
+                result = COAP_400_BAD_REQUEST;
+            }
+        }
+        break;
 
         case LWM2M_SERVER_DISABLE_ID:
             result = COAP_405_METHOD_NOT_ALLOWED;
             break;
 
         case LWM2M_SERVER_TIMEOUT_ID:
-            result = COAP_404_NOT_FOUND;
-            break;
+        {
+            int64_t value;
+
+            if (1 == lwm2m_tlv_decode_int(dataArray + i, &value))
+            {
+                if (value >= 0 && value <= 0xFFFFFFFF)
+                {
+                    targetP->disableTimeout = value;
+                    result = COAP_204_CHANGED;
+                }
+                else
+                {
+                    result = COAP_406_NOT_ACCEPTABLE;
+                }
+            }
+            else
+            {
+                result = COAP_400_BAD_REQUEST;
+            }
+        }
+        break;
 
         case LWM2M_SERVER_STORING_ID:
         {
@@ -214,14 +288,14 @@ static uint8_t prv_server_write(uint16_t instanceId,
 
         case LWM2M_SERVER_BINDING_ID:
             if ((dataArray[i].length > 0 && dataArray[i].length <= 3)
-             && (strncmp(dataArray[i].value, "U", dataArray[i].length) == 0
-              || strncmp(dataArray[i].value, "UQ", dataArray[i].length) == 0
-              || strncmp(dataArray[i].value, "S", dataArray[i].length) == 0
-              || strncmp(dataArray[i].value, "SQ", dataArray[i].length) == 0
-              || strncmp(dataArray[i].value, "US", dataArray[i].length) == 0
-              || strncmp(dataArray[i].value, "UQS", dataArray[i].length) == 0))
+             && (strncmp((char*)dataArray[i].value, "U",   dataArray[i].length) == 0
+              || strncmp((char*)dataArray[i].value, "UQ",  dataArray[i].length) == 0
+              || strncmp((char*)dataArray[i].value, "S",   dataArray[i].length) == 0
+              || strncmp((char*)dataArray[i].value, "SQ",  dataArray[i].length) == 0
+              || strncmp((char*)dataArray[i].value, "US",  dataArray[i].length) == 0
+              || strncmp((char*)dataArray[i].value, "UQS", dataArray[i].length) == 0))
             {
-                strncpy(targetP->binding, dataArray[i].value, dataArray[i].length);
+                strncpy(targetP->binding, (char*)dataArray[i].value, dataArray[i].length);
                 result = COAP_204_CHANGED;
             }
             else
@@ -258,9 +332,12 @@ static uint8_t prv_server_execute(uint16_t instanceId,
     switch (resourceId)
     {
     case LWM2M_SERVER_DISABLE_ID:
-        return COAP_404_NOT_FOUND;
+        // executed in core, if COAP_204_CHANGED is returned
+        if (0 < targetP->disableTimeout) return COAP_204_CHANGED;
+        else return COAP_405_METHOD_NOT_ALLOWED;
     case LWM2M_SERVER_UPDATE_ID:
-        return COAP_501_NOT_IMPLEMENTED;
+        // executed in core, if COAP_204_CHANGED is returned
+        return COAP_204_CHANGED;
     default:
         return COAP_405_METHOD_NOT_ALLOWED;
     }


### PR DESCRIPTION
Remove compiler warnings for all object implementations.
Unify memory management using lwm2m_malloc, lwm2m_free, lwm2m_strdup.
additional callback implementation for object 'closeFunc' for memory
management verification.
Resource Id defines for object implementations.
Connectivity Monitoring object bug: Reduce TLV message size of object to
less than 128 Byte to avoid message buffer truncation without blockwise.

Signed-off-by: Joerg Hubschneider <joerg.hubschneider@bosch-si.com>