### PR TITLE
Simplify lwm2m_uri_t by removing its member "flag".

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -81,12 +81,13 @@
 #define URI_BOOTSTRAP_SEGMENT           "bs"
 #define URI_BOOTSTRAP_SEGMENT_LEN       2
 
-#define LWM2M_URI_FLAG_DM           (uint8_t)0x00
-#define LWM2M_URI_FLAG_REGISTRATION (uint8_t)0x20
-#define LWM2M_URI_FLAG_BOOTSTRAP    (uint8_t)0x40
-
-#define LWM2M_URI_MASK_TYPE (uint8_t)0x70
-#define LWM2M_URI_MASK_ID   (uint8_t)0x07
+typedef enum
+{
+    LWM2M_URI_INVALID,
+    LWM2M_URI_DM,
+    LWM2M_URI_REGISTRATION,
+    LWM2M_URI_BOOTSTRAP
+} uri_type_t;
 
 typedef struct
 {
@@ -103,7 +104,7 @@ typedef struct _obs_list_
 
 // defined in uri.c
 int lwm2m_get_number(const char * uriString, size_t uriLength);
-lwm2m_uri_t * lwm2m_decode_uri(char * altPath, multi_option_t *uriPath);
+uri_type_t lwm2m_decode_uri(char * altPath, multi_option_t *uriPath, lwm2m_uri_t ** resultUriP);
 
 // defined in objects.c
 coap_status_t object_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, char ** bufferP, int * lengthP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -263,22 +263,20 @@ int lwm2m_opaqueToInt(char * buffer, size_t buffer_len, int64_t * dataP);
  * URI
  *
  * objectId is always set
- * if instanceId or resourceId is greater than LWM2M_URI_MAX_ID, it means it is not specified
+ * LWM2M_MAX_ID is a reserved value and means an ID is not specified
+ *
+ * IMPLEMENTATION LIMITATION: A resource can not have an ID of 65535.
+ * (LWM2M does not allow 65535 for Object IDs and Object Instance IDs)
  *
  */
 
 #define LWM2M_MAX_ID   ((uint16_t)0xFFFF)
 
-#define LWM2M_URI_FLAG_OBJECT_ID    (uint8_t)0x04
-#define LWM2M_URI_FLAG_INSTANCE_ID  (uint8_t)0x02
-#define LWM2M_URI_FLAG_RESOURCE_ID  (uint8_t)0x01
-
-#define LWM2M_URI_IS_SET_INSTANCE(uri) ((uri->flag & LWM2M_URI_FLAG_INSTANCE_ID) != 0)
-#define LWM2M_URI_IS_SET_RESOURCE(uri) ((uri->flag & LWM2M_URI_FLAG_RESOURCE_ID) != 0)
+#define LWM2M_URI_IS_SET_INSTANCE(uri) ((uri)->instanceId != LWM2M_MAX_ID)
+#define LWM2M_URI_IS_SET_RESOURCE(uri) ((uri)->resourceId != LWM2M_MAX_ID)
 
 typedef struct
 {
-    uint8_t     flag;           // indicates which segments are set
     uint16_t    objectId;
     uint16_t    instanceId;
     uint16_t    resourceId;

--- a/core/management.c
+++ b/core/management.c
@@ -102,7 +102,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                     //longest uri is /65535/65535 = 12 + 1 (null) chars
                     char location_path[13] = "";
                     //instanceId expected
-                    if ((uriP->flag & LWM2M_URI_FLAG_INSTANCE_ID) == 0)
+                    if (uriP->instanceId == LWM2M_MAX_ID)
                     {
                         result = COAP_500_INTERNAL_SERVER_ERROR;
                         break;
@@ -214,7 +214,6 @@ static void dm_result_callback(lwm2m_transaction_t * transacP,
             }
 
             ((dm_data_t*)transacP->userData)->uri.instanceId = locationUri.instanceId;
-            ((dm_data_t*)transacP->userData)->uri.flag = locationUri.flag;
 
             lwm2m_free(locationString);
         }

--- a/core/objects.c
+++ b/core/objects.c
@@ -265,7 +265,10 @@ coap_status_t object_create(lwm2m_context_t * contextP,
     else
     {
         uriP->instanceId = lwm2m_list_newId(targetP->instanceList);
-        uriP->flag |= LWM2M_URI_FLAG_INSTANCE_ID;
+        if (uriP->instanceId == LWM2M_MAX_ID)
+        {
+            return COAP_500_INTERNAL_SERVER_ERROR;
+        }
     }
 
     targetP = prv_find_object(contextP, uriP->objectId);

--- a/core/observe.c
+++ b/core/observe.c
@@ -60,9 +60,8 @@ static lwm2m_observed_t * prv_findObserved(lwm2m_context_t * contextP,
     targetP = contextP->observedList;
     while (targetP != NULL
         && (targetP->uri.objectId != uriP->objectId
-         || targetP->uri.flag != uriP->flag
-         || (LWM2M_URI_IS_SET_INSTANCE(uriP) && targetP->uri.instanceId != uriP->instanceId)
-         || (LWM2M_URI_IS_SET_RESOURCE(uriP) && targetP->uri.resourceId != uriP->resourceId)))
+         || targetP->uri.instanceId != uriP->instanceId
+         || targetP->uri.resourceId != uriP->resourceId))
     {
         targetP = targetP->next;
     }
@@ -83,12 +82,12 @@ static obs_list_t * prv_getObservedList(lwm2m_context_t * contextP,
     {
         if (targetP->uri.objectId == uriP->objectId)
         {
-            if (!LWM2M_URI_IS_SET_INSTANCE(uriP)
-             || (targetP->uri.flag & LWM2M_URI_FLAG_INSTANCE_ID) == 0
+            if (uriP->instanceId == LWM2M_MAX_ID
+             || targetP->uri.instanceId == LWM2M_MAX_ID
              || uriP->instanceId == targetP->uri.instanceId)
             {
-                if (!LWM2M_URI_IS_SET_RESOURCE(uriP)
-                 || (targetP->uri.flag & LWM2M_URI_FLAG_RESOURCE_ID) == 0
+                if (uriP->resourceId == LWM2M_MAX_ID
+                 || targetP->uri.resourceId == LWM2M_MAX_ID
                  || uriP->resourceId == targetP->uri.resourceId)
                 {
                     obs_list_t * newP;
@@ -292,7 +291,6 @@ static lwm2m_observation_t * prv_findObservationByURI(lwm2m_client_t * clientP,
     while (targetP != NULL)
     {
         if (targetP->uri.objectId == uriP->objectId
-         && targetP->uri.flag == uriP->flag
          && targetP->uri.instanceId == uriP->instanceId
          && targetP->uri.resourceId == uriP->resourceId)
         {

--- a/core/packet.c
+++ b/core/packet.c
@@ -107,30 +107,29 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
 {
     lwm2m_uri_t * uriP;
     coap_status_t result = NOT_FOUND_4_04;
+    uri_type_t type;
 
 #ifdef LWM2M_CLIENT_MODE
-    uriP = lwm2m_decode_uri(contextP->altPath, message->uri_path);
+    type = lwm2m_decode_uri(contextP->altPath, message->uri_path, &uriP);
 #else
-    uriP = lwm2m_decode_uri(NULL, message->uri_path);
+    type = lwm2m_decode_uri(NULL, message->uri_path, &uriP);
 #endif
 
-    if (uriP == NULL) return BAD_REQUEST_4_00;
-
-    switch(uriP->flag & LWM2M_URI_MASK_TYPE)
+    switch(type)
     {
 #ifdef LWM2M_CLIENT_MODE
-    case LWM2M_URI_FLAG_DM:
+    case LWM2M_URI_DM:
         // TODO: Authentify server
         result = handle_dm_request(contextP, uriP, fromSessionH, message, response);
         break;
 
-    case LWM2M_URI_FLAG_BOOTSTRAP:
+    case LWM2M_URI_BOOTSTRAP:
         result = NOT_IMPLEMENTED_5_01;
         break;
 #endif
 
 #ifdef LWM2M_SERVER_MODE
-   case LWM2M_URI_FLAG_REGISTRATION:
+   case LWM2M_URI_REGISTRATION:
         result = handle_registration_request(contextP, uriP, fromSessionH, message, response);
         break;
 #endif
@@ -146,7 +145,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
         result = NO_ERROR;
     }
 
-    lwm2m_free( uriP);
+    lwm2m_free(uriP);
     return result;
 }
 

--- a/core/registration.c
+++ b/core/registration.c
@@ -774,7 +774,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         lwm2m_client_t * clientP;
         char location[MAX_LOCATION_LENGTH];
 
-        if ((uriP->flag & LWM2M_URI_MASK_ID) != 0) return COAP_400_BAD_REQUEST;
+        if (uriP->objectId != LWM2M_MAX_ID) return COAP_400_BAD_REQUEST;
         if (0 != prv_getParameters(message->uri_query, &name, &lifetime, &msisdn, &binding))
         {
             return COAP_400_BAD_REQUEST;
@@ -860,7 +860,11 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         lwm2m_client_object_t * objects;
         lwm2m_client_t * clientP;
 
-        if ((uriP->flag & LWM2M_URI_MASK_ID) != LWM2M_URI_FLAG_OBJECT_ID) return COAP_400_BAD_REQUEST;
+        if (uriP->objectId == LWM2M_MAX_ID
+         || uriP->instanceId != LWM2M_MAX_ID)
+        {
+            return COAP_400_BAD_REQUEST;
+        }
 
         clientP = (lwm2m_client_t *)lwm2m_list_find((lwm2m_list_t *)contextP->clientList, uriP->objectId);
         if (clientP == NULL) return COAP_404_NOT_FOUND;
@@ -920,7 +924,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
                 }
                 else
                 {
-                    if ((observationP->uri.flag & LWM2M_URI_FLAG_INSTANCE_ID) != 0)
+                    if (observationP->uri.instanceId != LWM2M_MAX_ID)
                     {
                         if (lwm2m_list_find((lwm2m_list_t *)objP->instanceList, observationP->uri.instanceId) == NULL)
                         {
@@ -955,7 +959,11 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
     {
         lwm2m_client_t * clientP;
 
-        if ((uriP->flag & LWM2M_URI_MASK_ID) != LWM2M_URI_FLAG_OBJECT_ID) return COAP_400_BAD_REQUEST;
+        if (uriP->objectId == LWM2M_MAX_ID
+         || uriP->instanceId != LWM2M_MAX_ID)
+        {
+            return COAP_400_BAD_REQUEST;
+        }
 
         contextP->clientList = (lwm2m_client_t *)LWM2M_LIST_RM(contextP->clientList, uriP->objectId, &clientP);
         if (clientP == NULL) return COAP_400_BAD_REQUEST;


### PR DESCRIPTION
An ID is considered not set when it is equal to LWM2M_MAX_ID (0xFFFF).
Object and Object Instance can not have the MAX_ID 0xFFFF per LWM2M TS. We also add this limitation for Resource IDs.

Signed-off-by: David Navarro <david.navarro@intel.com>