### PR TITLE
use const char * for lwm2m_configure.

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -186,7 +186,7 @@ void delete_observed_list(lwm2m_context_t * contextP);
 
 // defined in utils.c
 lwm2m_binding_t lwm2m_stringToBinding(uint8_t *buffer, size_t length);
-int prv_isAltPathValid(char * altPath);
+int prv_isAltPathValid(const char * altPath);
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP, void * fromSessionH);
 lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP, void * fromSessionH);

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -209,9 +209,9 @@ void lwm2m_close(lwm2m_context_t * contextP)
 
 #ifdef LWM2M_CLIENT_MODE
 int lwm2m_configure(lwm2m_context_t * contextP,
-                    char * endpointName,
-                    char * msisdn,
-                    char * altPath,
+                    const char * endpointName,
+                    const char * msisdn,
+                    const char * altPath,
                     uint16_t numObject,
                     lwm2m_object_t * objectList[])
 {

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -316,7 +316,7 @@ typedef struct
 // Return the number of characters read from buffer or 0 in case of error.
 // Valid URIs: /1, /1/, /1/2, /1/2/, /1/2/3
 // Invalid URIs: /, //, //2, /1//, /1//3, /1/2/3/, /1/2/3/4
-int lwm2m_stringToUri(char * buffer, size_t buffer_len, lwm2m_uri_t * uriP);
+int lwm2m_stringToUri(const char * buffer, size_t buffer_len, lwm2m_uri_t * uriP);
 
 
 /*

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -589,7 +589,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int lengt
 // for objects (can be nil) and a list of objects.
 // LWM2M Security Object (ID 0) must be present with either a bootstrap server or a LWM2M server and
 // its matching LWM2M Server Object (ID 1) instance
-int lwm2m_configure(lwm2m_context_t * contextP, char * endpointName, char * msisdn, char * altPath, uint16_t numObject, lwm2m_object_t * objectList[]);
+int lwm2m_configure(lwm2m_context_t * contextP, const char * endpointName, const char * msisdn, const char * altPath, uint16_t numObject, lwm2m_object_t * objectList[]);
 
 // create objects for known LWM2M Servers.
 int lwm2m_start(lwm2m_context_t * contextP);

--- a/core/uri.c
+++ b/core/uri.c
@@ -199,7 +199,7 @@ error:
     return NULL;
 }
 
-int lwm2m_stringToUri(char * buffer,
+int lwm2m_stringToUri(const char * buffer,
                       size_t buffer_len,
                       lwm2m_uri_t * uriP)
 {

--- a/core/utils.c
+++ b/core/utils.c
@@ -377,7 +377,7 @@ lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP,
 #endif
 }
 
-int prv_isAltPathValid(char * altPath)
+int prv_isAltPathValid(const char * altPath)
 {
     int i;
 


### PR DESCRIPTION
`endpointName`, `msisdn` and `altPath` is not modified in lwm2m_configure, so we should use the const modifier.