### PR TITLE
Wrap around gettimeofday()

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -127,6 +127,7 @@ void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, void * fromSession
 coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void registration_deregister(lwm2m_context_t * contextP, lwm2m_server_t * serverP);
 void prv_freeClient(lwm2m_client_t * clientP);
+void registration_update(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
 // defined in packet.c
 coap_status_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, void * sessionH);

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -275,8 +275,9 @@ int lwm2m_step(lwm2m_context_t * contextP,
 
         transacP = nextP;
     }
+
 #ifdef LWM2M_CLIENT_MODE
-    lwm2m_update_registrations(contextP, tv_sec, timeoutP);
+    registration_update(contextP, tv_sec, timeoutP);
 #endif
 
 #ifdef LWM2M_SERVER_MODE

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -231,7 +231,7 @@ int lwm2m_configure(lwm2m_context_t * contextP,
 
 
 int lwm2m_step(lwm2m_context_t * contextP,
-               struct timeval * timeoutP)
+               time_t * timeoutP)
 {
     lwm2m_transaction_t * transacP;
     time_t tv_sec;
@@ -267,9 +267,9 @@ int lwm2m_step(lwm2m_context_t * contextP,
                 interval = 1;
             }
 
-            if (timeoutP->tv_sec > interval)
+            if (*timeoutP > interval)
             {
-                timeoutP->tv_sec = interval;
+                *timeoutP = interval;
             }
         }
 
@@ -301,9 +301,9 @@ int lwm2m_step(lwm2m_context_t * contextP,
 
             interval = clientP->endOfLife - tv_sec;
 
-            if (timeoutP->tv_sec > interval)
+            if (*timeoutP > interval)
             {
-                timeoutP->tv_sec = interval;
+                *timeoutP = interval;
             }
         }
         clientP = nextP;

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -511,8 +511,8 @@ lwm2m_context_t * lwm2m_init(lwm2m_connect_server_callback_t connectCallback, lw
 // close a liblwm2m context.
 void lwm2m_close(lwm2m_context_t * contextP);
 
-// perform any required pending operation and adjust timeoutP to the maximal time interval to wait.
-int lwm2m_step(lwm2m_context_t * contextP, struct timeval * timeoutP);
+// perform any required pending operation and adjust timeoutP to the maximal time interval to wait in seconds.
+int lwm2m_step(lwm2m_context_t * contextP, time_t * timeoutP);
 // dispatch received data to liblwm2m
 void lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int length, void * fromSessionH);
 
@@ -526,7 +526,7 @@ int lwm2m_configure(lwm2m_context_t * contextP, char * endpointName, char * msis
 int lwm2m_start(lwm2m_context_t * contextP);
 
 // check if the server registrations are outdated and needs to be renewed
-int lwm2m_update_registrations(lwm2m_context_t * contextP, uint32_t currentTime, struct timeval * timeoutP);
+int lwm2m_update_registrations(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
 // send a registration update to the server specified by the server short identifier
 int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -58,16 +58,22 @@
 #include <sys/time.h>
 
 #ifndef LWM2M_EMBEDDED_MODE
-#define lwm2m_gettimeofday gettimeofday
 #define lwm2m_malloc malloc
 #define lwm2m_free free
 #define lwm2m_strdup strdup
 #else
-int lwm2m_gettimeofday(struct timeval *tv, void *p);
 char *lwm2m_strdup(const char* str);
 void *lwm2m_malloc(size_t s);
 void lwm2m_free(void *p);
 #endif
+// This function must return the number of seconds elapsed since origin.
+// The origin (Epoch, system boot, etc...) does not matter as this
+// function is used only to determine the elapsed time since the last
+// call to it.
+// In case of error, this must return a negative value.
+// Per POSIX specifications, time_t is a signed integer.
+// An implementation for POSIX systems is provided in utils.c
+time_t lwm2m_gettime();
 
 /*
  * Error code

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -346,8 +346,8 @@ typedef struct _lwm2m_server_
 {
     struct _lwm2m_server_ * next;   // matches lwm2m_list_t::next
     uint16_t          shortID;      // matches lwm2m_list_t::id
-    uint32_t          lifetime;     // lifetime of the registration in sec or 0 if default value (86400 sec), also used as hold off time for the bootstrap server
-    uint32_t          registration; // date of the last registration in sec
+    time_t            lifetime;     // lifetime of the registration in sec or 0 if default value (86400 sec), also used as hold off time for the bootstrap server
+    time_t            registration; // date of the last registration in sec
     lwm2m_binding_t   binding;      // client connection mode with this server
     void *            sessionH;
     lwm2m_status_t    status;
@@ -524,9 +524,6 @@ int lwm2m_configure(lwm2m_context_t * contextP, char * endpointName, char * msis
 
 // create objects for known LWM2M Servers.
 int lwm2m_start(lwm2m_context_t * contextP);
-
-// check if the server registrations are outdated and needs to be renewed
-int lwm2m_update_registrations(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
 // send a registration update to the server specified by the server short identifier
 int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID);

--- a/core/registration.c
+++ b/core/registration.c
@@ -323,7 +323,9 @@ int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID
 }
 
 // for each server update the registration if needed
-int lwm2m_update_registrations(lwm2m_context_t * contextP, uint32_t currentTime, struct timeval * timeoutP)
+int lwm2m_update_registrations(lwm2m_context_t * contextP,
+                               time_t currentTime,
+                               time_t * timeoutP)
 {
     lwm2m_server_t * targetP;
     targetP = contextP->serverList;
@@ -331,7 +333,7 @@ int lwm2m_update_registrations(lwm2m_context_t * contextP, uint32_t currentTime,
     {
         switch (targetP->status) {
             case STATE_REGISTERED:
-                if (targetP->registration + targetP->lifetime - timeoutP->tv_sec <= currentTime)
+                if (targetP->registration + targetP->lifetime - *timeoutP <= currentTime)
                 {
                     prv_update_registration(contextP, targetP);
                 }

--- a/core/registration.c
+++ b/core/registration.c
@@ -128,7 +128,7 @@ static void prv_handleRegistrationReply(lwm2m_transaction_t * transacP,
     coap_packet_t * packet = (coap_packet_t *)message;
 
     targetP = (lwm2m_server_t *)(transacP->peerP);
-    struct timeval tv;
+    time_t tv_sec;
 
     switch(targetP->status)
     {
@@ -151,9 +151,10 @@ static void prv_handleRegistrationReply(lwm2m_transaction_t * transacP,
                 }
                 targetP->location = coap_get_multi_option_as_string(packet->location_path);
 
-                if (0 == lwm2m_gettimeofday(&tv, NULL)) 
+                tv_sec = lwm2m_gettime();
+                if (tv_sec >= 0)
                 {
-                    targetP->registration = tv.tv_sec;
+                    targetP->registration = tv_sec;
                 }
             }
             else if (packet->code == BAD_REQUEST_4_00)
@@ -235,11 +236,11 @@ int lwm2m_start(lwm2m_context_t * contextP)
 }
 
 static void prv_handleRegistrationUpdateReply(lwm2m_transaction_t * transacP,
-                                        void * message)
+                                              void * message)
 {
     lwm2m_server_t * targetP;
     coap_packet_t * packet = (coap_packet_t *)message;
-    struct timeval tv;
+    time_t tv_sec;
 
     targetP = (lwm2m_server_t *)(transacP->peerP);
 
@@ -257,9 +258,10 @@ static void prv_handleRegistrationUpdateReply(lwm2m_transaction_t * transacP,
         {
             if (packet->code == CHANGED_2_04)
             {
-                if (0 == lwm2m_gettimeofday(&tv, NULL)) 
+                tv_sec = lwm2m_gettime();
+                if (tv_sec >= 0)
                 {
-                    targetP->registration = tv.tv_sec;
+                    targetP->registration = tv_sec;
                 }
                 targetP->status = STATE_REGISTERED;
             }
@@ -673,12 +675,10 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
                                           coap_packet_t * response)
 {
     coap_status_t result;
-    struct timeval tv;
+    time_t tv_sec;
 
-    if (lwm2m_gettimeofday(&tv, NULL) != 0)
-    {
-        return COAP_500_INTERNAL_SERVER_ERROR;
-    }
+    tv_sec = lwm2m_gettime();
+    if (tv_sec < 0) return COAP_500_INTERNAL_SERVER_ERROR;
 
     switch(message->code)
     {
@@ -742,7 +742,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         clientP->binding = binding;
         clientP->msisdn = msisdn;
         clientP->lifetime = lifetime;
-        clientP->endOfLife = tv.tv_sec + lifetime;
+        clientP->endOfLife = tv_sec + lifetime;
         clientP->objectList = objects;
         clientP->sessionH = fromSessionH;
 
@@ -855,7 +855,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
             clientP->objectList = objects;
         }
 
-        clientP->endOfLife = tv.tv_sec + clientP->lifetime;
+        clientP->endOfLife = tv_sec + clientP->lifetime;
 
         if (contextP->monitorCallback != NULL)
         {

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -289,11 +289,12 @@ int transaction_send(lwm2m_context_t * contextP,
 
     if (transacP->retrans_counter == 0)
     {
-        struct timeval tv;
+        time_t tv_sec;
 
-        if (0 == lwm2m_gettimeofday(&tv, NULL))
+        tv_sec = lwm2m_gettime();
+        if (tv_sec >= 0)
         {
-            transacP->retrans_time = tv.tv_sec;
+            transacP->retrans_time = tv_sec;
             transacP->retrans_counter = 1;
         }
         else

--- a/core/utils.c
+++ b/core/utils.c
@@ -207,3 +207,18 @@ lwm2m_binding_t lwm2m_stringToBinding(uint8_t *buffer,
 
     return BINDING_UNKNOWN;
 }
+
+#ifndef LWM2M_EMBEDDED_MODE
+time_t lwm2m_gettime()
+{
+    struct timeval tv;
+
+    if (0 != gettimeofday(&tv, NULL))
+    {
+        return -1;
+    }
+
+    return tv.tv_sec;
+}
+#endif
+

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -623,7 +623,7 @@ int main(int argc, char *argv[])
          *  - Secondly it adjust the timeout value (default 60s) depending on the state of the transaction
          *    (eg. retransmission) and the time between the next operation
          */
-        result = lwm2m_step(lwm2mH, &tv);
+        result = lwm2m_step(lwm2mH, &(tv.tv_sec));
         if (result != 0)
         {
             fprintf(stderr, "lwm2m_step() failed: 0x%X\r\n", result);

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -354,11 +354,12 @@ syntax_error:
 static void update_battery_level(lwm2m_context_t * context)
 {
     static time_t next_change_time = 0;
-    struct timeval tv;
+    time_t tv_sec;
 
-    lwm2m_gettimeofday(&tv, NULL);
+    tv_sec = lwm2m_gettime();
+    if (tv_sec < 0) return;
 
-    if (next_change_time < tv.tv_sec)
+    if (next_change_time < tv_sec)
     {
         char value[15];
         int valueLength;
@@ -374,7 +375,7 @@ static void update_battery_level(lwm2m_context_t * context)
         }
         level = rand() % 20;
         if (0 > level) level = -level;
-        next_change_time = tv.tv_sec + level + 10;
+        next_change_time = tv_sec + level + 10;
     }
 }
 
@@ -579,12 +580,15 @@ int main(int argc, char *argv[])
 
         if (g_reboot)
         {
-            lwm2m_gettimeofday(&tv, NULL);
+            time_t tv_sec;
+
+            tv_sec = lwm2m_gettime();
+
             if (0 == reboot_time)
             {
-                reboot_time = tv.tv_sec + 5;
+                reboot_time = tv_sec + 5;
             }
-            if (reboot_time < tv.tv_sec)
+            if (reboot_time < tv_sec)
             {
                 /*
                  * Message should normally be lost with reboot ...
@@ -594,7 +598,7 @@ int main(int argc, char *argv[])
             }
             else
             {
-                tv.tv_sec = reboot_time - tv.tv_sec;
+                tv.tv_sec = reboot_time - tv_sec;
             }
         }
         else if (batterylevelchanging) 

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -771,7 +771,7 @@ int main(int argc, char *argv[])
         tv.tv_sec = 60;
         tv.tv_usec = 0;
 
-        result = lwm2m_step(lwm2mH, &tv);
+        result = lwm2m_step(lwm2mH, &(tv.tv_sec));
         if (result != 0)
         {
             fprintf(stderr, "lwm2m_step() failed: 0x%X\r\n", result);


### PR DESCRIPTION
For easier embedded OSes ports, a lwm2m_gettime() function is provided. On POSIX compliant systems, this a just a wrapper to gettimeofday with a simpler interface.
Also modifies the lwm2m_step() API.