### PR TITLE
Support for alternative path in registration

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -70,6 +70,10 @@
 
 #define LWM2M_MAX_PACKET_SIZE 198
 
+#define REG_ALT_PATH_LINK         "<%s>;rt=\"oma.lwm2m\","
+#define REG_OBJECT_PATH           "<%s/%hu>,"
+#define REG_OBJECT_INSTANCE_PATH  "<%s/%hu/%hu>,"
+
 #define URI_REGISTRATION_SEGMENT        "rd"
 #define URI_REGISTRATION_SEGMENT_LEN    2
 #define URI_BOOTSTRAP_SEGMENT           "bs"

--- a/core/internals.h
+++ b/core/internals.h
@@ -70,9 +70,11 @@
 
 #define LWM2M_MAX_PACKET_SIZE 198
 
-#define REG_ALT_PATH_LINK         "<%s>;rt=\"oma.lwm2m\","
-#define REG_OBJECT_PATH           "<%s/%hu>,"
-#define REG_OBJECT_INSTANCE_PATH  "<%s/%hu/%hu>,"
+#define REG_LWM2M_RESOURCE_TYPE     ">;rt=\"oma.lwm2m\","
+#define REG_LWM2M_RESOURCE_TYPE_LEN 17
+#define REG_ALT_PATH_LINK           "<%s"REG_LWM2M_RESOURCE_TYPE
+#define REG_OBJECT_PATH             "<%s/%hu>,"
+#define REG_OBJECT_INSTANCE_PATH    "<%s/%hu/%hu>,"
 
 #define URI_REGISTRATION_SEGMENT        "rd"
 #define URI_REGISTRATION_SEGMENT_LEN    2

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -211,10 +211,14 @@ int lwm2m_configure(lwm2m_context_t * contextP,
     if (altPath != NULL)
     {
         contextP->altPath = lwm2m_strdup(altPath);
-        if (contextP->altPath == NULL)
-        {
-            return COAP_500_INTERNAL_SERVER_ERROR;
-        }
+    }
+    else
+    {
+        contextP->altPath = lwm2m_strdup("");
+    }
+    if (contextP->altPath == NULL)
+    {
+        return COAP_500_INTERNAL_SERVER_ERROR;
     }
 
     contextP->objectList = (lwm2m_object_t **)lwm2m_malloc(numObject * sizeof(lwm2m_object_t *));

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -131,6 +131,15 @@ void lwm2m_close(lwm2m_context_t * contextP)
     }
 
     lwm2m_free(contextP->endpointName);
+    if (contextP->msisdn != NULL)
+    {
+        lwm2m_free(contextP->msisdn);
+    }
+    if (contextP->altPath != NULL)
+    {
+        lwm2m_free(contextP->altPath);
+    }
+
 #endif
 
 #ifdef LWM2M_SERVER_MODE
@@ -162,6 +171,7 @@ void lwm2m_close(lwm2m_context_t * contextP)
 int lwm2m_configure(lwm2m_context_t * contextP,
                     char * endpointName,
                     char * msisdn,
+                    char * altPath,
                     uint16_t numObject,
                     lwm2m_object_t * objectList[])
 {
@@ -193,6 +203,15 @@ int lwm2m_configure(lwm2m_context_t * contextP,
     {
         contextP->msisdn = strdup(msisdn);
         if (contextP->msisdn == NULL)
+        {
+            return COAP_500_INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    if (altPath != NULL)
+    {
+        contextP->altPath = strdup(altPath);
+        if (contextP->altPath == NULL)
         {
             return COAP_500_INTERNAL_SERVER_ERROR;
         }

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -193,7 +193,7 @@ int lwm2m_configure(lwm2m_context_t * contextP,
     }
     if (found != 0x07) return COAP_400_BAD_REQUEST;
 
-    contextP->endpointName = strdup(endpointName);
+    contextP->endpointName = lwm2m_strdup(endpointName);
     if (contextP->endpointName == NULL)
     {
         return COAP_500_INTERNAL_SERVER_ERROR;
@@ -201,7 +201,7 @@ int lwm2m_configure(lwm2m_context_t * contextP,
 
     if (msisdn != NULL)
     {
-        contextP->msisdn = strdup(msisdn);
+        contextP->msisdn = lwm2m_strdup(msisdn);
         if (contextP->msisdn == NULL)
         {
             return COAP_500_INTERNAL_SERVER_ERROR;
@@ -210,7 +210,7 @@ int lwm2m_configure(lwm2m_context_t * contextP,
 
     if (altPath != NULL)
     {
-        contextP->altPath = strdup(altPath);
+        contextP->altPath = lwm2m_strdup(altPath);
         if (contextP->altPath == NULL)
         {
             return COAP_500_INTERNAL_SERVER_ERROR;

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -491,6 +491,7 @@ typedef struct
 #ifdef LWM2M_CLIENT_MODE
     char *              endpointName;
     char *              msisdn;
+    char *              altPath;
     lwm2m_server_t *    bootstrapServerList;
     lwm2m_server_t *    serverList;
     lwm2m_object_t **   objectList;
@@ -522,10 +523,11 @@ int lwm2m_step(lwm2m_context_t * contextP, time_t * timeoutP);
 void lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int length, void * fromSessionH);
 
 #ifdef LWM2M_CLIENT_MODE
-// configure the client side with the Endpoint Name, binding, MSISDN (if any) and a list of objects.
+// configure the client side with the Endpoint Name, binding, MSISDN (can be nil), alternative path
+// for objects (can be nil) and a list of objects.
 // LWM2M Security Object (ID 0) must be present with either a bootstrap server or a LWM2M server and
 // its matching LWM2M Server Object (ID 1) instance
-int lwm2m_configure(lwm2m_context_t * contextP, char * endpointName, char * msisdn, uint16_t numObject, lwm2m_object_t * objectList[]);
+int lwm2m_configure(lwm2m_context_t * contextP, char * endpointName, char * msisdn, char * altPath, uint16_t numObject, lwm2m_object_t * objectList[]);
 
 // create objects for known LWM2M Servers.
 int lwm2m_start(lwm2m_context_t * contextP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -61,10 +61,12 @@
 #define lwm2m_malloc malloc
 #define lwm2m_free free
 #define lwm2m_strdup strdup
+#define lwm2m_strncmp strncmp
 #else
-char *lwm2m_strdup(const char* str);
-void *lwm2m_malloc(size_t s);
-void lwm2m_free(void *p);
+void * lwm2m_malloc(size_t s);
+void   lwm2m_free(void * p);
+char * lwm2m_strdup(const char * str);
+char * lwm2m_strncmp(const char * s1, const char * s2, size_t n);
 #endif
 // This function must return the number of seconds elapsed since origin.
 // The origin (Epoch, system boot, etc...) does not matter as this
@@ -408,6 +410,7 @@ typedef struct _lwm2m_client_
     char *                  name;
     lwm2m_binding_t         binding;
     char *                  msisdn;
+    char *                  altPath;
     uint32_t                lifetime;
     time_t                  endOfLife;
     void *                  sessionH;

--- a/core/objects.c
+++ b/core/objects.c
@@ -321,13 +321,28 @@ int prv_getRegisterPayload(lwm2m_context_t * contextP,
 
     // index can not be greater than length
     index = 0;
+
+    if (contextP->altPath[0] != 0)
+    {
+        result = snprintf(buffer, length, REG_ALT_PATH_LINK, contextP->altPath);
+        if (result > 0 && result <= length)
+        {
+            index = result;
+        }
+        else
+        {
+            return 0;
+        }
+    }
     for (i = 0 ; i < contextP->numObject ; i++)
     {
         if (contextP->objectList[i]->objID == LWM2M_SECURITY_OBJECT_ID) continue;
 
         if (contextP->objectList[i]->instanceList == NULL)
         {
-            result = snprintf(buffer + index, length - index, "</%hu>,", contextP->objectList[i]->objID);
+            result = snprintf(buffer + index, length - index,
+                              REG_OBJECT_PATH,
+                              contextP->altPath, contextP->objectList[i]->objID);
             if (result > 0 && result <= length - index)
             {
                 index += result;
@@ -344,7 +359,9 @@ int prv_getRegisterPayload(lwm2m_context_t * contextP,
             {
                 int result;
 
-                result = snprintf(buffer + index, length - index, "</%hu/%hu>,", contextP->objectList[i]->objID, targetP->id);
+                result = snprintf(buffer + index, length - index,
+                                  REG_OBJECT_INSTANCE_PATH,
+                                  contextP->altPath, contextP->objectList[i]->objID, targetP->id);
                 if (result > 0 && result <= length - index)
                 {
                     index += result;

--- a/core/registration.c
+++ b/core/registration.c
@@ -517,6 +517,8 @@ error:
 
 static int prv_getId(uint8_t * data,
                      uint16_t length,
+                     char * altPath,
+                     uint16_t altPathLen,
                      uint16_t * objId,
                      uint16_t * instanceId)
 {
@@ -534,6 +536,13 @@ static int prv_getId(uint8_t * data,
     else
     {
         return 0;
+    }
+
+    if (altPath != NULL)
+    {
+        if (length <= altPathLen) return 0;
+        if (0 != lwm2m_strncmp(data, altPath, altPathLen)) return 0;
+        data += altPathLen;
     }
 
     // If there is a preceding /, remove it
@@ -569,7 +578,8 @@ static int prv_getId(uint8_t * data,
 }
 
 static lwm2m_client_object_t * prv_decodeRegisterPayload(uint8_t * payload,
-                                                         uint16_t payloadLength)
+                                                         uint16_t payloadLength,
+                                                         char ** altPath)
 {
     lwm2m_client_object_t * objList;
     uint16_t id;
@@ -577,16 +587,56 @@ static lwm2m_client_object_t * prv_decodeRegisterPayload(uint8_t * payload,
     uint16_t start;
     uint16_t end;
     int result;
+    uint16_t altPathStart;
+    uint16_t altPathEnd;
+    uint16_t altPathLen;
 
     objList = NULL;
     start = 0;
+    altPathStart = 0;
+    altPathEnd = 0;
+    altPathLen = 0;
+    *altPath = NULL;
+
+    // Does the registration payload begin with an alternative path ?
+    while (start < payloadLength && payload[start] == ' ') start++;
+    if (start != payloadLength)
+    {
+        if (payload[start] == '<')
+        {
+            altPathStart = start + 1;
+        }
+        while (start < payloadLength - 1 && payload[start] != '>') start++;
+        if (start != payloadLength - 1)
+        {
+            altPathEnd = start - 1;
+            if ((payloadLength > altPathEnd + REG_LWM2M_RESOURCE_TYPE_LEN)
+             && (0 == lwm2m_strncmp(REG_LWM2M_RESOURCE_TYPE, (char *) payload + altPathEnd + 1, REG_LWM2M_RESOURCE_TYPE_LEN)))
+            {
+                payload[altPathEnd + 1] = 0;
+                *altPath = lwm2m_strdup((char *)payload + altPathStart);
+                if (*altPath == NULL) return NULL;
+                altPathLen = altPathEnd - altPathStart + 1;
+            }
+        }
+    }
+
+    if (altPathLen != 0)
+    {
+        start = altPathEnd + 1 + REG_LWM2M_RESOURCE_TYPE_LEN;
+    }
+    else
+    {
+        start = 0;
+    }
+
     while (start < payloadLength)
     {
         while (start < payloadLength && payload[start] == ' ') start++;
         if (start == payloadLength) return objList;
         end = start;
         while (end < payloadLength && payload[end] != ',') end++;
-        result = prv_getId(payload + start, end - start, &id, &instance);
+        result = prv_getId(payload + start, end - start, *altPath, altPathLen, &id, &instance);
         if (result != 0)
         {
             lwm2m_client_object_t * objectP;
@@ -659,6 +709,7 @@ void prv_freeClient(lwm2m_client_t * clientP)
 {
     if (clientP->name != NULL) lwm2m_free(clientP->name);
     if (clientP->msisdn != NULL) lwm2m_free(clientP->msisdn);
+    lwm2m_free(clientP->altPath);
     prv_freeClientObjectList(clientP->objectList);
     while(clientP->observationList != NULL)
     {
@@ -706,6 +757,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         char * name = NULL;
         uint32_t lifetime;
         char * msisdn;
+        char * altPath;
         lwm2m_binding_t binding;
         lwm2m_client_object_t * objects;
         lwm2m_client_t * clientP;
@@ -716,7 +768,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         {
             return COAP_400_BAD_REQUEST;
         }
-        objects = prv_decodeRegisterPayload(message->payload, message->payload_len);
+        objects = prv_decodeRegisterPayload(message->payload, message->payload_len, &altPath);
         if (objects == NULL)
         {
             lwm2m_free(name);
@@ -740,6 +792,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
             // we reset this registration
             lwm2m_free(clientP->name);
             if (clientP->msisdn != NULL) lwm2m_free(clientP->msisdn);
+            if (clientP->altPath != NULL) lwm2m_free(clientP->altPath);
             prv_freeClientObjectList(clientP->objectList);
             clientP->objectList = NULL;
         }
@@ -749,6 +802,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
             if (clientP == NULL)
             {
                 lwm2m_free(name);
+                lwm2m_free(altPath);
                 if (msisdn != NULL) lwm2m_free(msisdn);
                 prv_freeClientObjectList(objects);
                 return COAP_500_INTERNAL_SERVER_ERROR;
@@ -760,6 +814,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         clientP->name = name;
         clientP->binding = binding;
         clientP->msisdn = msisdn;
+        clientP->altPath = altPath;
         clientP->lifetime = lifetime;
         clientP->endOfLife = tv_sec + lifetime;
         clientP->objectList = objects;
@@ -789,6 +844,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         char * name = NULL;
         uint32_t lifetime;
         char * msisdn;
+        char * altPath;
         lwm2m_binding_t binding;
         lwm2m_client_object_t * objects;
         lwm2m_client_t * clientP;
@@ -802,7 +858,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         {
             return COAP_400_BAD_REQUEST;
         }
-        objects = prv_decodeRegisterPayload(message->payload, message->payload_len);
+        objects = prv_decodeRegisterPayload(message->payload, message->payload_len, &altPath);
 
         // Endpoint client name MUST NOT be present
         if (name != NULL)

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -536,7 +536,7 @@ int main(int argc, char *argv[])
      * We configure the liblwm2m library with the name of the client - which shall be unique for each client -
      * the number of objects we will be passing through and the objects array
      */
-    result = lwm2m_configure(lwm2mH, name, NULL, OBJ_COUNT, objArray);
+    result = lwm2m_configure(lwm2mH, name, NULL, NULL, OBJ_COUNT, objArray);
     if (result != 0)
     {
         fprintf(stderr, "lwm2m_set_objects() failed: 0x%X\r\n", result);

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -84,7 +84,7 @@
 int g_reboot = 0;
 static int g_quit = 0;
 
-#define OBJ_COUNT 9
+#define OBJ_COUNT 3
 lwm2m_object_t * objArray[OBJ_COUNT];
 
 
@@ -254,7 +254,7 @@ static uint8_t prv_buffer_send(void * sessionH,
         fprintf(stderr, "#> failed sending %lu bytes\r\n", length);
         return COAP_500_INTERNAL_SERVER_ERROR ;
     }
-    conn_s_updateTxStatistic(objArray[7], (uint16_t)length, false);
+    // conn_s_updateTxStatistic(objArray[7], (uint16_t)length, false);
     fprintf(stderr, "#> sent %lu bytes\r\n", length);
     return COAP_NO_ERROR;
 }
@@ -446,7 +446,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    objArray[1] = get_object_firmware();
+/*    objArray[1] = get_object_firmware();
     if (NULL == objArray[1])
     {
         fprintf(stderr, "Failed to create Firmware object\r\n");
@@ -459,10 +459,10 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to create test object\r\n");
         return -1;
     }
-
+*/
     int serverId = 123;
-    objArray[3] = get_server_object(serverId, "U", lifetime, false);
-    if (NULL == objArray[3])
+    objArray[1] = get_server_object(serverId, "U", lifetime, false);
+    if (NULL == objArray[1])
     {
         fprintf(stderr, "Failed to create server object\r\n");
         return -1;
@@ -470,15 +470,15 @@ int main(int argc, char *argv[])
 
     char serverUri[50];
     sprintf(serverUri, "coap://%s:%s", server, serverPort);
-    objArray[4] = get_security_object(serverId, serverUri, false);
-    if (NULL == objArray[4])
+    objArray[2] = get_security_object(serverId, serverUri, false);
+    if (NULL == objArray[2])
     {
         fprintf(stderr, "Failed to create security object\r\n");
         return -1;
     }
-    data.securityObjP = objArray[4];
+    data.securityObjP = objArray[2];
 
-    objArray[5] = get_object_location();
+ /*   objArray[5] = get_object_location();
     if (NULL == objArray[5])
     {
         fprintf(stderr, "Failed to create location object\r\n");
@@ -521,6 +521,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to create Access Control ACL resource for serverId: 999\r\n");
         return -1;
     }
+*/
     /*
      * The liblwm2m library is now initialized with the functions that will be in
      * charge of communication
@@ -536,7 +537,7 @@ int main(int argc, char *argv[])
      * We configure the liblwm2m library with the name of the client - which shall be unique for each client -
      * the number of objects we will be passing through and the objects array
      */
-    result = lwm2m_configure(lwm2mH, name, NULL, NULL, OBJ_COUNT, objArray);
+    result = lwm2m_configure(lwm2mH, name, NULL, "/test", OBJ_COUNT, objArray);
     if (result != 0)
     {
         fprintf(stderr, "lwm2m_set_objects() failed: 0x%X\r\n", result);
@@ -699,7 +700,7 @@ int main(int argc, char *argv[])
                          * Let liblwm2m respond to the query depending on the context
                          */
                         lwm2m_handle_packet(lwm2mH, buffer, numBytes, connP);
-                        conn_s_updateRxStatistic(objArray[7], numBytes, false);
+                        //conn_s_updateRxStatistic(objArray[7], numBytes, false);
                     }
                     else
                     {

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -147,6 +147,7 @@ static void prv_dump_client(lwm2m_client_t * targetP)
     fprintf(stdout, "\tname: \"%s\"\r\n", targetP->name);
     fprintf(stdout, "\tbinding: \"%s\"\r\n", prv_dump_binding(targetP->binding));
     if (targetP->msisdn) fprintf(stdout, "\tmsisdn: \"%s\"\r\n", targetP->msisdn);
+    if (targetP->altPath) fprintf(stdout, "\talternative path: \"%s\"\r\n", targetP->altPath);
     fprintf(stdout, "\tlifetime: %d sec\r\n", targetP->lifetime);
     fprintf(stdout, "\tobjects: ");
     for (objectP = targetP->objectList; objectP != NULL ; objectP = objectP->next)


### PR DESCRIPTION
As described in the LWM2M TS §5.3.1:
> By default, the RFC6690 links of Objects are located under the root path as in the examples above. However, devices might be hosting other Resources on an endpoint, and there may be the need to place Objects under an alternative path. This is achieved by including an OMA LWM2M link in addition to the Object links as follows, e.g. to place Objects under the “/lwm2m” path:
</lwm2m>;rt="oma.lwm2m", </lwm2m/1/101>, </lwm2m/1/102>, </lwm2m/2/0>, </lwm2m/2/1>, </lwm2m/2/2>, </lwm2m/3/0>,</lwm2m/4/0>,</lwm2m/5>
The RFC6690 Resource Type parameter (i.e., rt="oma.lwm2m") MAY be used to provide the information that the path in front of the Resource Type parameter is used for the LWM2M enabler.

