### PR TITLE
Bugfix: correct decoding of instanceId in "prv_getId", if altPath is provided.

### DIFF
--- a/core/registration.c
+++ b/core/registration.c
@@ -543,6 +543,7 @@ static int prv_getId(uint8_t * data,
         if (length <= altPathLen) return 0;
         if (0 != lwm2m_strncmp(data, altPath, altPathLen)) return 0;
         data += altPathLen;
+        length -= altPathLen;
     }
 
     // If there is a preceding /, remove it


### PR DESCRIPTION
Using the "altPath" feature, the object instance ids are not listed in the server.

Log:
---------------------------------------------------------------------------------------------------------
    72 bytes received from [127.0.0.1]:16415
      40 02 EB 3C B2 72 64 47 65 70 3D 74 65 73 74 03   @ . . < . r d G e p = t e s t .
      62 3D 55 05 6C 74 3D 36 30 FF 3C 2F 74 65 73 74   b = U . l t = 6 0 . < / t e s t
      3E 3B 72 74 3D 22 6F 6D 61 2E 6C 77 6D 32 6D 22   > ; r t = " o m a . l w m 2 m "
      2C 3C 2F 74 65 73 74 2F 33 2F 30 3E 2C 3C 2F 74   , < / t e s t / 3 / 0 > , < / t
      65 73 74 2F 31 2F 30 3E                           e s t / 1 / 0 >
      Parsed: ver 1, type 0, tkl 0, code 2, mid 60220
      Payload: </test>;rt="oma.lwm2m",</test/3/0>,</test/1/0>

    New client #0 registered.
    Client #0:
        name: "test"
        binding: "UDP"
        alternative path: "/test"
        lifetime: 60 sec
        objects: /1, /3,
 ---------------------------------------------------------------------------------------------------------
The request contains e.g. "< / t e s t / 3 / 0 >", but the server list only "/3"

With this bugfix, the server decodes the object instance id:

New log:
---------------------------------------------------------------------------------------------------------
    New client #0 registered.
    Client #0:
        name: "test"
        binding: "UDP"
        alternative path: "/test"
        lifetime: 60 sec
        objects: /1/0, /3/0,

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>