### PR TITLE
API Change: Add a media type parameter for server side APIs.

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -352,6 +352,7 @@ int lwm2m_bootstrap_delete(lwm2m_context_t * contextP,
 int lwm2m_bootstrap_write(lwm2m_context_t * contextP,
                           void * sessionH,
                           lwm2m_uri_t * uriP,
+                          lwm2m_media_type_t format,
                           uint8_t * buffer,
                           size_t length)
 {
@@ -368,7 +369,7 @@ int lwm2m_bootstrap_write(lwm2m_context_t * contextP,
     transaction = transaction_new(COAP_TYPE_CON, COAP_PUT, NULL, uriP, contextP->nextMID++, 4, NULL, ENDPOINT_UNKNOWN, sessionH);
     if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
 
-    coap_set_header_content_type(transaction->message, LWM2M_CONTENT_TLV);
+    coap_set_header_content_type(transaction->message, format);
     coap_set_payload(transaction->message, buffer, length);
 
     dataP = (bs_data_t *)lwm2m_malloc(sizeof(bs_data_t));

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -628,9 +628,9 @@ void lwm2m_set_monitoring_callback(lwm2m_context_t * contextP, lwm2m_result_call
 
 // Device Management APIs
 int lwm2m_dm_read(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_result_callback_t callback, void * userData);
-int lwm2m_dm_write(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
-int lwm2m_dm_execute(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
-int lwm2m_dm_create(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
+int lwm2m_dm_write(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
+int lwm2m_dm_execute(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
+int lwm2m_dm_create(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
 int lwm2m_dm_delete(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_result_callback_t callback, void * userData);
 
 // Information Reporting APIs
@@ -646,7 +646,7 @@ void lwm2m_set_bootstrap_callback(lwm2m_context_t * contextP, lwm2m_bootstrap_ca
 // Boostrap Interface APIs
 // if uriP is nil, a "Delete /" is sent to the client
 int lwm2m_bootstrap_delete(lwm2m_context_t * contextP, void * sessionH, lwm2m_uri_t * uriP);
-int lwm2m_bootstrap_write(lwm2m_context_t * contextP, void * sessionH, lwm2m_uri_t * uriP, uint8_t * buffer, size_t length);
+int lwm2m_bootstrap_write(lwm2m_context_t * contextP, void * sessionH, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 int lwm2m_bootstrap_finish(lwm2m_context_t * contextP, void * sessionH);
 
 #endif

--- a/core/management.c
+++ b/core/management.c
@@ -413,6 +413,7 @@ int lwm2m_dm_read(lwm2m_context_t * contextP,
 int lwm2m_dm_write(lwm2m_context_t * contextP,
                    uint16_t clientID,
                    lwm2m_uri_t * uriP,
+                   lwm2m_media_type_t format,
                    uint8_t * buffer,
                    int length,
                    lwm2m_result_callback_t callback,
@@ -428,14 +429,14 @@ int lwm2m_dm_write(lwm2m_context_t * contextP,
     {
         return prv_make_operation(contextP, clientID, uriP,
                                   COAP_PUT,
-                                  LWM2M_CONTENT_TEXT, buffer, length,
+                                  format, buffer, length,
                                   callback, userData);
     }
     else
     {
         return prv_make_operation(contextP, clientID, uriP,
                                   COAP_POST,
-                                  LWM2M_CONTENT_TLV, buffer, length,
+                                  format, buffer, length,
                                   callback, userData);
     }
 }
@@ -443,6 +444,7 @@ int lwm2m_dm_write(lwm2m_context_t * contextP,
 int lwm2m_dm_execute(lwm2m_context_t * contextP,
                      uint16_t clientID,
                      lwm2m_uri_t * uriP,
+                     lwm2m_media_type_t format,
                      uint8_t * buffer,
                      int length,
                      lwm2m_result_callback_t callback,
@@ -455,13 +457,14 @@ int lwm2m_dm_execute(lwm2m_context_t * contextP,
 
     return prv_make_operation(contextP, clientID, uriP,
                               COAP_POST,
-                              LWM2M_CONTENT_TEXT, buffer, length,
+                              format, buffer, length,
                               callback, userData);
 }
 
 int lwm2m_dm_create(lwm2m_context_t * contextP,
                     uint16_t clientID,
                     lwm2m_uri_t * uriP,
+                    lwm2m_media_type_t format,
                     uint8_t * buffer,
                     int length,
                     lwm2m_result_callback_t callback,
@@ -475,7 +478,7 @@ int lwm2m_dm_create(lwm2m_context_t * contextP,
 
     return prv_make_operation(contextP, clientID, uriP,
                               COAP_POST,
-                              LWM2M_CONTENT_TLV, buffer, length,
+                              format, buffer, length,
                               callback, userData);
 }
 

--- a/tests/bootstrap_server/bootstrap_server.c
+++ b/tests/bootstrap_server/bootstrap_server.c
@@ -228,7 +228,7 @@ static void prv_send_command(internal_data_t * dataP,
         uri.objectId = LWM2M_SECURITY_OBJECT_ID;
         uri.instanceId = endP->cmdList->serverId;
 
-        res = lwm2m_bootstrap_write(dataP->lwm2mH, endP->handle, &uri, serverP->securityData, serverP->securityLen);
+        res = lwm2m_bootstrap_write(dataP->lwm2mH, endP->handle, &uri, LWM2M_CONTENT_TLV, serverP->securityData, serverP->securityLen);
     }
         break;
 
@@ -249,7 +249,7 @@ static void prv_send_command(internal_data_t * dataP,
         uri.objectId = LWM2M_SERVER_OBJECT_ID;
         uri.instanceId = endP->cmdList->serverId;
 
-        res = lwm2m_bootstrap_write(dataP->lwm2mH, endP->handle, &uri, serverP->serverData, serverP->serverLen);
+        res = lwm2m_bootstrap_write(dataP->lwm2mH, endP->handle, &uri, LWM2M_CONTENT_TLV, serverP->serverData, serverP->serverLen);
     }
         break;
 

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -300,7 +300,7 @@ static void prv_write_client(char * buffer,
 
     if (!check_end_of_args(end)) goto syntax_error;
 
-    result = lwm2m_dm_write(lwm2mH, clientId, &uri, (uint8_t *)buffer, end - buffer, prv_result_callback, NULL);
+    result = lwm2m_dm_write(lwm2mH, clientId, &uri, LWM2M_CONTENT_TEXT, (uint8_t *)buffer, end - buffer, prv_result_callback, NULL);
 
     if (result == 0)
     {
@@ -340,13 +340,13 @@ static void prv_exec_client(char * buffer,
 
     if (buffer[0] == 0)
     {
-        result = lwm2m_dm_execute(lwm2mH, clientId, &uri, NULL, 0, prv_result_callback, NULL);
+        result = lwm2m_dm_execute(lwm2mH, clientId, &uri, 0, NULL, 0, prv_result_callback, NULL);
     }
     else
     {
         if (!check_end_of_args(end)) goto syntax_error;
 
-        result = lwm2m_dm_execute(lwm2mH, clientId, &uri, (uint8_t *)buffer, end - buffer, prv_result_callback, NULL);
+        result = lwm2m_dm_execute(lwm2mH, clientId, &uri, LWM2M_CONTENT_TEXT, (uint8_t *)buffer, end - buffer, prv_result_callback, NULL);
     }
 
     if (result == 0)
@@ -374,7 +374,7 @@ static void prv_create_client(char * buffer,
     int64_t value;
     uint8_t temp_buffer[MAX_PACKET_SIZE];
     int temp_length = 0;
-
+    lwm2m_media_type_t format = LWM2M_CONTENT_TEXT;
 
     //Get Client ID
     result = prv_read_id(buffer, &clientId);
@@ -401,11 +401,12 @@ static void prv_create_client(char * buffer,
     {
         result = lwm2m_PlainTextToInt64((uint8_t *)buffer, end - buffer, &value);
         temp_length = lwm2m_intToTLV(LWM2M_TYPE_RESOURCE, value, (uint16_t) 1, temp_buffer, MAX_PACKET_SIZE);
+        format = LWM2M_CONTENT_TLV;
     }
    /* End Client dependent part*/
 
     //Create
-    result = lwm2m_dm_create(lwm2mH, clientId,&uri, temp_buffer, temp_length, prv_result_callback, NULL);
+    result = lwm2m_dm_create(lwm2mH, clientId, &uri, format, temp_buffer, temp_length, prv_result_callback, NULL);
 
     if (result == 0)
     {


### PR DESCRIPTION
This parameter specifies the type of the buffer past to lwm2m_dm_write(), lwm2m_dm_execute(), lwm2m_dm_create() and lwm2m_bootstrap_write().
There is no check on the validity of the specified type or the buffer content.

Signed-off-by: David Navarro <david.navarro@intel.com>