### PR TITLE
Remove Close callback from lwm2m_object_t.

### DIFF
--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -86,25 +86,6 @@ lwm2m_context_t * lwm2m_init(lwm2m_connect_server_callback_t connectCallback,
 }
 
 #ifdef LWM2M_CLIENT_MODE
-void lwm2m_delete_object_list_content(lwm2m_context_t * context)
-{
-    lwm2m_object_t ** objectList = context->objectList;
-    if (NULL != objectList)
-    {
-        int i;
-        for (i = 0 ; i < context->numObject ; i++)
-        {
-            if (NULL != objectList[i])
-            {
-                if (objectList[i]->closeFunc != NULL)
-                {
-                    objectList[i]->closeFunc(objectList[i]);
-                }
-            }
-        }
-    }
-}
-
 void lwm2m_deregister(lwm2m_context_t * context)
 {
     lwm2m_server_t * server = context->serverList;
@@ -173,7 +154,6 @@ void lwm2m_close(lwm2m_context_t * contextP)
     delete_server_list(contextP);
     delete_bootstrap_server_list(contextP);
     delete_observed_list(contextP);
-    lwm2m_delete_object_list_content(contextP);
     for (i = 0 ; i < contextP->numObject ; i++)
     {
         lwm2m_free(contextP->objectList[i]);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -349,7 +349,6 @@ typedef uint8_t (*lwm2m_write_callback_t) (uint16_t instanceId, int numData, lwm
 typedef uint8_t (*lwm2m_execute_callback_t) (uint16_t instanceId, uint16_t resourceId, uint8_t * buffer, int length, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_create_callback_t) (uint16_t instanceId, int numData, lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_delete_callback_t) (uint16_t instanceId, lwm2m_object_t * objectP);
-typedef void (*lwm2m_close_callback_t) (lwm2m_object_t * objectP);
 
 struct _lwm2m_object_t
 {
@@ -360,7 +359,6 @@ struct _lwm2m_object_t
     lwm2m_execute_callback_t executeFunc;
     lwm2m_create_callback_t  createFunc;
     lwm2m_delete_callback_t  deleteFunc;
-    lwm2m_close_callback_t   closeFunc;
     void *                   userData;
 };
 

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -597,8 +597,17 @@ static void prv_backup_objects(lwm2m_context_t * context)
 
     for (i = 0; i < BACKUP_OBJECT_COUNT; i++) {
         if (NULL != backupObjectArray[i]) {
-            backupObjectArray[i]->closeFunc(backupObjectArray[i]);
-            lwm2m_free(backupObjectArray[i]);
+            switch (backupObjectArray[i]->objID)
+            {
+            case LWM2M_SECURITY_OBJECT_ID:
+                free_security_object(backupObjectArray[i]);
+                break;
+            case LWM2M_SERVER_OBJECT_ID:
+                free_server_object(backupObjectArray[i]);
+                break;
+            default:
+                break;
+            }
         }
         backupObjectArray[i] = (lwm2m_object_t *)lwm2m_malloc(sizeof(lwm2m_object_t));
         memset(backupObjectArray[i], 0, sizeof(lwm2m_object_t));
@@ -639,13 +648,13 @@ static void prv_restore_objects(lwm2m_context_t * context)
             {
             case LWM2M_SECURITY_OBJECT_ID:
                 // first delete internal content
-                object->closeFunc(object);
+                free_security_object(object);
                 // then restore previous object
                 copy_security_object(object, backupObjectArray[0]);
                 break;
             case LWM2M_SERVER_OBJECT_ID:
                 // first delete internal content
-                object->closeFunc(object);
+                free_server_object(object);
                 // then restore previous object
                 copy_server_object(object, backupObjectArray[1]);
                 break;
@@ -714,8 +723,17 @@ static void close_backup_object()
     int i;
     for (i = 0; i < BACKUP_OBJECT_COUNT; i++) {
         if (NULL != backupObjectArray[i]) {
-            backupObjectArray[i]->closeFunc(backupObjectArray[i]);
-            lwm2m_free(backupObjectArray[i]);
+            switch (backupObjectArray[i]->objID)
+            {
+            case LWM2M_SECURITY_OBJECT_ID:
+                free_security_object(backupObjectArray[i]);
+                break;
+            case LWM2M_SERVER_OBJECT_ID:
+                free_server_object(backupObjectArray[i]);
+                break;
+            default:
+                break;
+            }
         }
     }
 }
@@ -1161,6 +1179,16 @@ int main(int argc, char *argv[])
     }
     close(data.sock);
     connection_free(data.connList);
+
+    free_security_object(objArray[0]);
+    free_server_object(objArray[1]);
+    free_object_device(objArray[2]);
+    free_object_firmware(objArray[3]);
+    free_object_location(objArray[4]);
+    free_test_object(objArray[5]);
+    free_object_conn_m(objArray[6]);
+    free_object_conn_s(objArray[7]);
+    acl_ctrl_free_object(objArray[8]);
 
 #ifdef MEMORY_TRACE
     if (g_quit == 1)

--- a/tests/client/lwm2mclient.h
+++ b/tests/client/lwm2mclient.h
@@ -35,28 +35,33 @@ extern int g_reboot;
  * object_device.c
  */
 extern lwm2m_object_t * get_object_device(void);
+void free_object_device(lwm2m_object_t * objectP);
 uint8_t device_change(lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
 extern void display_device_object(lwm2m_object_t * objectP);
 /*
  * object_firmware.c
  */
 extern lwm2m_object_t * get_object_firmware(void);
+void free_object_firmware(lwm2m_object_t * objectP);
 extern void display_firmware_object(lwm2m_object_t * objectP);
 /*
  * object_location.c
  */
 extern lwm2m_object_t * get_object_location(void);
+void free_object_location(lwm2m_object_t * object);
 extern void display_location_object(lwm2m_object_t * objectP);
 /*
  * object_test.c
  */
 #define TEST_OBJECT_ID 1024
 extern lwm2m_object_t * get_test_object(void);
+void free_test_object(lwm2m_object_t * object);
 extern void display_test_object(lwm2m_object_t * objectP);
 /*
  * object_server.c
  */
 extern lwm2m_object_t * get_server_object(int serverId, const char* binding, int lifetime, bool storing);
+void free_server_object(lwm2m_object_t * object);
 extern void display_server_object(lwm2m_object_t * objectP);
 extern void copy_server_object(lwm2m_object_t * objectDest, lwm2m_object_t * objectSrc);
 
@@ -64,12 +69,14 @@ extern void copy_server_object(lwm2m_object_t * objectDest, lwm2m_object_t * obj
  * object_connectivity_moni.c
  */
 extern lwm2m_object_t * get_object_conn_m(void);
+void free_object_conn_m(lwm2m_object_t * objectP);
 uint8_t connectivity_moni_change(lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
 
 /*
  * object_connectivity_stat.c
  */
 extern lwm2m_object_t * get_object_conn_s(void);
+void free_object_conn_s(lwm2m_object_t * objectP);
 extern void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint16_t txDataByte, bool smsBased);
 extern void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint16_t rxDataByte, bool smsBased);
 
@@ -77,6 +84,7 @@ extern void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint16_t rxDataBy
  * object_access_control.c
  */
 extern lwm2m_object_t* acc_ctrl_create_object(void);
+extern void acl_ctrl_free_object(lwm2m_object_t * objectP);
 extern bool  acc_ctrl_obj_add_inst (lwm2m_object_t* accCtrlObjP, uint16_t instId,
                  uint16_t acObjectId, uint16_t acObjInstId, uint16_t acOwner);
 extern bool  acc_ctrl_oi_add_ac_val(lwm2m_object_t* accCtrlObjP, uint16_t instId,
@@ -95,6 +103,7 @@ extern void system_reboot(void);
  * object_security.c
  */
 extern lwm2m_object_t * get_security_object(int serverId, const char* serverUri, bool isBootstrap);
+void free_security_object(lwm2m_object_t * objectP);
 extern char * get_server_uri(lwm2m_object_t * objectP, uint16_t secObjInstID);
 extern void display_security_object(lwm2m_object_t * objectP);
 extern void copy_security_object(lwm2m_object_t * objectDest, lwm2m_object_t * objectSrc);

--- a/tests/client/lwm2mclient.h
+++ b/tests/client/lwm2mclient.h
@@ -34,41 +34,41 @@ extern int g_reboot;
 /*
  * object_device.c
  */
-extern lwm2m_object_t * get_object_device(void);
+lwm2m_object_t * get_object_device(void);
 void free_object_device(lwm2m_object_t * objectP);
 uint8_t device_change(lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
-extern void display_device_object(lwm2m_object_t * objectP);
+void display_device_object(lwm2m_object_t * objectP);
 /*
  * object_firmware.c
  */
-extern lwm2m_object_t * get_object_firmware(void);
+lwm2m_object_t * get_object_firmware(void);
 void free_object_firmware(lwm2m_object_t * objectP);
-extern void display_firmware_object(lwm2m_object_t * objectP);
+void display_firmware_object(lwm2m_object_t * objectP);
 /*
  * object_location.c
  */
-extern lwm2m_object_t * get_object_location(void);
+lwm2m_object_t * get_object_location(void);
 void free_object_location(lwm2m_object_t * object);
-extern void display_location_object(lwm2m_object_t * objectP);
+void display_location_object(lwm2m_object_t * objectP);
 /*
  * object_test.c
  */
 #define TEST_OBJECT_ID 1024
-extern lwm2m_object_t * get_test_object(void);
+lwm2m_object_t * get_test_object(void);
 void free_test_object(lwm2m_object_t * object);
-extern void display_test_object(lwm2m_object_t * objectP);
+void display_test_object(lwm2m_object_t * objectP);
 /*
  * object_server.c
  */
-extern lwm2m_object_t * get_server_object(int serverId, const char* binding, int lifetime, bool storing);
+lwm2m_object_t * get_server_object(int serverId, const char* binding, int lifetime, bool storing);
 void free_server_object(lwm2m_object_t * object);
-extern void display_server_object(lwm2m_object_t * objectP);
-extern void copy_server_object(lwm2m_object_t * objectDest, lwm2m_object_t * objectSrc);
+void display_server_object(lwm2m_object_t * objectP);
+void copy_server_object(lwm2m_object_t * objectDest, lwm2m_object_t * objectSrc);
 
 /*
  * object_connectivity_moni.c
  */
-extern lwm2m_object_t * get_object_conn_m(void);
+lwm2m_object_t * get_object_conn_m(void);
 void free_object_conn_m(lwm2m_object_t * objectP);
 uint8_t connectivity_moni_change(lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
 
@@ -83,29 +83,29 @@ extern void conn_s_updateRxStatistic(lwm2m_object_t * objectP, uint16_t rxDataBy
 /*
  * object_access_control.c
  */
-extern lwm2m_object_t* acc_ctrl_create_object(void);
-extern void acl_ctrl_free_object(lwm2m_object_t * objectP);
-extern bool  acc_ctrl_obj_add_inst (lwm2m_object_t* accCtrlObjP, uint16_t instId,
+lwm2m_object_t* acc_ctrl_create_object(void);
+void acl_ctrl_free_object(lwm2m_object_t * objectP);
+bool  acc_ctrl_obj_add_inst (lwm2m_object_t* accCtrlObjP, uint16_t instId,
                  uint16_t acObjectId, uint16_t acObjInstId, uint16_t acOwner);
-extern bool  acc_ctrl_oi_add_ac_val(lwm2m_object_t* accCtrlObjP, uint16_t instId,
+bool  acc_ctrl_oi_add_ac_val(lwm2m_object_t* accCtrlObjP, uint16_t instId,
                  uint16_t aclResId, uint16_t acValue);
 /*
  * lwm2mclient.c
  */
-extern void handle_value_changed(lwm2m_context_t* lwm2mH, lwm2m_uri_t* uri, const char * value, size_t valueLength);
+void handle_value_changed(lwm2m_context_t* lwm2mH, lwm2m_uri_t* uri, const char * value, size_t valueLength);
 /*
  * system_api.c
  */
-extern void init_value_change(lwm2m_context_t * lwm2m);
-extern void system_reboot(void);
+void init_value_change(lwm2m_context_t * lwm2m);
+void system_reboot(void);
 
 /*
  * object_security.c
  */
-extern lwm2m_object_t * get_security_object(int serverId, const char* serverUri, bool isBootstrap);
+lwm2m_object_t * get_security_object(int serverId, const char* serverUri, bool isBootstrap);
 void free_security_object(lwm2m_object_t * objectP);
-extern char * get_server_uri(lwm2m_object_t * objectP, uint16_t secObjInstID);
-extern void display_security_object(lwm2m_object_t * objectP);
-extern void copy_security_object(lwm2m_object_t * objectDest, lwm2m_object_t * objectSrc);
+char * get_server_uri(lwm2m_object_t * objectP, uint16_t secObjInstID);
+void display_security_object(lwm2m_object_t * objectP);
+void copy_security_object(lwm2m_object_t * objectDest, lwm2m_object_t * objectSrc);
 
 #endif /* LWM2MCLIENT_H_ */

--- a/tests/client/object_access_control.c
+++ b/tests/client/object_access_control.c
@@ -358,21 +358,6 @@ static uint8_t prv_write(uint16_t instanceId, int numData,
     return prv_write_resources(instanceId, numData, tlvArray, objectP, false);
 }
 
-
-static void prv_close(lwm2m_object_t * objectP)
-{
-    acc_ctrl_oi_t *accCtrlOiT;
-    acc_ctrl_oi_t *accCtrlOiP = (acc_ctrl_oi_t*)objectP->instanceList;
-    while (accCtrlOiP != NULL)
-    {
-        // first free acl (multiple resource!):
-        LWM2M_LIST_FREE(accCtrlOiP->accCtrlValList);
-        accCtrlOiT = accCtrlOiP;
-        accCtrlOiP = accCtrlOiP->next;
-        lwm2m_free(accCtrlOiT);
-    }
-}
-
 static uint8_t prv_delete(uint16_t id, lwm2m_object_t * objectP)
 {
     acc_ctrl_oi_t* targetP;
@@ -437,11 +422,25 @@ lwm2m_object_t * acc_ctrl_create_object(void)
         // Init callbacks, empty instanceList!
         accCtrlObj->readFunc    = prv_read;
         accCtrlObj->writeFunc   = prv_write;
-        accCtrlObj->closeFunc   = prv_close;
         accCtrlObj->createFunc  = prv_create;
         accCtrlObj->deleteFunc  = prv_delete;
     }
     return accCtrlObj;
+}
+
+void acl_ctrl_free_object(lwm2m_object_t * objectP)
+{
+    acc_ctrl_oi_t *accCtrlOiT;
+    acc_ctrl_oi_t *accCtrlOiP = (acc_ctrl_oi_t*)objectP->instanceList;
+    while (accCtrlOiP != NULL)
+    {
+        // first free acl (multiple resource!):
+        LWM2M_LIST_FREE(accCtrlOiP->accCtrlValList);
+        accCtrlOiT = accCtrlOiP;
+        accCtrlOiP = accCtrlOiP->next;
+        lwm2m_free(accCtrlOiT);
+    }
+    lwm2m_free(objectP);
 }
 
 bool  acc_ctrl_obj_add_inst (lwm2m_object_t* accCtrlObjP, uint16_t instId,

--- a/tests/client/object_connectivity_moni.c
+++ b/tests/client/object_connectivity_moni.c
@@ -286,12 +286,6 @@ static uint8_t prv_read(uint16_t instanceId,
     return result;
 }
 
-static void prv_close(lwm2m_object_t * objectP)
-{
-    lwm2m_free(objectP->userData);
-    lwm2m_list_free(objectP->instanceList);
-}
-
 lwm2m_object_t * get_object_conn_m(void)
 {
     /*
@@ -331,7 +325,6 @@ lwm2m_object_t * get_object_conn_m(void)
          * know the resources of the object, only the server does.
          */
         connObj->readFunc = prv_read;
-        connObj->closeFunc = prv_close;
         connObj->executeFunc = NULL;
         connObj->userData = lwm2m_malloc(sizeof(conn_m_data_t));
 
@@ -357,6 +350,13 @@ lwm2m_object_t * get_object_conn_m(void)
         }
     }
     return connObj;
+}
+
+void free_object_conn_m(lwm2m_object_t * objectP)
+{
+    lwm2m_free(objectP->userData);
+    lwm2m_list_free(objectP->instanceList);
+    lwm2m_free(objectP);
 }
 
 uint8_t connectivity_moni_change(lwm2m_data_t * dataArray,

--- a/tests/client/object_connectivity_stat.c
+++ b/tests/client/object_connectivity_stat.c
@@ -174,12 +174,6 @@ static uint8_t prv_exec(uint16_t instanceId, uint16_t resourceId,
     }
 }
 
-static void prv_close(lwm2m_object_t * objectP)
-{
-    lwm2m_free(objectP->userData);
-    lwm2m_list_free(objectP->instanceList);
-}
-
 void conn_s_updateTxStatistic(lwm2m_object_t * objectP, uint16_t txDataByte, bool smsBased)
 {
     conn_s_data_t* myData = (conn_s_data_t*) (objectP->userData);
@@ -249,7 +243,6 @@ lwm2m_object_t * get_object_conn_s(void)
          */
         connObj->readFunc     = prv_read;
         connObj->executeFunc  = prv_exec;
-        connObj->closeFunc    = prv_close;
         connObj->userData     = lwm2m_malloc(sizeof(conn_s_data_t));
 
         /*
@@ -267,4 +260,11 @@ lwm2m_object_t * get_object_conn_s(void)
         }
     }
     return connObj;
+}
+
+void free_object_conn_s(lwm2m_object_t * objectP)
+{
+    lwm2m_free(objectP->userData);
+    lwm2m_list_free(objectP->instanceList);
+    lwm2m_free(objectP);
 }

--- a/tests/client/object_device.c
+++ b/tests/client/object_device.c
@@ -521,19 +521,6 @@ static uint8_t prv_device_execute(uint16_t instanceId,
     }
 }
 
-static void prv_device_close(lwm2m_object_t * objectP) {
-    if (NULL != objectP->userData)
-    {
-        lwm2m_free(objectP->userData);
-        objectP->userData = NULL;
-    }
-    if (NULL != objectP->instanceList)
-    {
-        lwm2m_free(objectP->instanceList);
-        objectP->instanceList = NULL;
-    }
-}
-
 void display_device_object(lwm2m_object_t * object)
 {
 #ifdef WITH_LOGS
@@ -589,7 +576,6 @@ lwm2m_object_t * get_object_device()
         deviceObj->readFunc    = prv_device_read;
         deviceObj->writeFunc   = prv_device_write;
         deviceObj->executeFunc = prv_device_execute;
-        deviceObj->closeFunc = prv_device_close;
         deviceObj->userData = lwm2m_malloc(sizeof(device_data_t));
 
         /*
@@ -611,6 +597,22 @@ lwm2m_object_t * get_object_device()
     }
 
     return deviceObj;
+}
+
+void free_object_device(lwm2m_object_t * objectP)
+{
+    if (NULL != objectP->userData)
+    {
+        lwm2m_free(objectP->userData);
+        objectP->userData = NULL;
+    }
+    if (NULL != objectP->instanceList)
+    {
+        lwm2m_free(objectP->instanceList);
+        objectP->instanceList = NULL;
+    }
+
+    lwm2m_free(objectP);
 }
 
 uint8_t device_change(lwm2m_data_t * dataArray,

--- a/tests/client/object_firmware.c
+++ b/tests/client/object_firmware.c
@@ -226,19 +226,6 @@ static uint8_t prv_firmware_execute(uint16_t instanceId,
     }
 }
 
-static void prv_firmware_close(lwm2m_object_t * objectP) {
-    if (NULL != objectP->userData)
-    {
-        lwm2m_free(objectP->userData);
-        objectP->userData = NULL;
-    }
-    if (NULL != objectP->instanceList)
-    {
-        lwm2m_free(objectP->instanceList);
-        objectP->instanceList = NULL;
-    }
-}
-
 void display_firmware_object(lwm2m_object_t * object)
 {
 #ifdef WITH_LOGS
@@ -294,7 +281,6 @@ lwm2m_object_t * get_object_firmware(void)
         firmwareObj->readFunc    = prv_firmware_read;
         firmwareObj->writeFunc   = prv_firmware_write;
         firmwareObj->executeFunc = prv_firmware_execute;
-        firmwareObj->closeFunc   = prv_firmware_close;
         firmwareObj->userData    = lwm2m_malloc(sizeof(firmware_data_t));
 
         /*
@@ -315,3 +301,19 @@ lwm2m_object_t * get_object_firmware(void)
 
     return firmwareObj;
 }
+
+void free_object_firmware(lwm2m_object_t * objectP)
+{
+    if (NULL != objectP->userData)
+    {
+        lwm2m_free(objectP->userData);
+        objectP->userData = NULL;
+    }
+    if (NULL != objectP->instanceList)
+    {
+        lwm2m_free(objectP->instanceList);
+        objectP->instanceList = NULL;
+    }
+    lwm2m_free(objectP);
+}
+

--- a/tests/client/object_location.c
+++ b/tests/client/object_location.c
@@ -205,12 +205,6 @@ void display_location_object(lwm2m_object_t * object)
 #endif
 }
 
-static void prv_location_close(lwm2m_object_t * object)
-{
-    lwm2m_list_free(object->instanceList);
-    lwm2m_free(object->userData);
-}
-
 /**
   * Convenience function to set the velocity attributes.
   * see 3GPP TS 23.032 V11.0.0(2012-09) page 23,24.
@@ -302,7 +296,6 @@ lwm2m_object_t * get_object_location(void)
         // In fact the library don't need to know the resources of the object, only the server does.
         //
         locationObj->readFunc    = prv_location_read;
-        locationObj->closeFunc   = prv_location_close;
         locationObj->userData    = lwm2m_malloc(sizeof(location_data_t));
 
         // initialize private data structure containing the needed variables
@@ -325,4 +318,12 @@ lwm2m_object_t * get_object_location(void)
     
     return locationObj;
 }
+
+void free_object_location(lwm2m_object_t * object)
+{
+    lwm2m_list_free(object->instanceList);
+    lwm2m_free(object->userData);
+    lwm2m_free(object);
+}
+
 #endif  //LWM2M_CLIENT_MODE

--- a/tests/client/object_security.c
+++ b/tests/client/object_security.c
@@ -397,20 +397,6 @@ static uint8_t prv_security_create(uint16_t instanceId,
 }
 #endif
 
-static void prv_security_close(lwm2m_object_t * objectP)
-{
-    while (objectP->instanceList != NULL)
-    {
-        security_instance_t * securityInstance = (security_instance_t *)objectP->instanceList;
-        objectP->instanceList = objectP->instanceList->next;
-        if (NULL != securityInstance->uri)
-        {
-            lwm2m_free(securityInstance->uri);
-        }
-        lwm2m_free(securityInstance);
-    }
-}
-
 void copy_security_object(lwm2m_object_t * objectDest, lwm2m_object_t * objectSrc)
 {
     memcpy(objectDest, objectSrc, sizeof(lwm2m_object_t));
@@ -457,7 +443,9 @@ void display_security_object(lwm2m_object_t * object)
 #endif
 }
 
-lwm2m_object_t * get_security_object(int serverId, const char* serverUri, bool isBootstrap)
+lwm2m_object_t * get_security_object(int serverId,
+                                     const char* serverUri,
+                                     bool isBootstrap)
 {
     lwm2m_object_t * securityObj;
 
@@ -495,10 +483,24 @@ lwm2m_object_t * get_security_object(int serverId, const char* serverUri, bool i
         securityObj->createFunc = prv_security_create;
         securityObj->deleteFunc = prv_security_delete;
 #endif
-        securityObj->closeFunc = prv_security_close;
     }
 
     return securityObj;
+}
+
+void free_security_object(lwm2m_object_t * objectP)
+{
+    while (objectP->instanceList != NULL)
+    {
+        security_instance_t * securityInstance = (security_instance_t *)objectP->instanceList;
+        objectP->instanceList = objectP->instanceList->next;
+        if (NULL != securityInstance->uri)
+        {
+            lwm2m_free(securityInstance->uri);
+        }
+        lwm2m_free(securityInstance);
+    }
+    lwm2m_free(objectP);
 }
 
 char * get_server_uri(lwm2m_object_t * objectP,

--- a/tests/client/object_server.c
+++ b/tests/client/object_server.c
@@ -364,15 +364,6 @@ static uint8_t prv_server_create(uint16_t instanceId,
     return result;
 }
 
-static void prv_server_close(lwm2m_object_t * object) {
-    while (object->instanceList != NULL)
-    {
-        server_instance_t * serverInstance = (server_instance_t *)object->instanceList;
-        object->instanceList = object->instanceList->next;
-        lwm2m_free(serverInstance);
-    }
-}
-
 void copy_server_object(lwm2m_object_t * objectDest, lwm2m_object_t * objectSrc)
 {
     memcpy(objectDest, objectSrc, sizeof(lwm2m_object_t));
@@ -419,8 +410,10 @@ void display_server_object(lwm2m_object_t * object)
 #endif
 }
 
-lwm2m_object_t * get_server_object(int serverId, const char* binding,
-                                   int lifetime, bool storing)
+lwm2m_object_t * get_server_object(int serverId,
+                                   const char* binding,
+                                   int lifetime,
+                                   bool storing)
 {
     lwm2m_object_t * serverObj;
 
@@ -455,8 +448,18 @@ lwm2m_object_t * get_server_object(int serverId, const char* binding,
         serverObj->createFunc = prv_server_create;
         serverObj->deleteFunc = prv_server_delete;
         serverObj->executeFunc = prv_server_execute;
-        serverObj->closeFunc = prv_server_close;
     }
 
     return serverObj;
+}
+
+void free_server_object(lwm2m_object_t * object)
+{
+    while (object->instanceList != NULL)
+    {
+        server_instance_t * serverInstance = (server_instance_t *)object->instanceList;
+        object->instanceList = object->instanceList->next;
+        lwm2m_free(serverInstance);
+    }
+    lwm2m_free(object);
 }

--- a/tests/client/test_object.c
+++ b/tests/client/test_object.c
@@ -286,16 +286,6 @@ static uint8_t prv_exec(uint16_t instanceId,
     }
 }
 
-static void prv_test_close(lwm2m_object_t * object)
-{
-    LWM2M_LIST_FREE(object->instanceList);
-    if (object->userData != NULL)
-    {
-        lwm2m_free(object->userData);
-        object->userData = NULL;
-    }
-}
-
 void display_test_object(lwm2m_object_t * object)
 {
 #ifdef WITH_LOGS
@@ -347,8 +337,19 @@ lwm2m_object_t * get_test_object(void)
         testObj->executeFunc = prv_exec;
         testObj->createFunc = prv_create;
         testObj->deleteFunc = prv_delete;
-        testObj->closeFunc = prv_test_close;
     }
 
     return testObj;
 }
+
+void free_test_object(lwm2m_object_t * object)
+{
+    LWM2M_LIST_FREE(object->instanceList);
+    if (object->userData != NULL)
+    {
+        lwm2m_free(object->userData);
+        object->userData = NULL;
+    }
+    lwm2m_free(object);
+}
+

--- a/tests/lightclient/lightclient.c
+++ b/tests/lightclient/lightclient.c
@@ -73,11 +73,14 @@
 #include <signal.h>
 
 extern lwm2m_object_t * get_object_device(void);
+extern void free_object_device(lwm2m_object_t * objectP);
 extern lwm2m_object_t * get_server_object(void);
+extern void free_server_object(lwm2m_object_t * object);
 extern lwm2m_object_t * get_security_object(void);
+extern void free_security_object(lwm2m_object_t * objectP);
 extern char * get_server_uri(lwm2m_object_t * objectP, uint16_t secObjInstID);
 extern lwm2m_object_t * get_test_object(void);
-
+extern void free_test_object(lwm2m_object_t * object);
 
 #define MAX_PACKET_SIZE 1024
 
@@ -398,6 +401,11 @@ int main(int argc, char *argv[])
     lwm2m_close(lwm2mH);
     close(data.sock);
     connection_free(data.connList);
+
+    free_security_object(objArray[0]);
+    free_server_object(objArray[1]);
+    free_object_device(objArray[2]);
+    free_test_object(objArray[3]);
 
     fprintf(stdout, "\r\n\n");
 

--- a/tests/lightclient/object_device.c
+++ b/tests/lightclient/object_device.c
@@ -198,10 +198,6 @@ static uint8_t prv_device_execute(uint16_t instanceId,
     return COAP_405_METHOD_NOT_ALLOWED;
 }
 
-static void prv_device_close(lwm2m_object_t * objectP)
-{
-}
-
 lwm2m_object_t * get_object_device()
 {
     /*
@@ -247,4 +243,20 @@ lwm2m_object_t * get_object_device()
      }
 
     return deviceObj;
+}
+
+void free_object_device(lwm2m_object_t * objectP)
+{
+    if (NULL != objectP->userData)
+    {
+        lwm2m_free(objectP->userData);
+        objectP->userData = NULL;
+    }
+    if (NULL != objectP->instanceList)
+    {
+        lwm2m_free(objectP->instanceList);
+        objectP->instanceList = NULL;
+    }
+
+    lwm2m_free(objectP);
 }

--- a/tests/lightclient/object_security.c
+++ b/tests/lightclient/object_security.c
@@ -195,20 +195,6 @@ static uint8_t prv_security_read(uint16_t instanceId,
     return result;
 }
 
-static void prv_security_close(lwm2m_object_t * objectP)
-{
-    while (objectP->instanceList != NULL)
-    {
-        security_instance_t * securityInstance = (security_instance_t *)objectP->instanceList;
-        objectP->instanceList = objectP->instanceList->next;
-        if (NULL != securityInstance->uri)
-        {
-            lwm2m_free(securityInstance->uri);
-        }
-        lwm2m_free(securityInstance);
-    }
-}
-
 lwm2m_object_t * get_security_object()
 {
     lwm2m_object_t * securityObj;
@@ -241,10 +227,24 @@ lwm2m_object_t * get_security_object()
         securityObj->instanceList = LWM2M_LIST_ADD(securityObj->instanceList, targetP);
 
         securityObj->readFunc = prv_security_read;
-        securityObj->closeFunc = prv_security_close;
     }
 
     return securityObj;
+}
+
+void free_security_object(lwm2m_object_t * objectP)
+{
+    while (objectP->instanceList != NULL)
+    {
+        security_instance_t * securityInstance = (security_instance_t *)objectP->instanceList;
+        objectP->instanceList = objectP->instanceList->next;
+        if (NULL != securityInstance->uri)
+        {
+            lwm2m_free(securityInstance->uri);
+        }
+        lwm2m_free(securityInstance);
+    }
+    lwm2m_free(objectP);
 }
 
 char * get_server_uri(lwm2m_object_t * objectP,

--- a/tests/lightclient/object_server.c
+++ b/tests/lightclient/object_server.c
@@ -321,16 +321,6 @@ static uint8_t prv_server_create(uint16_t instanceId,
     return result;
 }
 
-static void prv_server_close(lwm2m_object_t * object)
-{
-    while (object->instanceList != NULL)
-    {
-        server_instance_t * serverInstance = (server_instance_t *)object->instanceList;
-        object->instanceList = object->instanceList->next;
-        lwm2m_free(serverInstance);
-    }
-}
-
 lwm2m_object_t * get_server_object()
 {
     lwm2m_object_t * serverObj;
@@ -366,8 +356,18 @@ lwm2m_object_t * get_server_object()
         serverObj->createFunc = prv_server_create;
         serverObj->deleteFunc = prv_server_delete;
         serverObj->executeFunc = prv_server_execute;
-        serverObj->closeFunc = prv_server_close;
     }
 
     return serverObj;
+}
+
+void free_server_object(lwm2m_object_t * object)
+{
+    while (object->instanceList != NULL)
+    {
+        server_instance_t * serverInstance = (server_instance_t *)object->instanceList;
+        object->instanceList = object->instanceList->next;
+        lwm2m_free(serverInstance);
+    }
+    lwm2m_free(object);
 }

--- a/tests/lightclient/test_object.c
+++ b/tests/lightclient/test_object.c
@@ -283,16 +283,6 @@ static uint8_t prv_exec(uint16_t instanceId,
     }
 }
 
-static void prv_test_close(lwm2m_object_t * object)
-{
-    LWM2M_LIST_FREE(object->instanceList);
-    if (object->userData != NULL)
-    {
-        lwm2m_free(object->userData);
-        object->userData = NULL;
-    }
-}
-
 lwm2m_object_t * get_test_object(void)
 {
     lwm2m_object_t * testObj;
@@ -329,8 +319,18 @@ lwm2m_object_t * get_test_object(void)
         testObj->executeFunc = prv_exec;
         testObj->createFunc = prv_create;
         testObj->deleteFunc = prv_delete;
-        testObj->closeFunc = prv_test_close;
     }
 
     return testObj;
+}
+
+void free_test_object(lwm2m_object_t * object)
+{
+    LWM2M_LIST_FREE(object->instanceList);
+    if (object->userData != NULL)
+    {
+        lwm2m_free(object->userData);
+        object->userData = NULL;
+    }
+    lwm2m_free(object);
 }

--- a/tests/secureclient/object_device.c
+++ b/tests/secureclient/object_device.c
@@ -198,10 +198,6 @@ static uint8_t prv_device_execute(uint16_t instanceId,
     return COAP_405_METHOD_NOT_ALLOWED;
 }
 
-static void prv_device_close(lwm2m_object_t * objectP)
-{
-}
-
 lwm2m_object_t * get_object_device()
 {
     /*

--- a/tests/secureclient/object_security.c
+++ b/tests/secureclient/object_security.c
@@ -438,20 +438,6 @@ static uint8_t prv_security_create(uint16_t instanceId,
     return result;
 }
 
-static void prv_security_close(lwm2m_object_t * objectP)
-{
-    while (objectP->instanceList != NULL)
-    {
-        security_instance_t * securityInstance = (security_instance_t *)objectP->instanceList;
-        objectP->instanceList = objectP->instanceList->next;
-        if (NULL != securityInstance->uri)
-        {
-            lwm2m_free(securityInstance->uri);
-        }
-        lwm2m_free(securityInstance);
-    }
-}
-
 lwm2m_object_t * get_security_object(int shortId, char* url, char * bsPskId, char * psk, uint16_t pskLen, bool bootstrap)
 {
     lwm2m_object_t * securityObj;
@@ -498,8 +484,22 @@ lwm2m_object_t * get_security_object(int shortId, char* url, char * bsPskId, cha
     securityObj->instanceList = LWM2M_LIST_ADD(securityObj->instanceList, targetP);
 
     securityObj->readFunc = prv_security_read;
-    securityObj->closeFunc = prv_security_close;
     securityObj->writeFunc = prv_security_write;
     securityObj->createFunc = prv_security_create;
     return securityObj;
+}
+
+void free_security_object(lwm2m_object_t * objectP)
+{
+    while (objectP->instanceList != NULL)
+    {
+        security_instance_t * securityInstance = (security_instance_t *)objectP->instanceList;
+        objectP->instanceList = objectP->instanceList->next;
+        if (NULL != securityInstance->uri)
+        {
+            lwm2m_free(securityInstance->uri);
+        }
+        lwm2m_free(securityInstance);
+    }
+    lwm2m_free(objectP);
 }

--- a/tests/secureclient/object_server.c
+++ b/tests/secureclient/object_server.c
@@ -341,16 +341,6 @@ static uint8_t prv_server_create(uint16_t instanceId,
     return result;
 }
 
-static void prv_server_close(lwm2m_object_t * object)
-{
-    while (object->instanceList != NULL)
-    {
-        server_instance_t * serverInstance = (server_instance_t *)object->instanceList;
-        object->instanceList = object->instanceList->next;
-        lwm2m_free(serverInstance);
-    }
-}
-
 lwm2m_object_t * get_server_object_with_instance(server_instance_t * firstInstance)
 {
     lwm2m_object_t * serverObj;
@@ -370,7 +360,6 @@ lwm2m_object_t * get_server_object_with_instance(server_instance_t * firstInstan
     serverObj->createFunc = prv_server_create;
     serverObj->deleteFunc = prv_server_delete;
     serverObj->executeFunc = prv_server_execute;
-    serverObj->closeFunc = prv_server_close;
     if (firstInstance != NULL)
         serverObj->instanceList = LWM2M_LIST_ADD(serverObj->instanceList, firstInstance);
 
@@ -404,4 +393,15 @@ lwm2m_object_t * get_server_object_with_default_instance(int shortID)
         lwm2m_free(serverInstance);
 
     return serverObj;
+}
+
+void free_server_object(lwm2m_object_t * object)
+{
+    while (object->instanceList != NULL)
+    {
+        server_instance_t * serverInstance = (server_instance_t *)object->instanceList;
+        object->instanceList = object->instanceList->next;
+        lwm2m_free(serverInstance);
+    }
+    lwm2m_free(object);
 }

--- a/tests/secureclient/secureclient.c
+++ b/tests/secureclient/secureclient.c
@@ -75,8 +75,11 @@
 extern lwm2m_object_t * get_object_device(void);
 extern lwm2m_object_t * get_empty_server_object(void);
 extern lwm2m_object_t * get_server_object_with_default_instance(int shortId);
+extern void free_server_object(lwm2m_object_t * object);
 extern lwm2m_object_t * get_security_object(int shortId, char* url, char * bsPskId, char * psk, uint16_t pskLen, bool bootstrap);
+extern void free_security_object(lwm2m_object_t * objectP);
 extern lwm2m_object_t * get_test_object(void);
+extern void free_test_object(lwm2m_object_t * object);
 
 
 #define MAX_PACKET_SIZE 1024
@@ -414,6 +417,11 @@ int main(int argc, char *argv[])
     lwm2m_close(lwm2mH);
     close(data.sock);
     connection_free(data.connList);
+
+    free_security_object(objArray[0]);
+    free_server_object(objArray[1]);
+    lwm2m_free(objArray[2]);
+    free_test_object(objArray[3]);
 
     fprintf(stdout, "\r\n\n");
 

--- a/tests/secureclient/test_object.c
+++ b/tests/secureclient/test_object.c
@@ -283,16 +283,6 @@ static uint8_t prv_exec(uint16_t instanceId,
     }
 }
 
-static void prv_test_close(lwm2m_object_t * object)
-{
-    LWM2M_LIST_FREE(object->instanceList);
-    if (object->userData != NULL)
-    {
-        lwm2m_free(object->userData);
-        object->userData = NULL;
-    }
-}
-
 lwm2m_object_t * get_test_object(void)
 {
     lwm2m_object_t * testObj;
@@ -329,8 +319,18 @@ lwm2m_object_t * get_test_object(void)
         testObj->executeFunc = prv_exec;
         testObj->createFunc = prv_create;
         testObj->deleteFunc = prv_delete;
-        testObj->closeFunc = prv_test_close;
     }
 
     return testObj;
+}
+
+void free_test_object(lwm2m_object_t * object)
+{
+    LWM2M_LIST_FREE(object->instanceList);
+    if (object->userData != NULL)
+    {
+        lwm2m_free(object->userData);
+        object->userData = NULL;
+    }
+    lwm2m_free(object);
 }

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -750,12 +750,12 @@ int main(int argc, char *argv[])
                 if (numBytes > 1)
                 {
                     buffer[numBytes] = 0;
-                    fprintf(stdout, "STDIN %d bytes '%s'\r\n> ", numBytes, buffer);
                     handle_command(commands, (char*)buffer);
+                    fprintf(stdout, "\r\n");
                 }
                 if (g_quit == 0)
                 {
-                    fprintf(stdout, "\r\n> ");
+                    fprintf(stdout, "> ");
                     fflush(stdout);
                 }
                 else


### PR DESCRIPTION
As the client application is creating the objects, the core should not be in charge of freeing them.

Signed-off-by: David Navarro <david.navarro@intel.com>