### PR TITLE
Call "transaction_handle_response" also on RST to remove transaction.

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -32,7 +32,7 @@ static void prv_handleBootstrapReply(lwm2m_transaction_t * transaction, void * m
     LOG("[BOOTSTRAP] Handling bootstrap reply...\r\n");
     lwm2m_context_t * context = (lwm2m_context_t *)transaction->userData;
     coap_packet_t * coapMessage = (coap_packet_t *)message;
-    if (NULL != coapMessage)
+    if (NULL != coapMessage && COAP_TYPE_RST != coapMessage->type)
     {
         handle_bootstrap_response(context, coapMessage, NULL);
     }

--- a/core/packet.c
+++ b/core/packet.c
@@ -322,6 +322,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
             case COAP_TYPE_RST:
                 /* Cancel possible subscriptions. */
                 handle_reset(contextP, fromSessionH, message);
+                transaction_handle_response(contextP, fromSessionH, message, NULL);
                 break;
 
             case COAP_TYPE_ACK:


### PR DESCRIPTION
Call "transaction_handle_response" also on RST to remove transaction and prevent the transaction client from repeating the message.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>