### PR TITLE
Bugfix: use ntohs before display port number.

### DIFF
--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -685,7 +685,7 @@ int main(int argc, char *argv[])
                         inet_ntop(saddr->sin6_family, &saddr->sin6_addr, s, INET6_ADDRSTRLEN);
                         port = saddr->sin6_port;
                     }
-                    fprintf(stderr, "%d bytes received from [%s]:%hu\r\n", numBytes, s, port);
+                    fprintf(stderr, "%d bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
 
                     /*
                      * Display it in the STDERR

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -825,7 +825,7 @@ int main(int argc, char *argv[])
                         port = saddr->sin6_port;
                     }
 
-                    fprintf(stderr, "%d bytes received from [%s]:%hu\r\n", numBytes, s, port);
+                    fprintf(stderr, "%d bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
 
                     output_buffer(stderr, buffer, numBytes);
 


### PR DESCRIPTION
Analyzing to log for the "altPath / object instance" issue, I recognized, that I mixed up the displayed ports some weeks ago ...

    72 bytes received from [127.0.0.1]:16415 

Now (again):

    ... bytes received from [127.0.0.1]:8000

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>