### PR TITLE
Introduce "separate response" transactions.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,7 @@
-SET(EXT_SOURCES ${CMAKE_CURRENT_LIST_DIR}/er-coap-13/er-coap-13.c)
+SET(EXT_SOURCES 
+    ${CMAKE_CURRENT_LIST_DIR}/er-coap-13/er-coap-13.c
+    ${CMAKE_CURRENT_LIST_DIR}/memtrace.c)
+
 SET(CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/liblwm2m.c
     ${CMAKE_CURRENT_LIST_DIR}/uri.c

--- a/core/internals.h
+++ b/core/internals.h
@@ -120,11 +120,12 @@ int prv_getRegisterPayload(lwm2m_context_t * contextP, uint8_t * buffer, size_t 
 int object_getServers(lwm2m_context_t * contextP);
 
 // defined in transaction.c
-lwm2m_transaction_t * transaction_new(coap_method_t method, char * altPath, lwm2m_uri_t * uriP, uint16_t mID, lwm2m_endpoint_type_t peerType, void * peerP);
+lwm2m_transaction_t * transaction_new(coap_message_type_t type, coap_method_t method, char * altPath, lwm2m_uri_t * uriP, uint16_t mID, uint8_t token_len, uint8_t* token, lwm2m_endpoint_type_t peerType, void * peerP);
+
 int transaction_send(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
 void transaction_free(lwm2m_transaction_t * transacP);
 void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
-int transaction_handle_response(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message);
+bool transaction_handle_response(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 
 // defined in management.c
 coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
@@ -144,11 +145,11 @@ void registration_update(lwm2m_context_t * contextP, time_t currentTime, time_t 
 coap_status_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, void * sessionH);
 
 // defined in observe.c
-void handle_observe_notify(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message);
+bool handle_observe_notify(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void observation_remove(lwm2m_client_t * clientP, lwm2m_observation_t * observationP);
 
 // defined in bootstrap.c
-void handle_bootstrap_ack(lwm2m_context_t * context, coap_packet_t * message, void * fromSessionH);
+void handle_bootstrap_response(lwm2m_context_t * context, coap_packet_t * message, void * fromSessionH);
 void bootstrap_failed(lwm2m_context_t * context);
 void reset_bootstrap_timer(lwm2m_context_t * context);
 void update_bootstrap_state(lwm2m_context_t * contextP, uint32_t currentTime, time_t* timeoutP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -63,9 +63,13 @@ extern "C" {
 #include <sys/time.h>
 
 #ifndef LWM2M_EMBEDDED_MODE
+#ifdef MEMORY_TRACE
+#include "memtrace.h"
+#else
 #define lwm2m_malloc malloc
 #define lwm2m_free free
 #define lwm2m_strdup strdup
+#endif
 #define lwm2m_strncmp strncmp
 #else
 void * lwm2m_malloc(size_t s);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -388,7 +388,6 @@ typedef struct _lwm2m_server_
     void *            sessionH;
     lwm2m_status_t    status;
     char *            location;
-    uint16_t          mid;
 } lwm2m_server_t;
 
 
@@ -471,6 +470,8 @@ struct _lwm2m_transaction_
     uint16_t              mID;   // matches lwm2m_list_t::id
     lwm2m_endpoint_type_t peerType;
     void *                peerP;
+    uint8_t               ack_received; // indicates, that the ACK was received
+    time_t                response_timeout; // timeout to wait for response, if token is used. When 0, use calculated acknowledge timeout.
     uint8_t  retrans_counter;
     time_t   retrans_time;
     char objStringID[LWM2M_STRING_ID_MAX_LEN];

--- a/core/management.c
+++ b/core/management.c
@@ -140,7 +140,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
 #endif
             if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
             {
-                result = object_create(contextP, uriP, (char*)message->payload, message->payload_len);
+                result = object_create(contextP, uriP, message->payload, message->payload_len);
                 if (result == COAP_201_CREATED)
                 {
                     //longest uri is /65535/65535 = 12 + 1 (null) chars
@@ -164,16 +164,16 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
             {
                 if (object_isInstanceNew(contextP, uriP->objectId, uriP->instanceId))
                 {
-                    result = object_create(contextP, uriP, (char*)message->payload, message->payload_len);
+                    result = object_create(contextP, uriP, message->payload, message->payload_len);
                 }
                 else
                 {
-                    result = object_write(contextP, uriP, (char*)message->payload, message->payload_len);
+                    result = object_write(contextP, uriP, message->payload, message->payload_len);
                 }
             }
             else
             {
-                result = object_execute(contextP, uriP, (char*)message->payload, message->payload_len);
+                result = object_execute(contextP, uriP, message->payload, message->payload_len);
             }
         }
         break;
@@ -185,7 +185,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
 #ifdef LWM2M_BOOTSTRAP
                 if (contextP->bsState == BOOTSTRAP_PENDING && object_isInstanceNew(contextP, uriP->objectId, uriP->instanceId))
                 {
-                    result = object_create(contextP, uriP, (char*)message->payload, message->payload_len);
+                    result = object_create(contextP, uriP, message->payload, message->payload_len);
                     if (COAP_201_CREATED == result)
                     {
                         result = COAP_204_CHANGED;
@@ -194,7 +194,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                 else
 #endif
                 {
-                    result = object_write(contextP, uriP, (char*)message->payload, message->payload_len);
+                    result = object_write(contextP, uriP, message->payload, message->payload_len);
                 }
             }
             else

--- a/core/management.c
+++ b/core/management.c
@@ -336,7 +336,7 @@ static int prv_make_operation(lwm2m_context_t * contextP,
     clientP = (lwm2m_client_t *)lwm2m_list_find((lwm2m_list_t *)contextP->clientList, clientID);
     if (clientP == NULL) return COAP_404_NOT_FOUND;
 
-    transaction = transaction_new(method, clientP->altPath, uriP, contextP->nextMID++, ENDPOINT_CLIENT, (void *)clientP);
+    transaction = transaction_new(COAP_TYPE_CON, method, clientP->altPath, uriP, contextP->nextMID++, 4, NULL, ENDPOINT_CLIENT, (void *)clientP);
     if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
 
     if (buffer != NULL)

--- a/core/memtrace.c
+++ b/core/memtrace.c
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innvoations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+
+#include "internals.h"
+
+#ifdef MEMORY_TRACE
+
+#undef malloc
+#undef free
+#undef strdup
+
+typedef struct MemoryEntry {
+    struct MemoryEntry* next;
+    const char *file;
+    const char *function;
+    int         lineno;
+    size_t      size;
+    int         count;
+    uint32_t    data[1];
+} memory_entry_t;
+
+static memory_entry_t prv_memory_malloc_list = { .next = NULL, .file = "head", .function="malloc", .lineno = 0, .size = 0, .count = 0};
+static memory_entry_t prv_memory_free_list = { .next = NULL, .file = "head", .function="free", .lineno = 0, .size = 0, .count = 0};
+
+static memory_entry_t* prv_memory_find_previous(memory_entry_t* list, void* memory)
+{
+    while (NULL != list->next)
+    {
+        if (list->next->data == memory)
+        {
+            return list;
+        }
+        list = list->next;
+    }
+    return NULL;
+}
+
+static void prv_trace_add_free_list(memory_entry_t* remove, const char* file, const char* function, int lineno)
+{
+    remove->next = prv_memory_free_list.next;
+    prv_memory_free_list.next = remove;
+    remove->file = file;
+    remove->function = function;
+    remove->lineno = lineno;
+
+    if (prv_memory_free_list.count < 200)
+    {
+        ++prv_memory_free_list.count;
+    }
+    else if (NULL != remove->next)
+    {
+        while (NULL != remove->next->next)
+        {
+            remove = remove->next;
+        }
+        free(remove->next);
+        remove->next = NULL;
+    }
+}
+
+char* trace_strdup(const char* str, const char* file, const char* function, int lineno)
+{
+    size_t length = strlen(str);
+    char* result = trace_malloc(length +1, file, function, lineno);
+    memcpy(result, str, length);
+    result[length] = 0;
+    return result;
+}
+
+void* trace_malloc(size_t size, const char* file, const char* function, int lineno)
+{
+    static int counter = 0;
+    memory_entry_t* entry = malloc(size + sizeof(memory_entry_t));
+    entry->next = prv_memory_malloc_list.next;
+    prv_memory_malloc_list.next = entry;
+    ++prv_memory_malloc_list.count;
+    prv_memory_malloc_list.size += size;
+    prv_memory_malloc_list.lineno = 1;
+
+    entry->file = file;
+    entry->function = function;
+    entry->lineno = lineno;
+    entry->size = size;
+    entry->count = ++counter;
+
+    return &(entry->data);
+}
+
+void trace_free(void* mem, const char* file, const char* function, int lineno)
+{
+    if (NULL != mem)
+    {
+        memory_entry_t* entry = prv_memory_find_previous(&prv_memory_malloc_list, mem);
+        if (NULL != entry)
+        {
+            memory_entry_t* remove = entry->next;
+            entry->next = remove->next;
+            --prv_memory_malloc_list.count;
+            prv_memory_malloc_list.size -= remove->size;
+            prv_memory_malloc_list.lineno = 1;
+            prv_trace_add_free_list(remove, file, function, lineno);
+        }
+        else
+        {
+            fprintf(stderr, "memory: free error (no malloc) %s, %d, %s\n", file, lineno, function);
+            memory_entry_t* entry = prv_memory_find_previous(&prv_memory_free_list, mem);
+            if (NULL != entry)
+            {
+                entry = entry->next;
+                fprintf(stderr, "memory: already frees at %s, %d, %s\n", entry->file, entry->lineno, entry->function);
+            }
+        }
+    }
+}
+
+void trace_print(int loops, int level)
+{
+    static int counter = 0;
+    if (0 == loops)
+    {
+        counter = 0;
+    }
+    else
+    {
+        ++counter;
+    }
+    if (0 == loops || (((counter % loops) == 0) && prv_memory_malloc_list.lineno))
+    {
+        prv_memory_malloc_list.lineno = 0;
+        if (1 == level)
+        {
+            size_t total = 0;
+            int entries = 0;
+            memory_entry_t* entry = prv_memory_malloc_list.next;
+            while (NULL != entry)
+            {
+                fprintf(stdout,"memory: #%d, %lu bytes, %s, %d, %s\n", entry->count, (unsigned long) entry->size, entry->file, entry->lineno, entry->function);
+                ++entries;
+                total += entry->size;
+                entry = entry->next;
+            }
+            if (entries != prv_memory_malloc_list.count)
+            {
+                fprintf(stderr,"memory: error %d entries != %d\n", prv_memory_malloc_list.count, entries);
+            }
+            if (total != prv_memory_malloc_list.size)
+            {
+                fprintf(stdout,"memory: error %lu total bytes != %lu\n", (unsigned long) prv_memory_malloc_list.size, (unsigned long) total);
+            }
+        }
+        fprintf(stdout,"memory: %d entries, %lu total bytes\n", prv_memory_malloc_list.count, (unsigned long) prv_memory_malloc_list.size);
+    }
+}
+
+void trace_status(int* blocks, size_t* size)
+{
+    if (NULL != blocks)
+    {
+        *blocks = prv_memory_malloc_list.count;
+    }
+
+    if (NULL != size)
+    {
+        *size = prv_memory_malloc_list.size;
+    }
+}
+
+#endif

--- a/core/memtrace.h
+++ b/core/memtrace.h
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innvoations GmbH and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+#ifndef MEMTRACE_H_
+#define MEMTRACE_H_
+
+#ifdef MEMORY_TRACE
+#include <string.h>
+#include <stdlib.h>
+
+char* trace_strdup(const char* str, const char* file, const char* function, int lineno);
+void* trace_malloc(size_t size, const char* file, const char* function, int lineno);
+void trace_free(void* mem, const char* file, const char* function, int lineno);
+void trace_print(int loops, int level);
+void trace_status(int* blocks, size_t* size);
+
+#define lwm2m_strdup(S) trace_strdup(S, __FILE__, __FUNCTION__, __LINE__)
+#define lwm2m_malloc(S) trace_malloc(S, __FILE__, __FUNCTION__, __LINE__)
+#define lwm2m_free(M) trace_free(M, __FILE__, __FUNCTION__, __LINE__)
+#define strdup(S) trace_strdup(S, __FILE__, __FUNCTION__, __LINE__)
+#define malloc(S) trace_malloc(S, __FILE__, __FUNCTION__, __LINE__)
+#define free(M) trace_free(M, __FILE__, __FUNCTION__, __LINE__)
+
+#endif
+
+#endif /* MEMTRACE_H_ */

--- a/core/registration.c
+++ b/core/registration.c
@@ -125,48 +125,33 @@ static int prv_getRegistrationQuery(lwm2m_context_t * contextP, lwm2m_server_t *
 static void prv_handleRegistrationReply(lwm2m_transaction_t * transacP,
                                         void * message)
 {
-    lwm2m_server_t * targetP;
     coap_packet_t * packet = (coap_packet_t *)message;
-
-    targetP = (lwm2m_server_t *)(transacP->peerP);
-    time_t tv_sec;
+    lwm2m_server_t * targetP = (lwm2m_server_t *)(transacP->peerP);
 
     switch(targetP->status)
     {
     case STATE_REG_PENDING:
     {
-        if (packet == NULL)
+        time_t tv_sec = lwm2m_gettime();
+        if (tv_sec >= 0)
+        {
+            targetP->registration = tv_sec;
+        }
+        if (packet != NULL && packet->code == CREATED_2_01)
+        {
+            targetP->status = STATE_REGISTERED;
+            if (NULL != targetP->location)
+            {
+                lwm2m_free(targetP->location);
+            }
+            targetP->location = coap_get_multi_option_as_string(packet->location_path);
+
+            LOG("    => REGISTERED\r\n");
+        }
+        else
         {
             targetP->status = STATE_REG_FAILED;
-            targetP->mid = 0;
             LOG("    => Registration FAILED\r\n");
-        }
-        else if (packet->mid == targetP->mid
-              && packet->type == COAP_TYPE_ACK
-              && packet->location_path != NULL)
-        {
-            if (packet->code == CREATED_2_01)
-            {
-                targetP->status = STATE_REGISTERED;
-                if (NULL != targetP->location)
-                {
-                    lwm2m_free(targetP->location);
-                }
-                targetP->location = coap_get_multi_option_as_string(packet->location_path);
-
-                tv_sec = lwm2m_gettime();
-                if (tv_sec >= 0)
-                {
-                    targetP->registration = tv_sec;
-                }
-                LOG("    => REGISTERED\r\n");
-            }
-            else if (packet->code == BAD_REQUEST_4_00)
-            {
-                targetP->status = STATE_REG_FAILED;
-                targetP->mid = 0;
-                LOG("    => Registration FAILED\r\n");
-            }
         }
     }
     break;
@@ -211,9 +196,9 @@ static void prv_register(lwm2m_context_t * contextP,
         server->sessionH = contextP->connectCallback(server->secObjInstID, contextP->userData);
     }
 
-    if (server->sessionH != NULL)
+    if (NULL != server->sessionH)
     {
-        transaction = transaction_new(COAP_POST, NULL, NULL, contextP->nextMID++, ENDPOINT_SERVER, (void *)server);
+        transaction = transaction_new(COAP_TYPE_CON, COAP_POST, NULL, NULL, contextP->nextMID++, 4, NULL, ENDPOINT_SERVER, (void *)server);
         if (transaction == NULL) return;
 
         coap_set_header_uri_path(transaction->message, "/"URI_REGISTRATION_SEGMENT);
@@ -227,7 +212,6 @@ static void prv_register(lwm2m_context_t * contextP,
         if (transaction_send(contextP, transaction) == 0)
         {
             server->status = STATE_REG_PENDING;
-            server->mid = transaction->mID;
         }
     }
 }
@@ -235,41 +219,27 @@ static void prv_register(lwm2m_context_t * contextP,
 static void prv_handleRegistrationUpdateReply(lwm2m_transaction_t * transacP,
                                               void * message)
 {
-    lwm2m_server_t * targetP;
     coap_packet_t * packet = (coap_packet_t *)message;
-    time_t tv_sec;
-
-    targetP = (lwm2m_server_t *)(transacP->peerP);
+    lwm2m_server_t * targetP = (lwm2m_server_t *)(transacP->peerP);
 
     switch(targetP->status)
     {
     case STATE_REG_UPDATE_PENDING:
     {
-        if (packet == NULL)
+        time_t tv_sec = lwm2m_gettime();
+        if (tv_sec >= 0)
+        {
+            targetP->registration = tv_sec;
+        }
+        if (packet != NULL && packet->code == CHANGED_2_04)
+        {
+            targetP->status = STATE_REGISTERED;
+            LOG("    => REGISTERED\r\n");
+        }
+        else
         {
             targetP->status = STATE_REG_FAILED;
-            targetP->mid = 0;
             LOG("    => Registration update FAILED\r\n");
-        }
-        else if (packet->mid == targetP->mid
-              && packet->type == COAP_TYPE_ACK)
-        {
-            if (packet->code == CHANGED_2_04)
-            {
-                tv_sec = lwm2m_gettime();
-                if (tv_sec >= 0)
-                {
-                    targetP->registration = tv_sec;
-                }
-                targetP->status = STATE_REGISTERED;
-                LOG("    => REGISTERED\r\n");
-            }
-            else
-            {
-                targetP->status = STATE_REG_FAILED;
-                targetP->mid = 0;
-                LOG("    => Registration update FAILED\r\n");
-            }
         }
     }
     break;
@@ -283,7 +253,7 @@ static int prv_update_registration(lwm2m_context_t * contextP,
 {
     lwm2m_transaction_t * transaction;
 
-    transaction = transaction_new(COAP_PUT, NULL, NULL, contextP->nextMID++, ENDPOINT_SERVER, (void *)server);
+    transaction = transaction_new(COAP_TYPE_CON, COAP_PUT, NULL, NULL, contextP->nextMID++, 4, NULL, ENDPOINT_SERVER, (void *)server);
     if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
 
     coap_set_header_uri_path(transaction->message, server->location);
@@ -296,7 +266,6 @@ static int prv_update_registration(lwm2m_context_t * contextP,
     if (transaction_send(contextP, transaction) == 0)
     {
         server->status = STATE_REG_UPDATE_PENDING;
-        server->mid = transaction->mID;
     }
 
     return 0;
@@ -340,6 +309,7 @@ void registration_update(lwm2m_context_t * contextP,
                          time_t * timeoutP)
 {
     time_t nextUpdate;
+    time_t interval;
     lwm2m_server_t * targetP = contextP->serverList;
 #ifdef LWM2M_BOOTSTRAP
     bool allServerFailed = true;
@@ -369,20 +339,16 @@ void registration_update(lwm2m_context_t * contextP,
                 {
                     nextUpdate -= 15; // update 15s earlier to have a chance to resend
                 }
-                if (targetP->registration + nextUpdate <= currentTime)
+
+                interval = targetP->registration + nextUpdate - currentTime;
+                if (0 >= interval)
                 {
                     LOG("Updating registration...\r\n");
                     prv_update_registration(contextP, targetP);
                 }
-                else
+                else if (interval < *timeoutP)
                 {
-                    time_t interval;
-
-                    interval = targetP->registration + nextUpdate - currentTime;
-                    if (interval < *timeoutP)
-                    {
-                        *timeoutP = interval;
-                    }
+                    *timeoutP = interval;
                 }
                 break;
 
@@ -403,20 +369,15 @@ void registration_update(lwm2m_context_t * contextP,
                 if (serverRegistered || NULL == contextP->bootstrapServerList)
                 {
 #endif
-                    if (targetP->registration + targetP->lifetime <= currentTime)
+                    interval = targetP->registration + targetP->lifetime - currentTime;
+                    if (0 >= interval)
                     {
                         LOG("Retry registration...\r\n");
                         prv_register(contextP, targetP);
                     }
-                    else
+                    else if (interval < *timeoutP)
                     {
-                        time_t interval;
-
-                        interval = targetP->registration + targetP->lifetime - currentTime;
-                        if (interval < *timeoutP)
-                        {
-                            *timeoutP = interval;
-                        }
+                        *timeoutP = interval;
                     }
 #ifdef LWM2M_BOOTSTRAP
                 }
@@ -443,7 +404,6 @@ static void prv_handleDeregistrationReply(lwm2m_transaction_t * transacP,
                                         void * message)
 {
     lwm2m_server_t * targetP;
-    coap_packet_t * packet = (coap_packet_t *)message;
 
     targetP = (lwm2m_server_t *)(transacP->peerP);
     if (NULL != targetP)
@@ -451,24 +411,7 @@ static void prv_handleDeregistrationReply(lwm2m_transaction_t * transacP,
         switch(targetP->status)
         {
         case STATE_DEREG_PENDING:
-            if (packet == NULL)
-            {
-                targetP->status = STATE_DEREGISTERED;
-                targetP->mid = 0;
-            }
-            else if (packet->mid == targetP->mid
-                  && packet->type == COAP_TYPE_ACK)
-            {
-                if (packet->code == DELETED_2_02)
-                {
-                    targetP->status = STATE_DEREGISTERED;
-                }
-                else if (packet->code == BAD_REQUEST_4_00)
-                {
-                    targetP->status = STATE_DEREGISTERED;
-                    targetP->mid = 0;
-                }
-            }
+            targetP->status = STATE_DEREGISTERED;
             break;
         default:
             break;
@@ -489,7 +432,7 @@ void registration_deregister(lwm2m_context_t * contextP,
         }
 
     lwm2m_transaction_t * transaction;
-    transaction = transaction_new(COAP_DELETE, NULL, NULL, contextP->nextMID++, ENDPOINT_SERVER, (void *)serverP);
+    transaction = transaction_new(COAP_TYPE_CON, COAP_DELETE, NULL, NULL, contextP->nextMID++, 4, NULL, ENDPOINT_SERVER, (void *)serverP);
     if (transaction == NULL) return;
 
     coap_set_header_uri_path(transaction->message, serverP->location);
@@ -501,7 +444,6 @@ void registration_deregister(lwm2m_context_t * contextP,
     if (transaction_send(contextP, transaction) == 0)
     {
         serverP->status = STATE_DEREG_PENDING;
-        serverP->mid = transaction->mID;
     }
 }
 #endif
@@ -825,12 +767,19 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
                                           coap_packet_t * response)
 {
     coap_status_t result;
+    int code;
     time_t tv_sec;
 
     tv_sec = lwm2m_gettime();
     if (tv_sec < 0) return COAP_500_INTERNAL_SERVER_ERROR;
 
-    switch(message->code)
+    code = message->code;
+    if (COAP_POST == code && ((uriP->flag & LWM2M_URI_MASK_ID) == LWM2M_URI_FLAG_OBJECT_ID))
+    {
+        /* process update also as "POST" as defined in TS since 20150212 */
+        code = COAP_PUT;
+    }
+    switch(code)
     {
     case COAP_POST:
     {

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -15,6 +15,7 @@
  *    Simon Bernard - Please refer to git log
  *    Toby Jaffey - Please refer to git log
  *    Pascal Rieux - Please refer to git log
+ *    Bosch Software Innovations GmbH - Please refer to git log
  *
  *******************************************************************************/
 
@@ -80,6 +81,28 @@ Contains code snippets which are:
 
 */
 
+/************************************************************************
+ *  Function for communications transactions.
+ *
+ *  Basic specification: rfc7252
+ *
+ *  Transaction implements processing of piggybacked and separate response communication
+ *  dialogs specified in section 2.2 of the above specification.
+ *  The caller registers a callback function, which is called, when either the result is
+ *  received or a timeout occurs.
+ *
+ *  Supported dialogs:
+ *  Requests (GET - DELETE):
+ *  - CON with mid, without token => regular finished with corresponding ACK.MID
+ *  - CON with mid, with token => regular finished with corresponding ACK.MID and response containing
+ *                  the token. Supports both versions, with piggybacked ACK and separate ACK/response.
+ *                  Though the ACK.MID may be lost in the separate version, a matching response may
+ *                  finish the transaction even without the ACK.MID.
+ *  - NON without token => no transaction, no result expected!
+ *  - NON with token => regular finished with response containing the token.
+ *  Responses (COAP_201_CREATED - ?):
+ *  - CON with mid => regular finished with corresponding ACK.MID
+ */
 
 #include "internals.h"
 
@@ -104,25 +127,69 @@ static int prv_check_addr(void * leftSessionH,
     return 1;
 }
 
-lwm2m_transaction_t * transaction_new(coap_method_t method,
+static int prv_transaction_check_finished(lwm2m_transaction_t * transacP,
+        coap_packet_t * receivedMessage)
+{
+    int len;
+    const uint8_t* token;
+    coap_packet_t * transactionMessage = transacP->message;
+
+    if (COAP_DELETE < transactionMessage->code)
+    {
+        // response
+        return transacP->ack_received ? 1 : 0;
+    }
+    if (!IS_OPTION(transactionMessage, COAP_OPTION_TOKEN))
+    {
+        // request without token
+        return transacP->ack_received ? 1 : 0;
+    }
+
+    len = coap_get_header_token(receivedMessage, &token);
+    if (transactionMessage->token_len == len)
+    {
+        if (memcmp(transactionMessage->token, token, len)==0) return 1;
+    }
+
+    return 0;
+}
+
+lwm2m_transaction_t * transaction_new(coap_message_type_t type,
+                                      coap_method_t method,
                                       char * altPath,
                                       lwm2m_uri_t * uriP,
                                       uint16_t mID,
+                                      uint8_t token_len,
+                                      uint8_t* token,
                                       lwm2m_endpoint_type_t peerType,
                                       void * peerP)
 {
     lwm2m_transaction_t * transacP;
     int result;
 
+    // no transactions for ack or rst
+    if (COAP_TYPE_ACK == type || COAP_TYPE_RST == type) return NULL;
+
+    // no transactions without peer
+    if (NULL == peerP) return NULL;
+
+    if (COAP_TYPE_NON == type)
+    {
+        // no transactions for NON responses
+        if (COAP_DELETE < method) return NULL;
+        // no transactions for NON request without token
+        if (0 == token_len) return NULL;
+    }
+
     transacP = (lwm2m_transaction_t *)lwm2m_malloc(sizeof(lwm2m_transaction_t));
 
-    if (transacP == NULL) return NULL;
+    if (NULL == transacP) return NULL;
     memset(transacP, 0, sizeof(lwm2m_transaction_t));
 
     transacP->message = lwm2m_malloc(sizeof(coap_packet_t));
-    if (transacP->message == NULL) goto error;
+    if (NULL == transacP->message) goto error;
 
-    coap_init_message(transacP->message, COAP_TYPE_CON, method, mID);
+    coap_init_message(transacP->message, type, method, mID);
 
     transacP->mID = mID;
     transacP->peerType = peerType;
@@ -133,7 +200,7 @@ lwm2m_transaction_t * transaction_new(coap_method_t method,
         // TODO: Support multi-segment alternative path
         coap_set_header_uri_path_segment(transacP->message, altPath + 1);
     }
-    if (uriP != NULL)
+    if (NULL != uriP)
     {
         result = snprintf(transacP->objStringID, LWM2M_STRING_ID_MAX_LEN, "%hu", uriP->objectId);
         if (result < 0 || result > LWM2M_STRING_ID_MAX_LEN) goto error;
@@ -160,6 +227,28 @@ lwm2m_transaction_t * transaction_new(coap_method_t method,
             coap_set_header_uri_path_segment(transacP->message, transacP->resourceStringID);
         }
     }
+    if (0 < token_len)
+    {
+        if (NULL != token)
+        {
+            coap_set_header_token(transacP->message, token, token_len);
+        }
+        else {
+            // generate a token
+            uint8_t temp_token[COAP_TOKEN_LEN];
+            time_t tv_sec = lwm2m_gettime();
+
+            // initialize first 6 bytes, leave the last 2 random
+            temp_token[0] = mID;
+            temp_token[1] = mID >> 8;
+            temp_token[2] = tv_sec;
+            temp_token[3] = tv_sec >> 8;
+            temp_token[4] = tv_sec >> 16;
+            temp_token[5] = tv_sec >> 24;
+            // use just the provided amount of bytes
+            coap_set_header_token(transacP->message, temp_token, token_len);
+        }
+    }
 
     return transacP;
 
@@ -178,38 +267,22 @@ void transaction_free(lwm2m_transaction_t * transacP)
 void transaction_remove(lwm2m_context_t * contextP,
                         lwm2m_transaction_t * transacP)
 {
-    if (NULL != contextP->transactionList)
-    {
-        if (transacP == contextP->transactionList)
-        {
-            contextP->transactionList = contextP->transactionList->next;
-        }
-        else
-        {
-            lwm2m_transaction_t *previous = contextP->transactionList;
-            while (previous->next && previous->next != transacP)
-            {
-                previous = previous->next;
-            }
-            if (NULL != previous->next)
-            {
-                previous->next = previous->next->next;
-            }
-        }
-    }
+    contextP->transactionList = (lwm2m_transaction_t *) LWM2M_LIST_RM(contextP->transactionList, transacP->mID, NULL);
     transaction_free(transacP);
 }
 
-
-int transaction_handle_response(lwm2m_context_t * contextP,
+bool transaction_handle_response(lwm2m_context_t * contextP,
                                  void * fromSessionH,
-                                 coap_packet_t * message)
+                                 coap_packet_t * message,
+                                 coap_packet_t * response)
 {
+    bool found = false;
+    bool reset = false;
     lwm2m_transaction_t * transacP;
 
     transacP = contextP->transactionList;
 
-    while (transacP != NULL)
+    while (NULL != transacP)
     {
         void * targetSessionH;
 
@@ -237,32 +310,76 @@ int transaction_handle_response(lwm2m_context_t * contextP,
 
         if (prv_check_addr(fromSessionH, targetSessionH))
         {
-            if (transacP->mID == message->mid)
+            if (!transacP->ack_received)
+            {
+                if ((COAP_TYPE_ACK == message->type) || (COAP_TYPE_RST == message->type))
+                {
+                    if (transacP->mID == message->mid)
+	                {
+    	                found = true;
+        	            transacP->ack_received = true;
+            	        reset = COAP_TYPE_RST == message->type;
+            	    }
+                }
+            }
+
+            if (reset || prv_transaction_check_finished(transacP, message))
             {
                 // HACK: If a message is sent from the monitor callback,
                 // it will arrive before the registration ACK.
                 // So we resend transaction that were denied for authentication reason.
-                if (message->code != COAP_401_UNAUTHORIZED || transacP->retrans_counter >= COAP_MAX_RETRANSMIT)
+                if (!reset)
                 {
-                    if (transacP->callback != NULL)
+                    if (COAP_TYPE_CON == message->type && NULL != response)
                     {
-                        transacP->callback(transacP, message);
+                        coap_init_message(response, COAP_TYPE_ACK, 0, message->mid);
+                        message_send(contextP, response, fromSessionH);
                     }
-                    transaction_remove(contextP, transacP);
+                
+	                if ((COAP_401_UNAUTHORIZED == message->code) && (COAP_MAX_RETRANSMIT > transacP->retrans_counter))
+    	            {
+        	            transacP->ack_received = false;
+            	        transacP->retrans_time += COAP_RESPONSE_TIMEOUT;
+                	    return true;
+                	}
+				}       
+                if (transacP->callback != NULL)
+                {
+                    transacP->callback(transacP, message);
                 }
-                // we found our guy, exit
-                return 1;
+                transaction_remove(contextP, transacP);
+                return true;
+            }
+            // if we found our guy, exit
+            if (found)
+            {
+                time_t tv_sec = lwm2m_gettime();
+                if (0 <= tv_sec)
+                {
+                    transacP->retrans_time = tv_sec;
+                }
+                if (transacP->response_timeout)
+                {
+                    transacP->retrans_time += transacP->response_timeout;
+                }
+                else
+                {
+                    transacP->retrans_time += COAP_RESPONSE_TIMEOUT * transacP->retrans_counter;
+                }
+                return true;
             }
         }
 
         transacP = transacP->next;
     }
-    return 0;
+    return false;
 }
 
 int transaction_send(lwm2m_context_t * contextP,
                      lwm2m_transaction_t * transacP)
 {
+    bool maxRetriesReached = false;
+
     if (transacP->buffer == NULL)
     {
         uint8_t tempBuffer[LWM2M_MAX_PACKET_SIZE];
@@ -278,48 +395,58 @@ int transaction_send(lwm2m_context_t * contextP,
         transacP->buffer_len = length;
     }
 
-    switch(transacP->peerType)
+    if (!transacP->ack_received)
     {
-    case ENDPOINT_CLIENT:
-        contextP->bufferSendCallback(((lwm2m_client_t*)transacP->peerP)->sessionH,
-                                     transacP->buffer, transacP->buffer_len, contextP->userData);
-        break;
+        long unsigned timeout = COAP_RESPONSE_TIMEOUT;
 
-    case ENDPOINT_SERVER:
-        if (NULL != transacP->peerP) 
+        if (0 == transacP->retrans_counter)
         {
-            contextP->bufferSendCallback(((lwm2m_server_t*)transacP->peerP)->sessionH,
-                    transacP->buffer, transacP->buffer_len, contextP->userData);
-        }
-        break;
-
-    default:
-        return 0;
-    }
-
-    if (transacP->retrans_counter == 0)
-    {
-        time_t tv_sec;
-
-        tv_sec = lwm2m_gettime();
-        if (tv_sec >= 0)
-        {
-            transacP->retrans_time = tv_sec;
-            transacP->retrans_counter = 1;
+            time_t tv_sec = lwm2m_gettime();
+            if (0 <= tv_sec)
+            {
+                transacP->retrans_time = tv_sec;
+                transacP->retrans_counter = 1;
+            }
+            else
+            {
+                maxRetriesReached = true;
+            }
         }
         else
         {
-            // crude error handling
-            transacP->retrans_counter = COAP_MAX_RETRANSMIT;
+            timeout = COAP_RESPONSE_TIMEOUT * transacP->retrans_counter;
+        }
+
+        if (COAP_MAX_RETRANSMIT >= transacP->retrans_counter)
+        {
+            switch(transacP->peerType)
+            {
+            case ENDPOINT_CLIENT:
+                contextP->bufferSendCallback(((lwm2m_client_t*)transacP->peerP)->sessionH,
+                                             transacP->buffer, transacP->buffer_len, contextP->userData);
+                break;
+
+            case ENDPOINT_SERVER:
+                if (NULL != transacP->peerP)
+                {
+                    contextP->bufferSendCallback(((lwm2m_server_t*)transacP->peerP)->sessionH,
+                            transacP->buffer, transacP->buffer_len, contextP->userData);
+                }
+                break;
+
+            default:
+                return 0;
+            }
+            transacP->retrans_time += timeout;
+            ++transacP->retrans_counter;
+        }
+        else
+        {
+            maxRetriesReached = true;
         }
     }
 
-    if (transacP->retrans_counter < COAP_MAX_RETRANSMIT)
-    {
-        transacP->retrans_time += COAP_RESPONSE_TIMEOUT * transacP->retrans_counter;
-        transacP->retrans_counter++;
-    }
-    else
+    if (transacP->ack_received || maxRetriesReached)
     {
         if (transacP->callback)
         {

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -412,8 +412,6 @@ static void prv_object_dump(char * buffer,
     char * end = NULL;
     int result;
     lwm2m_object_t * objectP;
-    uint16_t i;
-
 
     end = get_end_of_arg(buffer);
     if (end[0] == 0) goto syntax_error;

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -1167,7 +1167,8 @@ int main(int argc, char *argv[])
     /*
      * Finally when the loop is left smoothly - asked by user in the command line interface - we unregister our client from it
      */
-    if (g_quit == 1) {
+    if (g_quit == 1)
+    {
 #ifdef LWM2M_BOOTSTRAP
         close_backup_object();
 #endif
@@ -1175,6 +1176,13 @@ int main(int argc, char *argv[])
     }
     close(data.sock);
     connection_free(data.connList);
+
+#ifdef MEMORY_TRACE
+    if (g_quit == 1)
+    {
+        trace_print(0, 1);
+    }
+#endif
 
     return 0;
 }

--- a/tests/client/object_security.c
+++ b/tests/client/object_security.c
@@ -357,6 +357,10 @@ static uint8_t prv_security_delete(uint16_t id,
 
     objectP->instanceList = lwm2m_list_remove(objectP->instanceList, id, (lwm2m_list_t **)&targetP);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
+    if (NULL != targetP->uri)
+    {
+        lwm2m_free(targetP->uri);
+    }
 
     lwm2m_free(targetP);
 

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -595,7 +595,7 @@ static void prv_quit(char * buffer,
 
 void handle_sigint(int signum)
 {
-    prv_quit(NULL, NULL);
+    g_quit = 2;
 }
 
 void print_usage(void)
@@ -784,6 +784,13 @@ int main(int argc, char *argv[])
     lwm2m_close(lwm2mH);
     close(sock);
     connection_free(connList);
+
+#ifdef MEMORY_TRACE
+    if (g_quit == 1)
+    {
+        trace_print(0, 1);
+    }
+#endif
 
     return 0;
 }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required (VERSION 2.8.3)
+
+project (lwm2munittests)
+  
+SET(LIBLWM2M_DIR ${PROJECT_SOURCE_DIR}/../../core)
+
+add_definitions(-DLWM2M_CLIENT_MODE -DMEMORY_TRACE -DLWM2M_LITTLE_ENDIAN)
+
+include_directories (${LIBLWM2M_DIR})
+
+add_subdirectory(${LIBLWM2M_DIR} ${CMAKE_CURRENT_BINARY_DIR}/core)
+
+SET(SOURCES
+    unittests.c
+    tlvtests.c
+    uritests.c)
+
+add_executable(lwm2munittests ${SOURCES} ${CORE_SOURCES})
+
+target_link_libraries(lwm2munittests cunit)

--- a/tests/unittests/memtest.h
+++ b/tests/unittests/memtest.h
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innovations GmbH, Germany.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+
+#ifndef MEMTEST_H_
+#define MEMTEST_H_
+
+#ifdef MEMORY_TRACE
+#include "memtrace.h"
+static int blocks_before = 0;
+static size_t size_before = 0;
+static int blocks_after = 0;
+static size_t size_after = 0;
+#define MEMORY_TRACE_BEFORE trace_status(&blocks_before, &size_before)
+#define MEMORY_TRACE_AFTER(OP) { trace_status(&blocks_after, &size_after); CU_ASSERT(blocks_before OP blocks_after); CU_ASSERT(size_before OP size_after); }
+#define MEMORY_TRACE_AFTER_EQ { trace_status(&blocks_after, &size_after); CU_ASSERT_EQUAL(blocks_before, blocks_after); CU_ASSERT_EQUAL(size_before, size_after); }
+#else
+#define MEMORY_TRACE_BEFORE
+#define MEMORY_TRACE_AFTER(OP)
+#define MEMORY_TRACE_AFTER_EQ
+#endif
+
+#endif /* MEMTEST_H_ */

--- a/tests/unittests/tests.h
+++ b/tests/unittests/tests.h
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innovations GmbH, Germany.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+
+#ifndef TESTS_H_
+#define TESTS_H_
+
+#include "CUnit/CUError.h"
+
+struct TestTable {
+    const char* name;
+    CU_TestFunc function;
+};
+
+CU_ErrorCode add_tests(CU_pSuite pSuite, struct TestTable* testTable);
+CU_ErrorCode create_uri_suit();
+CU_ErrorCode create_tlv_suit();
+CU_ErrorCode create_object_read_suit();
+
+#endif /* TESTS_H_ */

--- a/tests/unittests/tlvtests.c
+++ b/tests/unittests/tlvtests.c
@@ -1,0 +1,584 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innovations GmbH, Germany.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+
+#include "tests.h"
+#include "CUnit/Basic.h"
+#include "liblwm2m.h"
+#include "memtest.h"
+
+static void fill(uint8_t *data, int size) {
+    int index;
+    for (index = 0; index < size; ++index) {
+        data[index] = index;
+    }
+}
+
+static void test_tlv_new(void)
+{
+   MEMORY_TRACE_BEFORE;
+   lwm2m_tlv_t *tlvP =  lwm2m_tlv_new(10);
+   CU_ASSERT_PTR_NOT_NULL(tlvP);
+   MEMORY_TRACE_AFTER(<);
+}
+
+static void test_tlv_free(void)
+{
+   MEMORY_TRACE_BEFORE;
+   lwm2m_tlv_t *tlvP =  lwm2m_tlv_new(10);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP);
+   lwm2m_tlv_free(10, tlvP);
+   MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_opaqueToTLV()
+{
+    MEMORY_TRACE_BEFORE;
+    uint8_t data[0x200];
+    uint8_t buffer[1024];
+    int result;
+
+    fill(data, sizeof(data));
+
+    result = lwm2m_opaqueToTLV(LWM2M_TYPE_RESOURCE, data, 3, 55, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 5);
+    CU_ASSERT_EQUAL(buffer[0], 0xC3);
+    CU_ASSERT_EQUAL(buffer[1], 55);
+    CU_ASSERT(0 == memcmp(data, &buffer[2], 3));
+
+    result = lwm2m_opaqueToTLV(LWM2M_TYPE_OBJECT_INSTANCE, data, 9, 0x0203, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 13);
+    CU_ASSERT_EQUAL(buffer[0], 0x28);
+    CU_ASSERT_EQUAL(buffer[1], 0x02);
+    CU_ASSERT_EQUAL(buffer[2], 0x03);
+    CU_ASSERT_EQUAL(buffer[3], 9);
+    CU_ASSERT(0 == memcmp(data, &buffer[4], 9));
+
+    result = lwm2m_opaqueToTLV(LWM2M_TYPE_MULTIPLE_RESOURCE, data, 0x190, 33, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 0x194);
+    CU_ASSERT_EQUAL(buffer[0], 0x90);
+    CU_ASSERT_EQUAL(buffer[1], 33);
+    CU_ASSERT_EQUAL(buffer[2], 0x1);
+    CU_ASSERT_EQUAL(buffer[3], 0x90);
+    CU_ASSERT(0 == memcmp(data, &buffer[4], 0x190));
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_boolToTLV()
+{
+    MEMORY_TRACE_BEFORE;
+    uint8_t buffer[16];
+    int result;
+
+    result = lwm2m_boolToTLV(LWM2M_TYPE_RESOURCE, 1, 55, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 3);
+    CU_ASSERT_EQUAL(buffer[0], 0xC1);
+    CU_ASSERT_EQUAL(buffer[1], 55);
+    CU_ASSERT_EQUAL(buffer[2], 1);
+
+    result = lwm2m_boolToTLV(LWM2M_TYPE_RESOURCE, 0, 0x2255, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 4);
+    CU_ASSERT_EQUAL(buffer[0], 0xE1);
+    CU_ASSERT_EQUAL(buffer[1], 0x22);
+    CU_ASSERT_EQUAL(buffer[2], 0x55);
+    CU_ASSERT_EQUAL(buffer[3], 0);
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_intToTLV()
+{
+    MEMORY_TRACE_BEFORE;
+    uint8_t buffer[32];
+    int result;
+
+    result = lwm2m_intToTLV(LWM2M_TYPE_RESOURCE, 1, 55, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 3);
+    CU_ASSERT_EQUAL(buffer[0], 0xC1);
+    CU_ASSERT_EQUAL(buffer[1], 55);
+    CU_ASSERT_EQUAL(buffer[2], 1);
+
+    result = lwm2m_intToTLV(LWM2M_TYPE_RESOURCE, 0x0102, 0x2255, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 5);
+    CU_ASSERT_EQUAL(buffer[0], 0xE2);
+    CU_ASSERT_EQUAL(buffer[1], 0x22);
+    CU_ASSERT_EQUAL(buffer[2], 0x55);
+    CU_ASSERT_EQUAL(buffer[3], 0x01);
+    CU_ASSERT_EQUAL(buffer[4], 0x02);
+
+    result = lwm2m_intToTLV(LWM2M_TYPE_RESOURCE, -0x010203, 0x2255, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 7);
+    CU_ASSERT_EQUAL(buffer[0], 0xE4);
+    CU_ASSERT_EQUAL(buffer[1], 0x22);
+    CU_ASSERT_EQUAL(buffer[2], 0x55);
+    CU_ASSERT_EQUAL(buffer[3], 0x80);
+    CU_ASSERT_EQUAL(buffer[4], 0x01);
+    CU_ASSERT_EQUAL(buffer[5], 0x02);
+    CU_ASSERT_EQUAL(buffer[6], 0x03);
+
+    result = lwm2m_intToTLV(LWM2M_TYPE_RESOURCE, -0x0102030405060708, 55, buffer, sizeof(buffer));
+    CU_ASSERT_EQUAL(result, 11);
+    CU_ASSERT_EQUAL(buffer[0], 0xC8);
+    CU_ASSERT_EQUAL(buffer[1], 55);
+    CU_ASSERT_EQUAL(buffer[2], 0x08);
+    CU_ASSERT_EQUAL(buffer[3], 0x81);
+    CU_ASSERT_EQUAL(buffer[4], 0x02);
+    CU_ASSERT_EQUAL(buffer[5], 0x03);
+    CU_ASSERT_EQUAL(buffer[6], 0x04);
+    CU_ASSERT_EQUAL(buffer[7], 0x05);
+    CU_ASSERT_EQUAL(buffer[8], 0x06);
+    CU_ASSERT_EQUAL(buffer[9], 0x07);
+    CU_ASSERT_EQUAL(buffer[10], 0x08);
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_decodeTLV()
+{
+    MEMORY_TRACE_BEFORE;
+    uint8_t data1[] = {0xC3, 55, 1, 2, 3};
+    uint8_t data2[] = {0x28, 2, 3, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    uint8_t data3[0x194] = {0x90, 33, 1, 0x90 };
+    lwm2m_tlv_type_t type;
+    uint16_t id = 0;
+    size_t   index = 0;
+    size_t   length = 0;
+    int result;
+
+
+    result = lwm2m_decodeTLV(data1, sizeof(data1) - 1, &type, &id, &index, &length);
+    CU_ASSERT_EQUAL(result, 0);
+
+    result = lwm2m_decodeTLV(data1, sizeof(data1), &type, &id, &index, &length);
+    CU_ASSERT_EQUAL(result, 5);
+    CU_ASSERT_EQUAL(type, LWM2M_TYPE_RESOURCE);
+    CU_ASSERT_EQUAL(id, 55);
+    CU_ASSERT_EQUAL(index, 2);
+    CU_ASSERT_EQUAL(length, 3);
+
+    result = lwm2m_decodeTLV(data2, sizeof(data2) - 1, &type, &id, &index, &length);
+    CU_ASSERT_EQUAL(result, 0);
+
+    result = lwm2m_decodeTLV(data2, sizeof(data2), &type, &id, &index, &length);
+    CU_ASSERT_EQUAL(result, 13);
+    CU_ASSERT_EQUAL(type, LWM2M_TYPE_OBJECT_INSTANCE);
+    CU_ASSERT_EQUAL(id, 0x0203);
+    CU_ASSERT_EQUAL(index, 4);
+    CU_ASSERT_EQUAL(length, 9);
+
+    result = lwm2m_decodeTLV(data3, sizeof(data3) - 1, &type, &id, &index, &length);
+    CU_ASSERT_EQUAL(result, 0);
+
+    result = lwm2m_decodeTLV(data3, sizeof(data3), &type, &id, &index, &length);
+    CU_ASSERT_EQUAL(result, 0x194);
+    CU_ASSERT_EQUAL(type, LWM2M_TYPE_MULTIPLE_RESOURCE);
+    CU_ASSERT_EQUAL(id, 33);
+    CU_ASSERT_EQUAL(index, 4);
+    CU_ASSERT_EQUAL(length, 0x190);
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_opaqueToInt()
+{
+    MEMORY_TRACE_BEFORE;
+    uint8_t data1[] = {1 };
+    uint8_t data2[] = {1, 2 };
+    uint8_t data3[] = {0x81, 2, 3, 4 };
+    uint8_t data4[] = {0x81, 2, 3, 4, 5, 6, 7, 8 };
+    int64_t value = 0;
+    int result;
+
+
+    result = lwm2m_opaqueToInt(data1, sizeof(data1), &value);
+    CU_ASSERT_EQUAL(result, 1);
+    CU_ASSERT_EQUAL(value, 1);
+
+    result = lwm2m_opaqueToInt(data2, sizeof(data2), &value);
+    CU_ASSERT_EQUAL(result, 2);
+    CU_ASSERT_EQUAL(value, 0x102);
+
+    result = lwm2m_opaqueToInt(data3, sizeof(data3), &value);
+    CU_ASSERT_EQUAL(result, 4);
+    CU_ASSERT_EQUAL(value, -0x1020304);
+
+    result = lwm2m_opaqueToInt(data4, sizeof(data4), &value);
+    CU_ASSERT_EQUAL(result, 8);
+    CU_ASSERT_EQUAL(value, -0x102030405060708);
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_tlv_parse()
+{
+    MEMORY_TRACE_BEFORE;
+    // Resource 55 {1, 2, 3}
+    uint8_t data1[] = {0xC3, 55, 1, 2, 3};
+    // Instance 0x203 {Resource 55 {1, 2, 3}, Resource 66 {4, 5, 6, 7, 8, 9, 10, 11, 12 } }
+    uint8_t data2[] = {0x28, 2, 3, 17, 0xC3, 55, 1, 2, 3, 0xC8, 66, 9, 4, 5, 6, 7, 8, 9, 10, 11, 12, };
+    // Instance 11 {MultiResource 11 {ResourceInstance 0 {1, 2, 3}, ResourceInstance 1 {4, 5, 6, 7, 8, 9, ... } }
+    uint8_t data3[174] = {0x08, 11, 171, 0x88, 77, 168, 0x43, 0, 1, 2, 3, 0x48, 1, 160, 4, 5, 6, 7, 8, 9};
+    int result;
+    lwm2m_tlv_t *tlvP;
+    lwm2m_tlv_t *tlvSubP;
+
+    result = lwm2m_tlv_parse(data1, sizeof(data1), &tlvP);
+    CU_ASSERT_EQUAL(result, 1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP);
+    CU_ASSERT_EQUAL(tlvP->type, LWM2M_TYPE_RESOURCE);
+    CU_ASSERT_EQUAL(tlvP->id, 55);
+    CU_ASSERT_EQUAL(tlvP->length, 3);
+    CU_ASSERT(0 == memcmp(tlvP->value, &data1[2], 3));
+    lwm2m_tlv_free(result, tlvP);
+
+    result = lwm2m_tlv_parse(data2, sizeof(data2), &tlvP);
+    CU_ASSERT_EQUAL(result, 1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP);
+    CU_ASSERT_EQUAL(tlvP->type, LWM2M_TYPE_OBJECT_INSTANCE);
+    CU_ASSERT_EQUAL(tlvP->id, 0x203);
+    CU_ASSERT_EQUAL(tlvP->length, 2);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP->value);
+    tlvSubP = (lwm2m_tlv_t *)tlvP->value;
+
+    CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_RESOURCE);
+    CU_ASSERT_EQUAL(tlvSubP[0].id, 55);
+    CU_ASSERT_EQUAL(tlvSubP[0].length, 3);
+    CU_ASSERT(0 == memcmp(tlvSubP[0].value, &data2[6], 3));
+
+    CU_ASSERT_EQUAL(tlvSubP[1].type, LWM2M_TYPE_RESOURCE);
+    CU_ASSERT_EQUAL(tlvSubP[1].id, 66);
+    CU_ASSERT_EQUAL(tlvSubP[1].length, 9);
+    CU_ASSERT(0 == memcmp(tlvSubP[1].value, &data2[12], 9));
+    lwm2m_tlv_free(result, tlvP);
+
+    result = lwm2m_tlv_parse(data3, sizeof(data3), &tlvP);
+    CU_ASSERT_EQUAL(result, 1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP);
+    CU_ASSERT_EQUAL(tlvP->type, LWM2M_TYPE_OBJECT_INSTANCE);
+    CU_ASSERT_EQUAL(tlvP->id, 11);
+    CU_ASSERT_EQUAL(tlvP->length, 1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP->value);
+    tlvSubP = (lwm2m_tlv_t *)tlvP->value;
+
+    CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_MULTIPLE_RESOURCE);
+    CU_ASSERT_EQUAL(tlvSubP[0].id, 77);
+    CU_ASSERT_EQUAL(tlvSubP[0].length, 2);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[0].value);
+    tlvSubP = (lwm2m_tlv_t *)tlvSubP[0].value;
+
+    CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_RESOURCE_INSTANCE);
+    CU_ASSERT_EQUAL(tlvSubP[0].id, 0);
+    CU_ASSERT_EQUAL(tlvSubP[0].length, 3);
+    CU_ASSERT(0 == memcmp(tlvSubP[0].value, &data3[8], 3));
+
+    CU_ASSERT_EQUAL(tlvSubP[1].type, LWM2M_TYPE_RESOURCE_INSTANCE);
+    CU_ASSERT_EQUAL(tlvSubP[1].id, 1);
+    CU_ASSERT_EQUAL(tlvSubP[1].length, 160);
+    CU_ASSERT(0 == memcmp(tlvSubP[1].value, &data3[14], 160));
+    lwm2m_tlv_free(result, tlvP);
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_tlv_serialize()
+{
+    MEMORY_TRACE_BEFORE;
+
+    int result;
+    lwm2m_tlv_t *tlvP;
+    lwm2m_tlv_t *tlvSubP;
+    uint8_t data1[] = {1, 2, 3, 4};
+    uint8_t data2[170] = {5, 6, 7, 8};
+    uint8_t* buffer;
+
+    tlvP =  lwm2m_tlv_new(1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP);
+    tlvP->type = LWM2M_TYPE_OBJECT_INSTANCE;
+    tlvP->id = 3;
+    tlvP->length = 2;
+    tlvSubP =  lwm2m_tlv_new(2);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP);
+    tlvP->value = (uint8_t *) tlvSubP;
+
+    tlvSubP[0].type = LWM2M_TYPE_RESOURCE;
+    tlvSubP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
+    tlvSubP[0].id = 66;
+    tlvSubP[0].length = sizeof(data1);
+    tlvSubP[0].value = data1;
+
+    tlvSubP[1].type = LWM2M_TYPE_MULTIPLE_RESOURCE;
+    tlvSubP[1].id = 77;
+    tlvSubP[1].length = 1;
+    tlvSubP[1].value = (uint8_t *) lwm2m_tlv_new(1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[1].value);
+    tlvSubP = (lwm2m_tlv_t *)tlvSubP[1].value;
+
+    tlvSubP[0].type = LWM2M_TYPE_RESOURCE_INSTANCE;
+    tlvSubP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
+    tlvSubP[0].id = 0;
+    tlvSubP[0].length = sizeof(data2);
+    tlvSubP[0].value = data2;
+
+    result = lwm2m_tlv_serialize(1, tlvP, &buffer);
+    CU_ASSERT_EQUAL(result, sizeof(data2) + sizeof(data1) + 11);
+
+    CU_ASSERT_EQUAL(buffer[0], 0x08);
+    CU_ASSERT_EQUAL(buffer[1], 3);
+    CU_ASSERT_EQUAL(buffer[2], sizeof(data2) + sizeof(data1) + 8);
+
+    CU_ASSERT_EQUAL(buffer[3], 0xC0 + sizeof(data1));
+    CU_ASSERT_EQUAL(buffer[4], 66);
+    CU_ASSERT(0 == memcmp(data1, &buffer[5], sizeof(data1)));
+
+    CU_ASSERT_EQUAL(buffer[5 + sizeof(data1)], 0x88);
+    CU_ASSERT_EQUAL(buffer[6 + sizeof(data1)], 77);
+    CU_ASSERT_EQUAL(buffer[7 + sizeof(data1)], sizeof(data2) + 3);
+
+    CU_ASSERT_EQUAL(buffer[8 + sizeof(data1)], 0x48);
+    CU_ASSERT_EQUAL(buffer[9 + sizeof(data1)], 0);
+    CU_ASSERT_EQUAL(buffer[10 + sizeof(data1)], sizeof(data2));
+    CU_ASSERT(0 == memcmp(data2, &buffer[11 + sizeof(data1)], sizeof(data2)));
+
+    lwm2m_tlv_free(1, tlvP);
+    lwm2m_free(buffer);
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_tlv_encode_int(void)
+{
+   MEMORY_TRACE_BEFORE;
+   uint8_t data1[] = { 0x92, 0x34 };
+   uint8_t data2[] = { 0x7f, 0x34, 0x56, 0x78, 0x91, 0x22, 0x33, 0x44 };
+   lwm2m_tlv_t *tlvP =  lwm2m_tlv_new(10);
+   CU_ASSERT_PTR_NOT_NULL(tlvP);
+
+   lwm2m_tlv_encode_int(0x12, tlvP);
+   tlvP[0].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[0].flags, 0);
+   CU_ASSERT_EQUAL(tlvP[0].length, 1);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[0].value);
+   CU_ASSERT_EQUAL(tlvP[0].value[0], 0x12);
+
+   tlvP[1].flags = LWM2M_TLV_FLAG_TEXT_FORMAT;
+   lwm2m_tlv_encode_int(18, &tlvP[1]);
+   tlvP[1].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[1].length, 2);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[1].value);
+   CU_ASSERT(0 == memcmp(tlvP[1].value, "18", 2));
+
+   lwm2m_tlv_encode_int(-0x1234, &tlvP[2]);
+   tlvP[2].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[2].length, 2);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[2].value);
+   CU_ASSERT(0 == memcmp(tlvP[2].value, data1, 2));
+
+   tlvP[3].flags = LWM2M_TLV_FLAG_TEXT_FORMAT;
+   lwm2m_tlv_encode_int(-14678, &tlvP[3]);
+   tlvP[3].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[3].length, 6);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[3].value);
+   CU_ASSERT(0 == memcmp(tlvP[3].value, "-14678", 6));
+
+   lwm2m_tlv_encode_int(0x7f34567891223344, &tlvP[4]);
+   tlvP[4].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[4].length, 8);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[4].value);
+   CU_ASSERT(0 == memcmp(tlvP[4].value, data2, 8));
+
+   lwm2m_tlv_free(10, tlvP);
+   MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_tlv_decode_int(void)
+{
+   MEMORY_TRACE_BEFORE;
+   uint8_t data1[] = { 0x12, 0x34 };
+   uint8_t data2[] = { 0x92, 0x34 };
+   uint8_t data3[] = { 0x7f, 0x34, 0x56, 0x78, 0x91, 0x22, 0x33, 0x44 };
+   int64_t value;
+   int result;
+   lwm2m_tlv_t *tlvP =  lwm2m_tlv_new(10);
+   CU_ASSERT_PTR_NOT_NULL(tlvP);
+
+   result = lwm2m_tlv_decode_int(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 0);
+
+   tlvP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
+   tlvP[0].length = 1;
+   tlvP[0].value = data1;
+   result = lwm2m_tlv_decode_int(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, 0x12);
+
+   tlvP[0].length = 2;
+   tlvP[0].value = data2;
+   result = lwm2m_tlv_decode_int(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, -0x1234);
+
+   tlvP[0].length = 8;
+   tlvP[0].value = data3;
+   result = lwm2m_tlv_decode_int(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, 0x7f34567891223344);
+
+   tlvP[0].length = 9;
+   result = lwm2m_tlv_decode_int(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 0);
+
+   tlvP[0].flags |= LWM2M_TLV_FLAG_TEXT_FORMAT;
+   tlvP[0].length = 2;
+   tlvP[0].value = (uint8_t *) "18";
+   result = lwm2m_tlv_decode_int(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, 18);
+
+   tlvP[0].length = 9;
+   tlvP[0].value = (uint8_t *) "-56923456";
+   result = lwm2m_tlv_decode_int(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, -56923456);
+
+   lwm2m_tlv_free(10, tlvP);
+   MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_tlv_encode_bool(void)
+{
+   MEMORY_TRACE_BEFORE;
+   lwm2m_tlv_t *tlvP =  lwm2m_tlv_new(10);
+   CU_ASSERT_PTR_NOT_NULL(tlvP);
+
+   lwm2m_tlv_encode_bool(2, tlvP);
+   tlvP[0].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[0].flags, 0);
+   CU_ASSERT_EQUAL(tlvP[0].length, 1);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[0].value);
+   CU_ASSERT_EQUAL(tlvP[0].value[0], 1);
+
+   lwm2m_tlv_encode_bool(0, &tlvP[1]);
+   tlvP[1].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[1].flags, 0);
+   CU_ASSERT_EQUAL(tlvP[1].length, 1);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[1].value);
+   CU_ASSERT_EQUAL(tlvP[1].value[0], 0);
+
+   tlvP[2].flags = LWM2M_TLV_FLAG_TEXT_FORMAT;
+   lwm2m_tlv_encode_bool(0, &tlvP[2]);
+   tlvP[2].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[2].flags, LWM2M_TLV_FLAG_TEXT_FORMAT);
+   CU_ASSERT_EQUAL(tlvP[2].length, 1);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[2].value);
+   CU_ASSERT_EQUAL(tlvP[2].value[0], '0');
+
+   tlvP[3].flags = LWM2M_TLV_FLAG_TEXT_FORMAT;
+   lwm2m_tlv_encode_bool(4, &tlvP[3]);
+   tlvP[3].type = LWM2M_TYPE_RESOURCE;
+   CU_ASSERT_EQUAL(tlvP[3].flags, LWM2M_TLV_FLAG_TEXT_FORMAT);
+   CU_ASSERT_EQUAL(tlvP[3].length, 1);
+   CU_ASSERT_PTR_NOT_NULL_FATAL(tlvP[3].value);
+   CU_ASSERT_EQUAL(tlvP[3].value[0], '1');
+
+   lwm2m_tlv_free(10, tlvP);
+   MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_tlv_decode_bool(void)
+{
+   MEMORY_TRACE_BEFORE;
+   uint8_t data1[] = { 0 };
+   uint8_t data2[] = { 1 };
+   uint8_t data3[] = { 2 };
+   bool value;
+   int result;
+   lwm2m_tlv_t *tlvP =  lwm2m_tlv_new(10);
+   CU_ASSERT_PTR_NOT_NULL(tlvP);
+
+   result = lwm2m_tlv_decode_bool(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 0);
+
+   tlvP[0].length = 2;
+   result = lwm2m_tlv_decode_bool(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 0);
+
+   tlvP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
+   tlvP[0].length = 1;
+   tlvP[0].value = data1;
+   result = lwm2m_tlv_decode_bool(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_FALSE(value);
+
+   tlvP[0].value = data2;
+   result = lwm2m_tlv_decode_bool(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_TRUE(value);
+
+   tlvP[0].value = data3;
+   result = lwm2m_tlv_decode_bool(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 0);
+
+   tlvP[0].flags |= LWM2M_TLV_FLAG_TEXT_FORMAT;
+   tlvP[0].value = (uint8_t *)"0";
+   result = lwm2m_tlv_decode_bool(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_FALSE(value);
+
+   tlvP[0].value = (uint8_t *)"1";
+   result = lwm2m_tlv_decode_bool(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_TRUE(value);
+
+   tlvP[0].value = (uint8_t *)"2";
+   result = lwm2m_tlv_decode_bool(tlvP, &value);
+   CU_ASSERT_EQUAL(result, 0);
+
+   lwm2m_tlv_free(10, tlvP);
+   MEMORY_TRACE_AFTER_EQ;
+}
+
+static struct TestTable table[] = {
+        { "test of lwm2m_tlv_new()", test_tlv_new },
+        { "test of lwm2m_tlv_free()", test_tlv_free },
+        { "test of lwm2m_opaqueToTLV()", test_opaqueToTLV },
+        { "test of lwm2m_boolToTLV()", test_boolToTLV },
+        { "test of lwm2m_intToTLV()", test_intToTLV },
+        { "test of lwm2m_decodeTLV()", test_decodeTLV },
+        { "test of lwm2m_opaqueToInt()", test_opaqueToInt },
+        { "test of lwm2m_tlv_parse()", test_tlv_parse },
+        { "test of lwm2m_tlv_serialize()", test_tlv_serialize },
+        { "test of lwm2m_tlv_encode_int()", test_tlv_encode_int },
+        { "test of lwm2m_tlv_decode_int()", test_tlv_decode_int },
+        { "test of lwm2m_tlv_encode_bool()", test_tlv_encode_bool },
+        { "test of lwm2m_tlv_decode_bool()", test_tlv_decode_bool },
+        { NULL, NULL },
+};
+
+CU_ErrorCode create_tlv_suit()
+{
+   CU_pSuite pSuite = NULL;
+
+   pSuite = CU_add_suite("Suite_TLV", NULL, NULL);
+   if (NULL == pSuite) {
+      return CU_get_error();
+   }
+
+   return add_tests(pSuite, table);
+}
+
+
+

--- a/tests/unittests/unittests.c
+++ b/tests/unittests/unittests.c
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innovations GmbH, Germany.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+
+
+#include <stdio.h>
+
+#include "CUnit/Basic.h"
+
+#include "tests.h"
+
+CU_ErrorCode add_tests(CU_pSuite pSuite, struct TestTable* testTable)
+{
+    int index;
+    for (index = 0; NULL != testTable && NULL != testTable[index].name; ++index) {
+        if (NULL == CU_add_test(pSuite, testTable[index].name, testTable[index].function)) {
+            fprintf(stderr, "Failed to add test %s\n", testTable[index].name);
+            return CU_get_error();
+         }
+    }
+    return CUE_SUCCESS;
+}
+
+int main()
+{
+   /* initialize the CUnit test registry */
+   if (CUE_SUCCESS != CU_initialize_registry())
+      return CU_get_error();
+
+   if (CUE_SUCCESS != create_tlv_suit()) {
+       goto exit;
+   }
+   if (CUE_SUCCESS != create_uri_suit()) {
+       goto exit;
+   }
+
+   CU_basic_set_mode(CU_BRM_VERBOSE);
+   CU_basic_run_tests();
+exit:
+   CU_cleanup_registry();
+   return CU_get_error();
+}

--- a/tests/unittests/uritests.c
+++ b/tests/unittests/uritests.c
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innovations GmbH, Germany.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+
+#include "tests.h"
+#include "CUnit/Basic.h"
+#include "liblwm2m.h"
+#include "internals.h"
+#include "memtest.h"
+
+
+static void test_uri_decode(void)
+{
+    lwm2m_uri_t* uri;
+    multi_option_t extraID = { .next = NULL, .is_static = 1, .len = 3, .data = (uint8_t *) "555" };
+    multi_option_t rID = { .next = NULL, .is_static = 1, .len = 1, .data = (uint8_t *) "0" };
+    multi_option_t iID = { .next = &rID, .is_static = 1, .len = 2, .data = (uint8_t *) "11" };
+    multi_option_t oID = { .next = &iID, .is_static = 1, .len = 4, .data = (uint8_t *) "9050" };
+    multi_option_t location = { .next = NULL, .is_static = 1, .len = 4, .data = (uint8_t *) "5a3f" };
+    multi_option_t locationDecimal = { .next = NULL, .is_static = 1, .len = 4, .data = (uint8_t *) "5312" };
+    multi_option_t reg = { .next = NULL, .is_static = 1, .len = 2, .data = (uint8_t *) "rd" };
+    multi_option_t boot = { .next = NULL, .is_static = 1, .len = 2, .data = (uint8_t *) "bs" };
+
+    MEMORY_TRACE_BEFORE;
+
+    /* "/rd" */
+    uri = lwm2m_decode_uri(NULL, &reg);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
+    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_REGISTRATION);
+    lwm2m_free(uri);
+
+    /* "/rd/5a3f" */
+    reg.next = &location;
+    uri = lwm2m_decode_uri(NULL, &reg);
+    /* should not fail, error in uri_parse */
+    /* CU_ASSERT_PTR_NOT_NULL(uri); */
+    lwm2m_free(uri);
+
+    /* "/rd/5312" */
+    reg.next = &locationDecimal;
+    uri = lwm2m_decode_uri(NULL, &reg);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
+    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_REGISTRATION | LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT_EQUAL(uri->objectId, 5312);
+    lwm2m_free(uri);
+
+    /* "/bs" */
+    uri = lwm2m_decode_uri(NULL, &boot);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
+    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_BOOTSTRAP);
+    lwm2m_free(uri);
+
+    /* "/bs/5a3f" */
+    boot.next = &location;
+    uri = lwm2m_decode_uri(NULL, &boot);
+    CU_ASSERT_PTR_NULL(uri);
+    lwm2m_free(uri);
+
+    /* "/9050/11/0" */
+    uri = lwm2m_decode_uri(NULL, &oID);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
+    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID | LWM2M_URI_FLAG_RESOURCE_ID);
+    CU_ASSERT_EQUAL(uri->objectId, 9050);
+    CU_ASSERT_EQUAL(uri->instanceId, 11);
+    CU_ASSERT_EQUAL(uri->resourceId, 0);
+    lwm2m_free(uri);
+
+    /* "/11/0" */
+    uri = lwm2m_decode_uri(NULL, &iID);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
+    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID);
+    CU_ASSERT_EQUAL(uri->objectId, 11);
+    CU_ASSERT_EQUAL(uri->instanceId, 0);
+    lwm2m_free(uri);
+
+    /* "/0" */
+    uri = lwm2m_decode_uri(NULL, &rID);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
+    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT_EQUAL(uri->objectId, 0);
+    lwm2m_free(uri);
+
+    /* "/9050/11/0/555" */
+    rID.next = &extraID;
+    uri = lwm2m_decode_uri(NULL, &oID);
+    CU_ASSERT_PTR_NULL(uri);
+    lwm2m_free(uri);
+
+    /* "/0/5a3f" */
+    rID.next = &location;
+    uri = lwm2m_decode_uri(NULL, &rID);
+    CU_ASSERT_PTR_NULL(uri);
+    lwm2m_free(uri);
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+
+static void test_string_to_uri(void)
+{
+    int result;
+    lwm2m_uri_t uri;
+    MEMORY_TRACE_BEFORE;
+    result = lwm2m_stringToUri("", 0, &uri);
+    CU_ASSERT_EQUAL(result, 0);
+    result = lwm2m_stringToUri("no_uri", 6, &uri);
+    CU_ASSERT_EQUAL(result, 0);
+    result = lwm2m_stringToUri("/1", 2, &uri);
+    CU_ASSERT_EQUAL(result, 2);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_OBJECT_ID), LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT_EQUAL(uri.objectId, 1);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_INSTANCE_ID), 0);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_ID), 0);
+
+    result = lwm2m_stringToUri("/1/2", 4, &uri);
+    CU_ASSERT_EQUAL(result, 4);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_OBJECT_ID), LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT_EQUAL(uri.objectId, 1);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_INSTANCE_ID), LWM2M_URI_FLAG_INSTANCE_ID);
+    CU_ASSERT_EQUAL(uri.instanceId, 2);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_ID), 0);
+
+    result = lwm2m_stringToUri("/1/2/3", 6, &uri);
+    CU_ASSERT_EQUAL(result, 6);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_OBJECT_ID), LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT_EQUAL(uri.objectId, 1);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_INSTANCE_ID), LWM2M_URI_FLAG_INSTANCE_ID);
+    CU_ASSERT_EQUAL(uri.instanceId, 2);
+    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_ID), LWM2M_URI_FLAG_RESOURCE_ID);
+    CU_ASSERT_EQUAL(uri.resourceId, 3);
+
+    MEMORY_TRACE_AFTER_EQ;
+}
+
+static struct TestTable table[] = {
+        { "test of uri_decode()", test_uri_decode },
+        { "test of lwm2m_stringToUri()", test_string_to_uri },
+        { NULL, NULL },
+};
+
+CU_ErrorCode create_uri_suit()
+{
+   CU_pSuite pSuite = NULL;
+
+   pSuite = CU_add_suite("Suite_URI", NULL, NULL);
+   if (NULL == pSuite) {
+      return CU_get_error();
+   }
+
+   return add_tests(pSuite, table);
+}
+

--- a/tests/utils/commandline.c
+++ b/tests/utils/commandline.c
@@ -342,7 +342,7 @@ void dump_tlv(FILE * stream,
         fprintf(stream, "\r\n");
 
         print_indent(stream, indent+1);
-        fprintf(stream, "data length: %d\r\n", tlvP[i].length);
+        fprintf(stream, "data length: %d\r\n", (int) tlvP[i].length);
 
         if (tlvP[i].type == LWM2M_TYPE_OBJECT_INSTANCE
          || tlvP[i].type == LWM2M_TYPE_MULTIPLE_RESOURCE)


### PR DESCRIPTION
Add processing of transactions with separate response as specified in section 2.2 of RFC 7252.
Add first cunit tests and optional memory tracing.