### PR TITLE
Bug fix: fix the bootstrap server.

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -368,6 +368,7 @@ int lwm2m_bootstrap_write(lwm2m_context_t * contextP,
     transaction = transaction_new(COAP_TYPE_CON, COAP_PUT, NULL, uriP, contextP->nextMID++, 4, NULL, ENDPOINT_UNKNOWN, sessionH);
     if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
 
+    coap_set_header_content_type(transaction->message, LWM2M_CONTENT_TLV);
     coap_set_payload(transaction->message, buffer, length);
 
     dataP = (bs_data_t *)lwm2m_malloc(sizeof(bs_data_t));


### PR DESCRIPTION
A quick fix exhibiting a problem with current writing APIs prototypes. We need a content type parameter as we pass a buffer. 

Signed-off-by: David Navarro <david.navarro@intel.com>