### PR TITLE
Bugfix: missing fractional part of floats in "text format".

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -244,7 +244,7 @@ size_t lwm2m_float64ToPlainText(double data,
         decPart = 1 + decPart;
     }
 
-    if (decPart >= 1 + FLT_EPSILON)
+    if (decPart <= 1 + FLT_EPSILON)
     {
         return lwm2m_int64ToPlainText(intPart, bufferP);
     }


### PR DESCRIPTION
When reading a float as single resource in text format (e.g. /1024/10/3), the fractional part is missing.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>