### PR TITLE
Code fix for object Access Control read implementation

### DIFF
--- a/tests/client/object_access_control.c
+++ b/tests/client/object_access_control.c
@@ -121,7 +121,7 @@ static uint8_t prv_set_tlv(lwm2m_tlv_t* tlvP, acc_ctrl_oi_t* accCtrlOiP)
 static uint8_t prv_read(uint16_t instanceId, int * numDataP,
                         lwm2m_tlv_t** dataArrayP, lwm2m_object_t * objectP)
 {
-    uint8_t result, tmpRes;
+    uint8_t result;//, tmpRes;
     int     ri, ni;
 
     // multi-instance object: search instance
@@ -153,26 +153,22 @@ static uint8_t prv_read(uint16_t instanceId, int * numDataP,
         }
     }
 
+    ni = 0;
     ri = 0;
-    result = COAP_205_CONTENT;
     do
     {
-        tmpRes = prv_set_tlv((*dataArrayP)+ni, accCtrlOiP);
-        ri++;
-        // skip on tmpRes==COAP_404_NOT_FOUND:
-        if (tmpRes == COAP_205_CONTENT)
-        {
-            result = tmpRes;
-            ni++;
+        result = prv_set_tlv((*dataArrayP) + ni, accCtrlOiP);
+        if (result==COAP_404_NOT_FOUND) {
+            ri++;
+            result = COAP_205_CONTENT;
         }
-        else if (*numDataP<=1 || tmpRes != COAP_404_NOT_FOUND)
+        else if (ri > 0)    // copy new one by ri skipped ones in front
         {
-            result = tmpRes;
+            memcpy ((*dataArrayP)+ni-ri, (*dataArrayP)+ni, sizeof(lwm2m_tlv_t));
         }
-
-    } while (ri < *numDataP && result == COAP_205_CONTENT);
-
-    if (*numDataP!=1) *numDataP = ni;
+        ni++;
+    } while (ni < *numDataP && result == COAP_205_CONTENT);
+    *numDataP = ni-ri;
 
     return result;
 }

--- a/tests/client/object_access_control.c
+++ b/tests/client/object_access_control.c
@@ -163,7 +163,7 @@ static uint8_t prv_read(uint16_t instanceId, int * numDataP,
         }
         else if (ri > 0)    // copy new one by ri skipped ones in front
         {
-            memcpy ((*dataArrayP)+ni-ri, (*dataArrayP)+ni, sizeof(lwm2m_tlv_t));
+            (*dataArrayP)[ni-ri] = (*dataArrayP)[ni];
         }
         ni++;
     } while (ni < *numDataP && result == COAP_205_CONTENT);

--- a/tests/client/object_access_control.c
+++ b/tests/client/object_access_control.c
@@ -121,7 +121,7 @@ static uint8_t prv_set_tlv(lwm2m_tlv_t* tlvP, acc_ctrl_oi_t* accCtrlOiP)
 static uint8_t prv_read(uint16_t instanceId, int * numDataP,
                         lwm2m_tlv_t** dataArrayP, lwm2m_object_t * objectP)
 {
-    uint8_t result;//, tmpRes;
+    uint8_t result;
     int     ri, ni;
 
     // multi-instance object: search instance
@@ -153,14 +153,13 @@ static uint8_t prv_read(uint16_t instanceId, int * numDataP,
         }
     }
 
-    ni = 0;
-    ri = 0;
+    ni = ri = 0;
     do
     {
         result = prv_set_tlv((*dataArrayP) + ni, accCtrlOiP);
         if (result==COAP_404_NOT_FOUND) {
             ri++;
-            result = COAP_205_CONTENT;
+            if (*numDataP>1) result = COAP_205_CONTENT;
         }
         else if (ri > 0)    // copy new one by ri skipped ones in front
         {


### PR DESCRIPTION
This PR corrects TLV structure initialization for reading the Access Control object in the case, the ACL multiple instance resource does not contain any instances. The following resources when reading the whole object were lost. By the way, the old implementation lacks of a missing counter init potentially producing an core.