### PR TITLE
Bugfix: preserve COAP_IGNORE and don't send it as error message.

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -136,7 +136,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
 
     coap_set_status_code(response, result);
 
-    if (result < BAD_REQUEST_4_00)
+    if (COAP_IGNORE < result && result < BAD_REQUEST_4_00)
     {
         result = NO_ERROR;
     }
@@ -290,7 +290,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
         LOG("Message parsing failed %d\r\n", coap_error_code);
     }
 
-    if (coap_error_code != NO_ERROR)
+    if (coap_error_code != NO_ERROR && coap_error_code != COAP_IGNORE)
     {
         LOG("ERROR %u: %s\n", coap_error_code, coap_error_message);
 


### PR DESCRIPTION
Bugfix for pull request #24, ignore_result

The wakaama client still reponses to "too early" requests
("request" from server before the "ack" of "register").
(e.g. server side received response:
> 4 bytes received from [127.0.0.1]:16415
  60 01 2F 48   ` . / H
  Parsed: ver 1, type 2, tkl 0, code 1, mid 12104
  Payload:
 )

Therefor two additional small bugfixes seems to be required.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>