### PR TITLE
Do not a reply to DM requests coming from unregistered servers.

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -120,7 +120,7 @@ int transaction_handle_response(lwm2m_context_t * contextP, void * fromSessionH,
 coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 
 // defined in observe.c
-coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
+coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
 void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, void * fromSessionH);
 
 // defined in registration.c

--- a/core/internals.h
+++ b/core/internals.h
@@ -137,5 +137,6 @@ void observation_remove(lwm2m_client_t * clientP, lwm2m_observation_t * observat
 
 // defined in utils.c
 lwm2m_binding_t lwm2m_stringToBinding(uint8_t *buffer, size_t length);
+lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP, void * fromSessionH);
 
 #endif

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -74,6 +74,7 @@ void lwm2m_free(void *p);
  */
 
 #define COAP_NO_ERROR                   (uint8_t)0x00
+#define COAP_IGNORE                     (uint8_t)0x01
 
 #define COAP_201_CREATED                (uint8_t)0x41
 #define COAP_202_DELETED                (uint8_t)0x42

--- a/core/management.c
+++ b/core/management.c
@@ -59,6 +59,11 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                                 coap_packet_t * response)
 {
     coap_status_t result;
+    lwm2m_server_t * serverP;
+
+    serverP = prv_findServer(contextP, fromSessionH);
+    if (serverP == NULL) return COAP_IGNORE;
+    if (serverP->status != STATE_REGISTERED && serverP->status != STATE_REG_UPDATE_PENDING) return COAP_IGNORE;
 
     switch (message->code)
     {
@@ -72,7 +77,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
             {
                 if (IS_OPTION(message, COAP_OPTION_OBSERVE))
                 {
-                    result = handle_observe_request(contextP, uriP, fromSessionH, message, response);
+                    result = handle_observe_request(contextP, uriP, serverP, message, response);
                 }
                 if (COAP_205_CONTENT == result)
                 {
@@ -86,6 +91,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
             }
         }
         break;
+
     case COAP_POST:
         {
             if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
@@ -127,6 +133,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
             }
         }
         break;
+
     case COAP_PUT:
         {
             if (LWM2M_URI_IS_SET_INSTANCE(uriP))
@@ -139,6 +146,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
             }
         }
         break;
+
     case COAP_DELETE:
         {
             if (LWM2M_URI_IS_SET_INSTANCE(uriP) && !LWM2M_URI_IS_SET_RESOURCE(uriP))
@@ -151,6 +159,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
             }
         }
         break;
+
     default:
         result = BAD_REQUEST_4_00;
         break;

--- a/core/observe.c
+++ b/core/observe.c
@@ -150,22 +150,17 @@ static lwm2m_watcher_t * prv_findWatcher(lwm2m_observed_t * observedP,
 
 coap_status_t handle_observe_request(lwm2m_context_t * contextP,
                                      lwm2m_uri_t * uriP,
-                                     void * fromSessionH,
+                                     lwm2m_server_t * serverP,
                                      coap_packet_t * message,
                                      coap_packet_t * response)
 {
     lwm2m_observed_t * observedP;
     lwm2m_watcher_t * watcherP;
-    lwm2m_server_t * serverP;
 
     LOG("handle_observe_request()\r\n");
 
     if (!LWM2M_URI_IS_SET_INSTANCE(uriP) && LWM2M_URI_IS_SET_RESOURCE(uriP)) return COAP_400_BAD_REQUEST;
     if (message->token_len == 0) return COAP_400_BAD_REQUEST;
-
-    serverP = prv_findServer(contextP, fromSessionH);
-    if (serverP == NULL) return COAP_401_UNAUTHORIZED ;
-    if (serverP->status != STATE_REGISTERED && serverP->status != STATE_REG_UPDATE_PENDING) return COAP_401_UNAUTHORIZED ;
 
     observedP = prv_findObserved(contextP, uriP);
     if (observedP == NULL)

--- a/core/observe.c
+++ b/core/observe.c
@@ -133,21 +133,6 @@ static void prv_unlinkObserved(lwm2m_context_t * contextP,
     }
 }
 
-static lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP,
-                                       void * fromSessionH)
-{
-    lwm2m_server_t * targetP;
-
-    targetP = contextP->serverList;
-    while (targetP != NULL
-        && targetP->sessionH != fromSessionH)
-    {
-        targetP = targetP->next;
-    }
-
-    return targetP;
-}
-
 static lwm2m_watcher_t * prv_findWatcher(lwm2m_observed_t * observedP,
                                          lwm2m_server_t * serverP)
 {

--- a/core/packet.c
+++ b/core/packet.c
@@ -249,7 +249,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
                 response->payload = NULL;
                 response->payload_len = 0;
             }
-            else
+            else if (coap_error_code != COAP_IGNORE)
             {
             	coap_error_code = message_send(contextP, response, fromSessionH);
             }

--- a/core/utils.c
+++ b/core/utils.c
@@ -207,3 +207,26 @@ lwm2m_binding_t lwm2m_stringToBinding(uint8_t *buffer,
 
     return BINDING_UNKNOWN;
 }
+
+lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP,
+                                void * fromSessionH)
+{
+#ifdef LWM2M_CLIENT_MODE
+
+    lwm2m_server_t * targetP;
+
+    targetP = contextP->serverList;
+    while (targetP != NULL
+        && targetP->sessionH != fromSessionH)
+    {
+        targetP = targetP->next;
+    }
+
+    return targetP;
+
+#else
+
+    return NULL;
+
+#endif
+}


### PR DESCRIPTION
This can serve as a work around for issue https://github.com/OpenMobileAlliance/OMA-LwM2M-Public-Review/issues/7
If a request arrives before the registration ACK, it will be ignored. So the server will resend it per CoAP specifications. Chances are the ACK will arrive before the retransmission.