### PR TITLE
Rework of the client start sequence

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -560,7 +560,7 @@ int lwm2m_bootstrap_finish(lwm2m_context_t * contextP,
     lwm2m_transaction_t * transaction;
     bs_data_t * dataP;
 
-    transaction = transaction_new(COAP_TYPE_CON, COAP_PUT, NULL, NULL, contextP->nextMID++, 4, NULL, ENDPOINT_UNKNOWN, sessionH);
+    transaction = transaction_new(COAP_TYPE_CON, COAP_POST, NULL, NULL, contextP->nextMID++, 4, NULL, ENDPOINT_UNKNOWN, sessionH);
     if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
 
     coap_set_header_uri_path(transaction->message, "/"URI_BOOTSTRAP_SEGMENT);

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -24,7 +24,7 @@
 #include <stdio.h>
 
 #ifdef LWM2M_CLIENT_MODE
-#ifdef LWM2M_BOOTSTRAP_MODE
+#ifdef LWM2M_BOOTSTRAP
 
 #define PRV_QUERY_BUFFER_LENGTH 200
 

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -23,214 +23,377 @@
 #include <string.h>
 #include <stdio.h>
 
-#ifdef LWM2M_BOOTSTRAP
 #ifdef LWM2M_CLIENT_MODE
 
 #define PRV_QUERY_BUFFER_LENGTH 200
 
-static void prv_handleBootstrapReply(lwm2m_transaction_t * transaction, void * message)
+static void bootstrap_failed(lwm2m_server_t * bootstrapServer)
 {
-    LOG("[BOOTSTRAP] Handling bootstrap reply...\r\n");
-    lwm2m_context_t * context = (lwm2m_context_t *)transaction->userData;
-    coap_packet_t * coapMessage = (coap_packet_t *)message;
-    if (NULL != coapMessage && COAP_TYPE_RST != coapMessage->type)
+    LOG("[BOOTSTRAP] Bootstrap failed\r\n");
+
+    bootstrapServer->status = STATE_BS_FAILED;
+}
+
+static void handle_bootstrap_response(lwm2m_server_t * bootstrapServer,
+                                      coap_packet_t * message)
+{
+    if (COAP_204_CHANGED == message->code)
     {
-        handle_bootstrap_response(context, coapMessage, NULL);
+        LOG("[BOOTSTRAP] Received ACK/2.04, Bootstrap pending, waiting for DEL/PUT from BS server...\r\n");
+        bootstrapServer->status = STATE_BS_PENDING;
     }
     else
     {
-        bootstrap_failed(context);
+        bootstrap_failed(bootstrapServer);
+    }
+}
+
+static void prv_handleBootstrapReply(lwm2m_transaction_t * transaction,
+                                     void * message)
+{
+    lwm2m_server_t * bootstrapServer = (lwm2m_server_t *)transaction->userData;
+    coap_packet_t * coapMessage = (coap_packet_t *)message;
+
+    LOG("[BOOTSTRAP] Handling bootstrap reply...\r\n");
+
+    if (bootstrapServer->status == STATE_BS_INITIATED)
+    {
+        if (NULL != coapMessage && COAP_TYPE_RST != coapMessage->type)
+        {
+            handle_bootstrap_response(bootstrapServer, coapMessage);
+        }
+        else
+        {
+            bootstrap_failed(bootstrapServer);
+        }
     }
 }
 
 // start a device initiated bootstrap
-int bootstrap_initiating_request(lwm2m_context_t * context)
+static void bootstrap_initiating_request(lwm2m_context_t * context,
+                                         lwm2m_server_t * bootstrapServer)
 {
     char query[PRV_QUERY_BUFFER_LENGTH];
     int query_length = 0;
-    lwm2m_transaction_t * transaction = NULL;
 
     query_length = snprintf(query, sizeof(query), "?ep=%s", context->endpointName);
     if (query_length <= 1)
     {
-        return INTERNAL_SERVER_ERROR_5_00;
+        bootstrapServer->status = STATE_BS_FAILED;
+        return;
     }
 
-    // find the first bootstrap server
-    lwm2m_server_t * bootstrapServer = context->bootstrapServerList;
-    while (bootstrapServer != NULL)
+    if (bootstrapServer->sessionH == NULL)
     {
-        if (bootstrapServer->sessionH == NULL)
-        {
-            bootstrapServer->sessionH = context->connectCallback(bootstrapServer->secObjInstID, context->userData);
-        }
-        if (bootstrapServer->sessionH != NULL)
-        {
-            LOG("[BOOTSTRAP] Bootstrap session starting...\r\n");
-            transaction = transaction_new(COAP_TYPE_CON, COAP_POST, NULL, NULL, context->nextMID++, 4, NULL, ENDPOINT_SERVER, (void *)bootstrapServer);
-            if (transaction == NULL)
-            {
-                return INTERNAL_SERVER_ERROR_5_00;
-            }
-            coap_set_header_uri_path(transaction->message, "/"URI_BOOTSTRAP_SEGMENT);
-            coap_set_header_uri_query(transaction->message, query);
-            transaction->callback = prv_handleBootstrapReply;
-            transaction->userData = (void *)context;
-            context->transactionList = (lwm2m_transaction_t *)LWM2M_LIST_ADD(context->transactionList, transaction);
-            if (transaction_send(context, transaction) == 0)
-            {
-                LOG("[BOOTSTRAP] DI bootstrap requested to BS server\r\n");
-                context->bsState = BOOTSTRAP_INITIATED;
-                reset_bootstrap_timer(context);
-            }
-        }
-        else
-        {
-            LOG("No bootstrap session handler found\r\n");
-        }
-        bootstrapServer = bootstrapServer->next;
+        bootstrapServer->sessionH = context->connectCallback(bootstrapServer->secObjInstID, context->userData);
     }
-    return NO_ERROR;
-}
 
-void handle_bootstrap_response(lwm2m_context_t * context,
-        coap_packet_t * message,
-        void * fromSessionH)
-{
-    if (COAP_204_CHANGED == message->code)
+    if (bootstrapServer->sessionH != NULL)
     {
-        context->bsState = BOOTSTRAP_PENDING;
-        LOG("[BOOTSTRAP] Received ACK/2.04, Bootstrap pending, waiting for DEL/PUT from BS server...\r\n");
-        reset_bootstrap_timer(context);
+        lwm2m_transaction_t * transaction = NULL;
+
+        LOG("[BOOTSTRAP] Bootstrap session starting...\r\n");
+
+        transaction = transaction_new(COAP_TYPE_CON, COAP_POST, NULL, NULL, context->nextMID++, 4, NULL, ENDPOINT_SERVER, (void *)bootstrapServer);
+        if (transaction == NULL)
+        {
+            bootstrapServer->status = STATE_BS_FAILED;
+            return;
+        }
+
+        coap_set_header_uri_path(transaction->message, "/"URI_BOOTSTRAP_SEGMENT);
+        coap_set_header_uri_query(transaction->message, query);
+        transaction->callback = prv_handleBootstrapReply;
+        transaction->userData = (void *)bootstrapServer;
+        context->transactionList = (lwm2m_transaction_t *)LWM2M_LIST_ADD(context->transactionList, transaction);
+        if (transaction_send(context, transaction) == 0)
+        {
+            LOG("[BOOTSTRAP] CI bootstrap requested to BS server\r\n");
+            bootstrapServer->status = STATE_BS_INITIATED;
+        }
     }
     else
     {
-        bootstrap_failed(context);
+        LOG("No bootstrap session handler found\r\n");
+        bootstrapServer->status = STATE_BS_FAILED;
     }
 }
 
-void bootstrap_failed(lwm2m_context_t * context)
+void bootstrap_step(lwm2m_context_t * contextP,
+                    uint32_t currentTime,
+                    time_t* timeoutP)
 {
-    reset_bootstrap_timer(context);
-    context->bsState = BOOTSTRAP_FAILED;
-    LOG("[BOOTSTRAP] Bootstrap failed\r\n");
-}
+    lwm2m_server_t * targetP;
 
-void reset_bootstrap_timer(lwm2m_context_t * context)
-{
-    context->bsStart = lwm2m_gettime();
-}
+    targetP = contextP->bootstrapServerList;
+    while (targetP != NULL)
+    {
+        switch (targetP->status)
+        {
+        case STATE_DEREGISTERED:
+            targetP->registration = currentTime + targetP->lifetime;
+            targetP->status = STATE_BS_HOLD_OFF;
+            if (*timeoutP > targetP->lifetime)
+            {
+                *timeoutP = targetP->lifetime;
+            }
+            break;
 
-void update_bootstrap_state(lwm2m_context_t * context,
-        uint32_t currentTime,
-        time_t* timeoutP)
-{
-    if (context->bsState == BOOTSTRAP_REQUESTED)
-    {
-        context->bsState = BOOTSTRAP_CLIENT_HOLD_OFF;
-        context->bsStart = currentTime;
-        LOG("[BOOTSTRAP] Bootstrap requested at: %lu, now waiting during ClientHoldOffTime...\r\n",
-                (unsigned long)context->bsStart);
-    }
-    if (context->bsState == BOOTSTRAP_CLIENT_HOLD_OFF)
-    {
-        lwm2m_server_t * bootstrapServer = context->bootstrapServerList;
-        if (bootstrapServer != NULL)
-        {
-            // get ClientHoldOffTime from bootstrapServer->lifetime
-            // (see objects.c => object_getServers())
-            int32_t timeToBootstrap = (context->bsStart + bootstrapServer->lifetime) - currentTime;
-            LOG("[BOOTSTRAP] ClientHoldOffTime %ld\r\n", (long)timeToBootstrap);
-            if (0 >= timeToBootstrap)
+        case STATE_BS_HOLD_OFF:
+            if (targetP->registration <= currentTime)
             {
-                bootstrap_initiating_request(context);
+                bootstrap_initiating_request(contextP, targetP);
             }
-            else if (timeToBootstrap < *timeoutP)
+            else if (*timeoutP > targetP->registration - currentTime)
             {
-                *timeoutP = timeToBootstrap;
+                *timeoutP = targetP->registration - currentTime;
             }
+            break;
+
+        case STATE_BS_INITIATED:
+        case STATE_BS_PENDING:
+            // waiting
+            break;
+
+        case STATE_BS_FINISHED:
+            // do nothing
+            break;
+
+        case STATE_BS_FAILED:
+            // do nothing
+            break;
+
+        default:
+            break;
         }
-        else
-        {
-            bootstrap_failed(context);
-        }
-    }
-    if (context->bsState == BOOTSTRAP_PENDING)
-    {
-        // Use COAP_DEFAULT_MAX_AGE according proposal in
-        // https://github.com/OpenMobileAlliance/OMA-LwM2M-Public-Review/issues/35
-        int32_t timeToBootstrap = (context->bsStart + COAP_DEFAULT_MAX_AGE) - currentTime;
-        LOG("[BOOTSTRAP] Pending %ld\r\n", (long)timeToBootstrap);
-        if (0 >= timeToBootstrap)
-        {
-            // Time out and no error => bootstrap OK
-            // TODO: add smarter condition for bootstrap success:
-            // 1) security object contains at least one bootstrap server
-            // 2) there are coherent configurations for provisioned DM servers
-            // if these conditions are not met, then bootstrap has failed and previous security
-            // and server object configurations might be restored by client
-            LOG("\r\n[BOOTSTRAP] Bootstrap finished at: %lu (difftime: %lu s)\r\n",
-                    (unsigned long)currentTime, (unsigned long)(currentTime - context->bsStart));
-            context->bsState = BOOTSTRAP_FINISHED;
-            context->bsStart = currentTime;
-            *timeoutP = 1;
-        }
-        else if (timeToBootstrap < *timeoutP)
-        {
-            *timeoutP = timeToBootstrap;
-        }
-    }
-    else if (context->bsState == BOOTSTRAP_FINISHED)
-    {
-        context->bsStart = currentTime;
-        if (0 <= refresh_server_list(context))
-        {
-            context->bsState = BOOTSTRAPPED;
-        }
-        else
-        {
-            bootstrap_failed(context);
-        }
-        // during next step, lwm2m_update_registrations will connect the client to DM server
-    }
-    if (BOOTSTRAP_FAILED == context->bsState)
-    {
-        lwm2m_server_t * bootstrapServer = context->bootstrapServerList;
-        if (bootstrapServer != NULL)
-        {
-            // get ClientHoldOffTime from bootstrapServer->lifetime
-            // (see objects.c => object_getServers())
-            int32_t timeToBootstrap = (context->bsStart + bootstrapServer->lifetime) - currentTime;
-            LOG("[BOOTSTRAP] Bootstrap failed: %lu, now waiting during ClientHoldOffTime %ld ...\r\n",
-                    (unsigned long)context->bsStart, (long)timeToBootstrap);
-            if (0 >= timeToBootstrap)
-            {
-                context->bsState = NOT_BOOTSTRAPPED;
-                context->bsStart = currentTime;
-                LOG("[BOOTSTRAP] Bootstrap failed: retry ...\r\n");
-                *timeoutP = 1;
-            }
-            else if (timeToBootstrap < *timeoutP)
-            {
-                *timeoutP = timeToBootstrap;
-            }
-        }
+
+        targetP = targetP->next;
     }
 }
 
 coap_status_t handle_bootstrap_finish(lwm2m_context_t * context,
                                       void * fromSessionH)
 {
-    if (context->bsState == BOOTSTRAP_PENDING)
+    lwm2m_server_t * bootstrapServer;
+
+    bootstrapServer = utils_findBootstrapServer(context, fromSessionH);
+    if (bootstrapServer != NULL
+     && bootstrapServer->status == STATE_BS_PENDING)
     {
-        context->bsState = BOOTSTRAP_FINISHED;
+        bootstrapServer->status = STATE_BS_FINISHED;
         return COAP_204_CHANGED;
     }
 
     return COAP_IGNORE;
 }
-#endif
 
+/*
+ * Reset the bootstrap servers statuses
+ *
+ * TODO: handle LWM2M Servers the client is registered to ?
+ *
+ */
+void bootstrap_start(lwm2m_context_t * contextP)
+{
+    lwm2m_server_t * targetP;
+
+    targetP = contextP->bootstrapServerList;
+    while (targetP != NULL)
+    {
+        targetP->status = STATE_DEREGISTERED;
+        targetP = targetP->next;
+    }
+}
+
+/*
+ * Returns STATE_BS_PENDING if at least one bootstrap is still pending
+ * Returns STATE_BS_FINISHED if at least one bootstrap succeeded and no bootstrap is pending
+ * Returns STATE_BS_FAILED if all bootstrap failed.
+ */
+lwm2m_status_t bootstrap_get_status(lwm2m_context_t * contextP)
+{
+    lwm2m_server_t * targetP;
+    lwm2m_status_t bs_status;
+
+    targetP = contextP->bootstrapServerList;
+    bs_status = STATE_BS_FAILED;
+
+    while (targetP != NULL)
+    {
+        switch (targetP->status)
+        {
+            case STATE_BS_FINISHED:
+                if (bs_status == STATE_BS_FAILED)
+                {
+                    bs_status = STATE_BS_FINISHED;
+                }
+                break;
+
+            case STATE_BS_HOLD_OFF:
+            case STATE_BS_INITIATED:
+            case STATE_BS_PENDING:
+                bs_status = STATE_BS_PENDING;
+                break;
+
+            default:
+                break;
+        }
+        targetP = targetP->next;
+    }
+
+    return bs_status;
+}
+
+static coap_status_t prv_check_server_status(lwm2m_server_t * serverP)
+{
+    switch (serverP->status)
+    {
+    case STATE_DEREGISTERED:
+        // Should not happen
+        return COAP_IGNORE;
+
+    case STATE_BS_HOLD_OFF:
+        serverP->status = STATE_BS_PENDING;
+        break;
+
+    case STATE_BS_INITIATED:
+        // The ACK was probably lost
+        serverP->status = STATE_BS_PENDING;
+        break;
+
+    case STATE_BS_PENDING:
+        // do nothing
+        break;
+
+    case STATE_BS_FINISHED:
+    case STATE_BS_FAILED:
+    default:
+        return COAP_IGNORE;
+    }
+
+    return COAP_NO_ERROR;
+}
+
+coap_status_t handle_bootstrap_command(lwm2m_context_t * contextP,
+                                       lwm2m_uri_t * uriP,
+                                       lwm2m_server_t * serverP,
+                                       coap_packet_t * message,
+                                       coap_packet_t * response)
+{
+    coap_status_t result;
+    lwm2m_media_type_t format;
+
+    format = prv_convertMediaType(message->content_type);
+
+    result = prv_check_server_status(serverP);
+    if (result != COAP_NO_ERROR) return result;
+
+    switch (message->code)
+    {
+    case COAP_PUT:
+        {
+            if (LWM2M_URI_IS_SET_INSTANCE(uriP))
+            {
+                if (object_isInstanceNew(contextP, uriP->objectId, uriP->instanceId))
+                {
+                    result = object_create(contextP, uriP, format, message->payload, message->payload_len);
+                    if (COAP_201_CREATED == result)
+                    {
+                        result = COAP_204_CHANGED;
+                    }
+                }
+                else
+                {
+                    result = object_write(contextP, uriP, format, message->payload, message->payload_len);
+                }
+            }
+            else
+            {
+                result = BAD_REQUEST_4_00;
+            }
+        }
+        break;
+
+    case COAP_DELETE:
+        {
+            if (LWM2M_URI_IS_SET_INSTANCE(uriP) && !LWM2M_URI_IS_SET_RESOURCE(uriP))
+            {
+                result = object_delete(contextP, uriP);
+            }
+            else
+            {
+                result = BAD_REQUEST_4_00;
+            }
+        }
+        break;
+
+    case COAP_GET:
+    case COAP_POST:
+    default:
+        result = BAD_REQUEST_4_00;
+        break;
+    }
+
+    return result;
+}
+
+static void management_delete_all_instances(lwm2m_object_t * object)
+{
+    if (NULL != object->deleteFunc)
+    {
+        while (NULL != object->instanceList)
+        {
+            object->deleteFunc(object->instanceList->id, object);
+        }
+    }
+}
+
+coap_status_t handle_delete_all(lwm2m_context_t * contextP,
+                                void * fromSessionH)
+{
+    lwm2m_server_t * serverP;
+    coap_status_t result;
+    int i;
+
+    serverP = utils_findBootstrapServer(contextP, fromSessionH);
+    if (serverP == NULL) return COAP_IGNORE;
+    result = prv_check_server_status(serverP);
+    if (result != COAP_NO_ERROR) return result;
+
+    result = COAP_202_DELETED;
+    for (i = 0 ; i < contextP->numObject && result == COAP_202_DELETED ; i++)
+    {
+        lwm2m_object_t * objectP = contextP->objectList[i];
+
+        if (NULL != objectP->instanceList)
+        {
+            if (objectP->deleteFunc)
+            {
+                lwm2m_list_t * targetP;
+
+                targetP = objectP->instanceList;
+                while (NULL != targetP
+                    && result == COAP_202_DELETED)
+                {
+                    if (objectP->objID == LWM2M_SECURITY_OBJECT_ID
+                     && targetP->id == serverP->secObjInstID)
+                    {
+                        // Do not delete the Security Object instance matching the current bootstrap server
+                        targetP = targetP->next;
+                    }
+                    else
+                    {
+                        result = objectP->deleteFunc(targetP->id, objectP);
+                        targetP = objectP->instanceList;
+                    }
+                }
+            }
+            else result = COAP_501_NOT_IMPLEMENTED;
+        }
+    }
+
+    return DELETED_2_02;
+}
 #endif
 
 #ifdef LWM2M_BOOTSTRAP_SERVER_MODE

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -455,6 +455,11 @@ coap_status_t handle_delete_all(lwm2m_context_t * contextP,
         else
         {
             result = object_delete(contextP, &uri);
+            if (result == METHOD_NOT_ALLOWED_4_05)
+            {
+                // Fake a successful deletion for static objects like the Device object.
+                result = COAP_202_DELETED;
+            }
         }
     }
 

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 
 #ifdef LWM2M_CLIENT_MODE
+#ifdef LWM2M_BOOTSTRAP_MODE
 
 #define PRV_QUERY_BUFFER_LENGTH 200
 
@@ -394,6 +395,7 @@ coap_status_t handle_delete_all(lwm2m_context_t * contextP,
 
     return DELETED_2_02;
 }
+#endif
 #endif
 
 #ifdef LWM2M_BOOTSTRAP_SERVER_MODE

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -183,7 +183,7 @@ void update_bootstrap_state(lwm2m_context_t * context,
     else if (context->bsState == BOOTSTRAP_FINISHED)
     {
         context->bsStart = currentTime;
-        if (0 <= lwm2m_start(context))
+        if (0 <= refresh_server_list(context))
         {
             context->bsState = BOOTSTRAPPED;
         }

--- a/core/internals.h
+++ b/core/internals.h
@@ -189,6 +189,7 @@ uint8_t handle_bootstrap_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP,
 void delete_transaction_list(lwm2m_context_t * context);
 void delete_server_list(lwm2m_context_t * context);
 void delete_observed_list(lwm2m_context_t * contextP);
+int refresh_server_list(lwm2m_context_t * contextP);
 
 // defined in json.c
 #ifdef LWM2M_SUPPORT_JSON

--- a/core/internals.h
+++ b/core/internals.h
@@ -158,8 +158,7 @@ bool transaction_handle_response(lwm2m_context_t * contextP, void * fromSessionH
 void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
 // defined in management.c
-coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
-coap_status_t handle_delete_all(lwm2m_context_t * context);
+coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
 
 // defined in observe.c
 coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
@@ -181,18 +180,18 @@ bool handle_observe_notify(lwm2m_context_t * contextP, void * fromSessionH, coap
 void observation_remove(lwm2m_client_t * clientP, lwm2m_observation_t * observationP);
 
 // defined in bootstrap.c
-void handle_bootstrap_response(lwm2m_context_t * context, coap_packet_t * message, void * fromSessionH);
-void bootstrap_failed(lwm2m_context_t * context);
-void reset_bootstrap_timer(lwm2m_context_t * context);
-void update_bootstrap_state(lwm2m_context_t * contextP, uint32_t currentTime, time_t* timeoutP);
+void bootstrap_step(lwm2m_context_t * contextP, uint32_t currentTime, time_t* timeoutP);
 void delete_bootstrap_server_list(lwm2m_context_t * contextP);
+coap_status_t handle_bootstrap_command(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
+coap_status_t handle_delete_all(lwm2m_context_t * context, void * fromSessionH);
+void bootstrap_start(lwm2m_context_t * contextP);
+lwm2m_status_t bootstrap_get_status(lwm2m_context_t * contextP);
 uint8_t handle_bootstrap_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 
 // defined in liblwm2m.c
 void delete_transaction_list(lwm2m_context_t * context);
 void delete_server_list(lwm2m_context_t * context);
 void delete_observed_list(lwm2m_context_t * contextP);
-int refresh_server_list(lwm2m_context_t * contextP);
 
 // defined in json.c
 #ifdef LWM2M_SUPPORT_JSON
@@ -202,6 +201,7 @@ int lwm2m_json_serialize(int size, lwm2m_data_t * tlvP, uint8_t ** bufferP);
 
 // defined in utils.c
 lwm2m_binding_t lwm2m_stringToBinding(uint8_t *buffer, size_t length);
+lwm2m_media_type_t prv_convertMediaType(coap_content_type_t type);
 int prv_isAltPathValid(const char * altPath);
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP, void * fromSessionH);

--- a/core/internals.h
+++ b/core/internals.h
@@ -168,7 +168,8 @@ void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, void * fromSession
 coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void registration_deregister(lwm2m_context_t * contextP, lwm2m_server_t * serverP);
 void prv_freeClient(lwm2m_client_t * clientP);
-void registration_update(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
+void registration_start(lwm2m_context_t * contextP);
+void registration_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 lwm2m_status_t registration_get_status(lwm2m_context_t * contextP);
 
 // defined in packet.c

--- a/core/internals.h
+++ b/core/internals.h
@@ -169,6 +169,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_
 void registration_deregister(lwm2m_context_t * contextP, lwm2m_server_t * serverP);
 void prv_freeClient(lwm2m_client_t * clientP);
 void registration_update(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
+lwm2m_status_t registration_get_status(lwm2m_context_t * contextP);
 
 // defined in packet.c
 coap_status_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, void * sessionH);

--- a/core/internals.h
+++ b/core/internals.h
@@ -155,6 +155,7 @@ int transaction_send(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP)
 void transaction_free(lwm2m_transaction_t * transacP);
 void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
 bool transaction_handle_response(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
+void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
 // defined in management.c
 coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);

--- a/core/internals.h
+++ b/core/internals.h
@@ -186,6 +186,7 @@ coap_status_t handle_bootstrap_command(lwm2m_context_t * contextP, lwm2m_uri_t *
 coap_status_t handle_delete_all(lwm2m_context_t * context, void * fromSessionH);
 void bootstrap_start(lwm2m_context_t * contextP);
 lwm2m_status_t bootstrap_get_status(lwm2m_context_t * contextP);
+coap_status_t handle_bootstrap_finish(lwm2m_context_t * context, void * fromSessionH);
 uint8_t handle_bootstrap_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 
 // defined in liblwm2m.c

--- a/core/internals.h
+++ b/core/internals.h
@@ -144,6 +144,7 @@ coap_status_t object_write(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m
 coap_status_t object_create(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 coap_status_t object_execute(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * buffer, size_t length);
 coap_status_t object_delete(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
+coap_status_t object_delete_others(lwm2m_context_t * contextP, uint16_t objectId, uint16_t instanceId);
 bool object_isInstanceNew(lwm2m_context_t * contextP, uint16_t objectId, uint16_t instanceId);
 int prv_getRegisterPayload(lwm2m_context_t * contextP, uint8_t * buffer, size_t length);
 int object_getServers(lwm2m_context_t * contextP);

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -314,15 +314,21 @@ next_step:
         break;
 
     case STATE_BOOTSTRAP_REQUIRED:
+#ifdef LWM2M_BOOTSTRAP_MODE
         if (contextP->bootstrapServerList != NULL)
         {
             bootstrap_start(contextP);
             contextP->state = STATE_BOOTSTRAPPING;
             bootstrap_step(contextP, tv_sec, timeoutP);
         }
-        else return COAP_503_SERVICE_UNAVAILABLE;
+        else
+#endif
+        {
+            return COAP_503_SERVICE_UNAVAILABLE;
+        }
         break;
 
+#ifdef LWM2M_BOOTSTRAP_MODE
     case STATE_BOOTSTRAPPING:
         switch (bootstrap_get_status(contextP))
         {
@@ -341,7 +347,7 @@ next_step:
             break;
         }
         break;
-
+#endif
     case STATE_REGISTER_REQUIRED:
         registration_start(contextP);
         contextP->state = STATE_REGISTERING;

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -279,7 +279,7 @@ int lwm2m_step(lwm2m_context_t * contextP,
     case STATE_INITIAL:
         if (contextP->serverList != NULL)
         {
-            registration_update(contextP, tv_sec, timeoutP);
+            registration_start(contextP);
             contextP->state = STATE_REGISTERING;
         }
         else
@@ -334,6 +334,7 @@ int lwm2m_step(lwm2m_context_t * contextP,
         break;
     }
 
+    registration_step(contextP, tv_sec, timeoutP);
 
 #ifdef LWM2M_BOOTSTRAP
     if ((contextP->bsState != BOOTSTRAP_CLIENT_HOLD_OFF) &&

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -283,7 +283,7 @@ int lwm2m_configure(lwm2m_context_t * contextP,
         return COAP_500_INTERNAL_SERVER_ERROR;
     }
 
-    return refresh_server_list(contextP);
+    return COAP_NO_ERROR;
 }
 #endif
 
@@ -301,6 +301,7 @@ next_step:
     switch (contextP->state)
     {
     case STATE_INITIAL:
+        if (0 != refresh_server_list(contextP)) return COAP_503_SERVICE_UNAVAILABLE;
         if (contextP->serverList != NULL)
         {
             contextP->state = STATE_REGISTER_REQUIRED;
@@ -314,7 +315,7 @@ next_step:
         break;
 
     case STATE_BOOTSTRAP_REQUIRED:
-#ifdef LWM2M_BOOTSTRAP_MODE
+#ifdef LWM2M_BOOTSTRAP
         if (contextP->bootstrapServerList != NULL)
         {
             bootstrap_start(contextP);
@@ -328,13 +329,12 @@ next_step:
         }
         break;
 
-#ifdef LWM2M_BOOTSTRAP_MODE
+#ifdef LWM2M_BOOTSTRAP
     case STATE_BOOTSTRAPPING:
         switch (bootstrap_get_status(contextP))
         {
         case STATE_BS_FINISHED:
-            refresh_server_list(contextP);
-            contextP->state = STATE_REGISTER_REQUIRED;
+            contextP->state = STATE_INITIAL;
             goto next_step;
             break;
 

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -256,7 +256,7 @@ int lwm2m_configure(lwm2m_context_t * contextP,
         return COAP_500_INTERNAL_SERVER_ERROR;
     }
 
-    return COAP_NO_ERROR;
+    return refresh_server_list(contextP);
 }
 #endif
 
@@ -357,7 +357,7 @@ int lwm2m_step(lwm2m_context_t * contextP,
 }
 
 #ifdef LWM2M_CLIENT_MODE
-int lwm2m_start(lwm2m_context_t * contextP)
+int refresh_server_list(lwm2m_context_t * contextP)
 {
     int result;
     bool cleanup = (NULL != contextP->bootstrapServerList) || (NULL != contextP->serverList);
@@ -365,17 +365,17 @@ int lwm2m_start(lwm2m_context_t * contextP)
     delete_observed_list(contextP);
     if (cleanup)
     {
-        LOG("lwm2m_start: cleanup\n");
+        LOG("reffresh_server_list: cleanup\n");
         delete_server_list(contextP);
         delete_bootstrap_server_list(contextP);
     }
     result = object_getServers(contextP);
     if (0 > result)
     {
-        LOG("lwm2m_start: security- or server-objects configuration error.\n");
+        LOG("reffresh_server_list: security- or server-objects configuration error.\n");
         if (0 > result && cleanup)
         {
-            LOG("lwm2m_start: cleanup on error\n");
+            LOG("reffresh_server_list: cleanup on error\n");
             delete_server_list(contextP);
             delete_bootstrap_server_list(contextP);
         }

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -222,10 +222,7 @@ size_t lwm2m_boolToPlainText(bool data, uint8_t ** bufferP);
  */
 #define LWM2M_TLV_FLAG_STATIC_DATA   0x01
 #define LWM2M_TLV_FLAG_TEXT_FORMAT   0x02
-
-#ifdef LWM2M_BOOTSTRAP
 #define LWM2M_TLV_FLAG_BOOTSTRAPPING 0x04
-#endif
 
 /*
  * Bits 7 and 6 of assigned values for LWM2M_TYPE_RESOURCE,

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -521,18 +521,18 @@ typedef struct _lwm2m_observed_
     lwm2m_watcher_t * watcherList;
 } lwm2m_observed_t;
 
-#ifdef LWM2M_BOOTSTRAP
+#ifdef LWM2M_CLIENT_MODE
 
-typedef enum {
-    NOT_BOOTSTRAPPED = 0,
-    BOOTSTRAP_REQUESTED,
-    BOOTSTRAP_CLIENT_HOLD_OFF,
-    BOOTSTRAP_INITIATED,
-    BOOTSTRAP_PENDING,
-    BOOTSTRAP_FINISHED,
-    BOOTSTRAP_FAILED,
-    BOOTSTRAPPED
-} lwm2m_bootstrap_state_t;
+typedef enum
+{
+    STATE_INITIAL = 0,
+    STATE_BOOTSTRAP_REQUIRED,
+    STATE_HOLD_OFF,
+    STATE_CLIENT_INITIATED,
+    STATE_BOOTSTRAPPING,
+    STATE_REGISTERING,
+    STATE_READY
+} lwm2m_client_state_t;
 
 #endif
 /*
@@ -558,9 +558,9 @@ typedef int (*lwm2m_bootstrap_callback_t) (void * sessionH, uint8_t status, lwm2
 typedef struct
 {
 #ifdef LWM2M_CLIENT_MODE
+    lwm2m_client_state_t state;
 #ifdef LWM2M_BOOTSTRAP
-    lwm2m_bootstrap_state_t bsState;
-    time_t              bsStart;
+    time_t               bsStart;
 #endif
     char *              endpointName;
     char *              msisdn;

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -371,12 +371,17 @@ struct _lwm2m_object_t
 
 typedef enum
 {
-    STATE_DEREGISTERED = 0,   // not registered
+    STATE_DEREGISTERED = 0,   // not registered or boostrap not started
     STATE_REG_PENDING,        // registration pending
     STATE_REGISTERED,         // successfully registered
     STATE_REG_FAILED,         // last registration failed
     STATE_REG_UPDATE_PENDING, // registration update pending
-    STATE_DEREG_PENDING       // deregistration pending
+    STATE_DEREG_PENDING,      // deregistration pending
+    STATE_BS_HOLD_OFF,        // bootstrap hold off time
+    STATE_BS_INITIATED,       // bootstrap request sent
+    STATE_BS_PENDING,         // boostrap on going
+    STATE_BS_FINISHED,        // bootstrap done
+    STATE_BS_FAILED           // bootstrap failed
 } lwm2m_status_t;
 
 typedef enum
@@ -395,8 +400,8 @@ typedef struct _lwm2m_server_
     struct _lwm2m_server_ * next;   // matches lwm2m_list_t::next
     uint16_t          secObjInstID; // matches lwm2m_list_t::id
     uint16_t          shortID;      // servers short ID, may be 0 for bootstrap server
-    time_t            lifetime;     // lifetime of the registration in sec or 0 if default value (86400 sec), also used as hold off time for the bootstrap server
-    time_t            registration; // date of the last registration in sec
+    time_t            lifetime;     // lifetime of the registration in sec or 0 if default value (86400 sec), also used as hold off time for bootstrap servers
+    time_t            registration; // date of the last registration in sec or end of client hold off time for bootstrap servers
     lwm2m_binding_t   binding;      // client connection mode with this server
     void *            sessionH;
     lwm2m_status_t    status;
@@ -527,9 +532,8 @@ typedef enum
 {
     STATE_INITIAL = 0,
     STATE_BOOTSTRAP_REQUIRED,
-    STATE_HOLD_OFF,
-    STATE_CLIENT_INITIATED,
     STATE_BOOTSTRAPPING,
+    STATE_REGISTER_REQUIRED,
     STATE_REGISTERING,
     STATE_READY
 } lwm2m_client_state_t;
@@ -559,17 +563,14 @@ typedef struct
 {
 #ifdef LWM2M_CLIENT_MODE
     lwm2m_client_state_t state;
-#ifdef LWM2M_BOOTSTRAP
-    time_t               bsStart;
-#endif
-    char *              endpointName;
-    char *              msisdn;
-    char *              altPath;
-    lwm2m_server_t *    bootstrapServerList;
-    lwm2m_server_t *    serverList;
-    lwm2m_object_t **   objectList;
-    uint16_t            numObject;
-    lwm2m_observed_t *  observedList;
+    char *               endpointName;
+    char *               msisdn;
+    char *               altPath;
+    lwm2m_server_t *     bootstrapServerList;
+    lwm2m_server_t *     serverList;
+    lwm2m_object_t **    objectList;
+    uint16_t             numObject;
+    lwm2m_observed_t *   observedList;
 #endif
 #ifdef LWM2M_SERVER_MODE
     lwm2m_client_t *        clientList;

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -222,7 +222,6 @@ size_t lwm2m_boolToPlainText(bool data, uint8_t ** bufferP);
  */
 #define LWM2M_TLV_FLAG_STATIC_DATA   0x01
 #define LWM2M_TLV_FLAG_TEXT_FORMAT   0x02
-#define LWM2M_TLV_FLAG_BOOTSTRAPPING 0x04
 
 /*
  * Bits 7 and 6 of assigned values for LWM2M_TYPE_RESOURCE,

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -377,7 +377,8 @@ typedef enum
     STATE_BS_INITIATED,       // bootstrap request sent
     STATE_BS_PENDING,         // boostrap on going
     STATE_BS_FINISHED,        // bootstrap done
-    STATE_BS_FAILED           // bootstrap failed
+    STATE_BS_FAILED,          // bootstrap failed
+    STATE_DIRTY               // deleted or modified by bootstrap interface
 } lwm2m_status_t;
 
 typedef enum

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -606,9 +606,6 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int lengt
 // its matching LWM2M Server Object (ID 1) instance
 int lwm2m_configure(lwm2m_context_t * contextP, const char * endpointName, const char * msisdn, const char * altPath, uint16_t numObject, lwm2m_object_t * objectList[]);
 
-// create objects for known LWM2M Servers.
-int lwm2m_start(lwm2m_context_t * contextP);
-
 // send a registration update to the server specified by the server short identifier
 int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID);
 

--- a/core/management.c
+++ b/core/management.c
@@ -164,10 +164,6 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
 #endif
             if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
             {
-                lwm2m_media_type_t format;
-
-                format = prv_convertMediaType(message->content_type);
-
                 result = object_create(contextP, uriP, format, message->payload, message->payload_len);
                 if (result == COAP_201_CREATED)
                 {

--- a/core/management.c
+++ b/core/management.c
@@ -52,81 +52,30 @@
 #include <stdio.h>
 
 
-static lwm2m_media_type_t prv_convertMediaType(coap_content_type_t type)
-{
-    // Here we just check the content type is a valid value for LWM2M
-    switch(type)
-    {
-    case TEXT_PLAIN:
-        return LWM2M_CONTENT_TEXT;
-    case APPLICATION_OCTET_STREAM:
-        return LWM2M_CONTENT_OPAQUE;
-    case LWM2M_CONTENT_TLV:
-        return LWM2M_CONTENT_TLV;
-    case LWM2M_CONTENT_JSON:
-        return LWM2M_CONTENT_JSON;
-
-    default:
-        return LWM2M_CONTENT_TEXT;
-    }
-}
-
 #ifdef LWM2M_CLIENT_MODE
 coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                                 lwm2m_uri_t * uriP,
-                                void * fromSessionH,
+                                lwm2m_server_t * serverP,
                                 coap_packet_t * message,
                                 coap_packet_t * response)
 {
     coap_status_t result;
-    lwm2m_server_t * serverP = NULL;
     lwm2m_media_type_t format;
-
-#ifdef LWM2M_BOOTSTRAP
-    lwm2m_server_t * bsServerP = NULL;
-#endif
 
     format = prv_convertMediaType(message->content_type);
 
-    serverP = prv_findServer(contextP, fromSessionH);
-    if (NULL == serverP)
+    if (uriP->objectId == LWM2M_SECURITY_OBJECT_ID)
     {
-#ifdef LWM2M_BOOTSTRAP
-        bsServerP = utils_findBootstrapServer(contextP, fromSessionH);
-        if (NULL == bsServerP)
-        {
-            // No server found
-            return COAP_IGNORE;
-        }
-#else
-        return COAP_IGNORE;
-#endif
+        return COAP_404_NOT_FOUND;
     }
 
-#ifdef LWM2M_BOOTSTRAP
-    if (contextP->bsState != BOOTSTRAP_PENDING)
+    if (serverP->status != STATE_REGISTERED
+     && serverP->status != STATE_REG_UPDATE_PENDING)
     {
-        if (NULL != bsServerP)
-        {
-            // server initiated bootstrap?
-            // currently not implemented.
-            return NOT_IMPLEMENTED_5_01;
-        }
-        if ( serverP->status != STATE_REGISTERED &&
-                serverP->status != STATE_REG_UPDATE_PENDING)
-        {
-            return COAP_IGNORE;
-        }
+        return COAP_IGNORE;
     }
-    else
-    {
-        if (NULL != serverP)
-        {
-            // Request form management server during bootstrap.
-            return UNAUTHORIZED_4_01;
-        }
-    }
-#endif
+
+    // TODO: check ACL
 
     switch (message->code)
     {
@@ -158,10 +107,6 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
 
     case COAP_POST:
         {
-#ifdef LWM2M_BOOTSTRAP
-            /* no POST during bootstrap */
-            if (contextP->bsState == BOOTSTRAP_PENDING) return METHOD_NOT_ALLOWED_4_05;
-#endif
             if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
             {
                 result = object_create(contextP, uriP, format, message->payload, message->payload_len);
@@ -206,20 +151,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
         {
             if (LWM2M_URI_IS_SET_INSTANCE(uriP))
             {
-#ifdef LWM2M_BOOTSTRAP
-                if (contextP->bsState == BOOTSTRAP_PENDING && object_isInstanceNew(contextP, uriP->objectId, uriP->instanceId))
-                {
-                    result = object_create(contextP, uriP, format, message->payload, message->payload_len);
-                    if (COAP_201_CREATED == result)
-                    {
-                        result = COAP_204_CHANGED;
-                    }
-                }
-                else
-#endif
-                {
-                    result = object_write(contextP, uriP, format, message->payload, message->payload_len);
-                }
+                result = object_write(contextP, uriP, format, message->payload, message->payload_len);
             }
             else
             {
@@ -249,39 +181,6 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
     return result;
 }
 
-static void management_delete_all_instances(lwm2m_object_t * object)
-{
-    if (NULL != object->deleteFunc)
-    {
-        while (NULL != object->instanceList)
-        {
-            object->deleteFunc(object->instanceList->id, object);
-        }
-    }
-}
-
-coap_status_t handle_delete_all(lwm2m_context_t * context)
-{
-    lwm2m_object_t ** objectList = context->objectList;
-    if (NULL != objectList)
-    {
-        int i;
-        for (i = 0 ; i < context->numObject ; i++)
-        {
-            // Only security and server objects are deleted upon a DEL /
-            switch (objectList[i]->objID)
-            {
-            case LWM2M_SECURITY_OBJECT_ID:
-            case LWM2M_SERVER_OBJECT_ID:
-                management_delete_all_instances(objectList[i]);
-                break;
-            default:
-                break;
-            }
-        }
-    }
-    return DELETED_2_02;
-}
 #endif
 
 #ifdef LWM2M_SERVER_MODE

--- a/core/management.c
+++ b/core/management.c
@@ -162,13 +162,13 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
 
     case COAP_DELETE:
         {
-            if (LWM2M_URI_IS_SET_INSTANCE(uriP) && !LWM2M_URI_IS_SET_RESOURCE(uriP))
+            if (!LWM2M_URI_IS_SET_INSTANCE(uriP) || LWM2M_URI_IS_SET_RESOURCE(uriP))
             {
-                result = object_delete(contextP, uriP);
+                result = BAD_REQUEST_4_00;
             }
             else
             {
-                result = BAD_REQUEST_4_00;
+                result = object_delete(contextP, uriP);
             }
         }
         break;

--- a/core/objects.c
+++ b/core/objects.c
@@ -162,7 +162,7 @@ coap_status_t object_read(lwm2m_context_t * contextP,
          && dataP->type == LWM2M_TYPE_RESOURCE
          && (dataP->flags && LWM2M_TLV_FLAG_TEXT_FORMAT) != 0 )
         {
-            *bufferP = (uint8_t *)malloc(dataP->length);
+            *bufferP = (uint8_t *)lwm2m_malloc(dataP->length);
             if (*bufferP == NULL)
             {
                 result = COAP_500_INTERNAL_SERVER_ERROR;

--- a/core/packet.c
+++ b/core/packet.c
@@ -130,7 +130,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
         {
             result = handle_dm_request(contextP, uriP, serverP, message, response);
         }
-#ifdef LWM2M_BOOTSTRAP_MODE
+#ifdef LWM2M_BOOTSTRAP
         else
         {
             serverP = utils_findBootstrapServer(contextP, fromSessionH);
@@ -143,7 +143,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
     }
     break;
 
-#ifdef LWM2M_BOOTSTRAP_MODE
+#ifdef LWM2M_BOOTSTRAP
     case LWM2M_URI_FLAG_DELETE_ALL:
         if (COAP_DELETE != message->code)
         {

--- a/core/packet.c
+++ b/core/packet.c
@@ -108,7 +108,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
                                     coap_packet_t * response)
 {
     lwm2m_uri_t * uriP;
-    coap_status_t result = NOT_FOUND_4_04;
+    coap_status_t result = COAP_IGNORE;
 
 #ifdef LWM2M_CLIENT_MODE
     uriP = lwm2m_decode_uri(contextP->altPath, message->uri_path);
@@ -116,40 +116,48 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
     uriP = lwm2m_decode_uri(NULL, message->uri_path);
 #endif
 
-    if (uriP == NULL) return BAD_REQUEST_4_00;
+    if (uriP == NULL) return COAP_400_BAD_REQUEST;
 
     switch(uriP->flag & LWM2M_URI_MASK_TYPE)
     {
 #ifdef LWM2M_CLIENT_MODE
     case LWM2M_URI_FLAG_DM:
-        // TODO: Authentify server
-        result = handle_dm_request(contextP, uriP, fromSessionH, message, response);
-        break;
+    {
+        lwm2m_server_t * serverP;
 
-#ifdef LWM2M_BOOTSTRAP
-    case LWM2M_URI_FLAG_DELETE_ALL:
-        if (COAP_DELETE != message->code)
+        serverP = prv_findServer(contextP, fromSessionH);
+        if (serverP != NULL)
         {
-            result = BAD_REQUEST_4_00;
-        }
-        else if (NULL == utils_findBootstrapServer(contextP, fromSessionH))
-        {
-            result = UNAUTHORIZED_4_01;
-        }
-        else if (BOOTSTRAP_PENDING == contextP->bsState)
-        {
-            result = handle_delete_all(contextP);
+            result = handle_dm_request(contextP, uriP, serverP, message, response);
         }
         else
         {
-            result = COAP_IGNORE;
+            serverP = utils_findBootstrapServer(contextP, fromSessionH);
+            if (serverP != NULL)
+            {
+                result = handle_bootstrap_command(contextP, uriP, serverP, message, response);
+            }
+        }
+    }
+    break;
+
+    case LWM2M_URI_FLAG_DELETE_ALL:
+        if (COAP_DELETE != message->code)
+        {
+            result = COAP_400_BAD_REQUEST;
+        }
+        else
+        {
+            result = handle_delete_all(contextP, fromSessionH);
         }
         break;
 
     case LWM2M_URI_FLAG_BOOTSTRAP:
-        result = handle_bootstrap_finish(contextP, fromSessionH);
+        if (message->code == COAP_POST)
+        {
+            result = handle_bootstrap_finish(contextP, fromSessionH);
+        }
         break;
-#endif
 #endif
 
 #ifdef LWM2M_SERVER_MODE
@@ -169,7 +177,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
 
     coap_set_status_code(response, result);
 
-    if (COAP_IGNORE < result && result < BAD_REQUEST_4_00)
+    if (COAP_IGNORE < result && result < COAP_400_BAD_REQUEST)
     {
         result = NO_ERROR;
     }

--- a/core/packet.c
+++ b/core/packet.c
@@ -130,6 +130,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
         {
             result = handle_dm_request(contextP, uriP, serverP, message, response);
         }
+#ifdef LWM2M_BOOTSTRAP_MODE
         else
         {
             serverP = utils_findBootstrapServer(contextP, fromSessionH);
@@ -138,9 +139,11 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
                 result = handle_bootstrap_command(contextP, uriP, serverP, message, response);
             }
         }
+#endif
     }
     break;
 
+#ifdef LWM2M_BOOTSTRAP_MODE
     case LWM2M_URI_FLAG_DELETE_ALL:
         if (COAP_DELETE != message->code)
         {
@@ -158,6 +161,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
             result = handle_bootstrap_finish(contextP, fromSessionH);
         }
         break;
+#endif
 #endif
 
 #ifdef LWM2M_SERVER_MODE

--- a/core/registration.c
+++ b/core/registration.c
@@ -114,9 +114,7 @@ static void prv_handleRegistrationReply(lwm2m_transaction_t * transacP,
     coap_packet_t * packet = (coap_packet_t *)message;
     lwm2m_server_t * targetP = (lwm2m_server_t *)(transacP->peerP);
 
-    switch(targetP->status)
-    {
-    case STATE_REG_PENDING:
+    if (targetP->status == STATE_REG_PENDING)
     {
         time_t tv_sec = lwm2m_gettime();
         if (tv_sec >= 0)
@@ -139,10 +137,6 @@ static void prv_handleRegistrationReply(lwm2m_transaction_t * transacP,
             targetP->status = STATE_REG_FAILED;
             LOG("    => Registration FAILED\r\n");
         }
-    }
-    break;
-    default:
-        break;
     }
 }
 
@@ -209,9 +203,7 @@ static void prv_handleRegistrationUpdateReply(lwm2m_transaction_t * transacP,
     coap_packet_t * packet = (coap_packet_t *)message;
     lwm2m_server_t * targetP = (lwm2m_server_t *)(transacP->peerP);
 
-    switch(targetP->status)
-    {
-    case STATE_REG_UPDATE_PENDING:
+    if (targetP->status == STATE_REG_UPDATE_PENDING)
     {
         time_t tv_sec = lwm2m_gettime();
         if (tv_sec >= 0)
@@ -228,10 +220,6 @@ static void prv_handleRegistrationUpdateReply(lwm2m_transaction_t * transacP,
             targetP->status = STATE_REG_FAILED;
             LOG("    => Registration update FAILED\r\n");
         }
-    }
-    break;
-    default:
-        break;
     }
 }
 
@@ -290,101 +278,56 @@ int lwm2m_update_registration(lwm2m_context_t * contextP,
     return NOT_FOUND_4_04;
 }
 
-// for each server update the registration if needed
-void registration_update(lwm2m_context_t * contextP,
-                         time_t currentTime,
-                         time_t * timeoutP)
+void registration_start(lwm2m_context_t * contextP)
 {
-    time_t nextUpdate;
-    time_t interval;
     lwm2m_server_t * targetP = contextP->serverList;
-#ifdef LWM2M_BOOTSTRAP
-    bool allServerFailed = true;
-    bool serverRegistered = false;
-
-    while (targetP != NULL)
-    {
-        if (STATE_REGISTERED == targetP->status)
-        {
-            serverRegistered = true;
-            allServerFailed = false;
-            break;
-        }
-        else if (STATE_REG_FAILED != targetP->status) allServerFailed = false;
-        targetP = targetP->next;
-    }
-#endif
 
     targetP = contextP->serverList;
     while (targetP != NULL)
     {
-        switch (targetP->status)
+        if (targetP->status == STATE_DEREGISTERED
+         || targetP->status == STATE_REG_FAILED)
         {
-            case STATE_REGISTERED:
-                nextUpdate = targetP->lifetime;
-                if (30 < nextUpdate)
-                {
-                    nextUpdate -= 15; // update 15s earlier to have a chance to resend
-                }
-
-                interval = targetP->registration + nextUpdate - currentTime;
-                if (0 >= interval)
-                {
-                    LOG("Updating registration...\r\n");
-                    prv_update_registration(contextP, targetP);
-                }
-                else if (interval < *timeoutP)
-                {
-                    *timeoutP = interval;
-                }
-                break;
-
-            case STATE_DEREGISTERED:
-                // TODO: is it disabled?
-                prv_register(contextP, targetP);
-                break;
-
-            case STATE_REG_UPDATE_PENDING:
-                // TODO: check for timeout and retry?
-                break;
-
-            case STATE_DEREG_PENDING:
-                break;
-
-            case STATE_REG_FAILED:
-#ifdef LWM2M_BOOTSTRAP
-                if (serverRegistered || NULL == contextP->bootstrapServerList)
-                {
-#endif
-                    interval = targetP->registration + targetP->lifetime - currentTime;
-                    if (0 >= interval)
-                    {
-                        LOG("Retry registration...\r\n");
-                        prv_register(contextP, targetP);
-                    }
-                    else if (interval < *timeoutP)
-                    {
-                        *timeoutP = interval;
-                    }
-#ifdef LWM2M_BOOTSTRAP
-                }
-#endif
-                break;
-
-            default:
-                break;
+            prv_register(contextP, targetP);
         }
         targetP = targetP->next;
     }
-#ifdef LWM2M_BOOTSTRAP
-    if (allServerFailed && NULL != contextP->bootstrapServerList)
+}
+
+// for each server update the registration if needed
+void registration_step(lwm2m_context_t * contextP,
+                       time_t currentTime,
+                       time_t * timeoutP)
+{
+    lwm2m_server_t * targetP = contextP->serverList;
+
+    targetP = contextP->serverList;
+    while (targetP != NULL)
     {
-        if (BOOTSTRAPPED == contextP->bsState || NOT_BOOTSTRAPPED == contextP->bsState)
+        if (targetP->status == STATE_REGISTERED)
         {
-            contextP->bsState = BOOTSTRAP_REQUESTED;
+            time_t nextUpdate;
+            time_t interval;
+
+            nextUpdate = targetP->lifetime;
+            if (30 < nextUpdate)
+            {
+                nextUpdate -= 15; // update 15s earlier to have a chance to resend
+            }
+
+            interval = targetP->registration + nextUpdate - currentTime;
+            if (0 >= interval)
+            {
+                LOG("Updating registration...\r\n");
+                prv_update_registration(contextP, targetP);
+            }
+            else if (interval < *timeoutP)
+            {
+                *timeoutP = interval;
+            }
         }
+        targetP = targetP->next;
     }
-#endif
 }
 
 /*
@@ -436,13 +379,9 @@ static void prv_handleDeregistrationReply(lwm2m_transaction_t * transacP,
     targetP = (lwm2m_server_t *)(transacP->peerP);
     if (NULL != targetP)
     {
-        switch(targetP->status)
+        if (targetP->status == STATE_DEREG_PENDING)
         {
-        case STATE_DEREG_PENDING:
             targetP->status = STATE_DEREGISTERED;
-            break;
-        default:
-            break;
         }
     }
 }

--- a/core/registration.c
+++ b/core/registration.c
@@ -280,7 +280,7 @@ int lwm2m_update_registration(lwm2m_context_t * contextP,
 
 void registration_start(lwm2m_context_t * contextP)
 {
-    lwm2m_server_t * targetP = contextP->serverList;
+    lwm2m_server_t * targetP;
 
     targetP = contextP->serverList;
     while (targetP != NULL)

--- a/core/registration.c
+++ b/core/registration.c
@@ -387,6 +387,47 @@ void registration_update(lwm2m_context_t * contextP,
 #endif
 }
 
+/*
+ * Returns STATE_REG_PENDING if at least one registration is still pending
+ * Returns STATE_REGISTERED if no registration is pending and there is at least one server the client is registered to
+ * Returns STATE_REG_FAILED if all registration failed.
+ */
+lwm2m_status_t registration_get_status(lwm2m_context_t * contextP)
+{
+    lwm2m_server_t * targetP;
+    lwm2m_status_t reg_status;
+
+    targetP = contextP->serverList;
+    reg_status = STATE_REG_FAILED;
+
+    while (targetP != NULL)
+    {
+        switch (targetP->status)
+        {
+            case STATE_REGISTERED:
+            case STATE_REG_UPDATE_PENDING:
+                if (reg_status == STATE_REG_FAILED)
+                {
+                    reg_status = STATE_REGISTERED;
+                }
+                break;
+
+            case STATE_REG_PENDING:
+                reg_status = STATE_REG_PENDING;
+                break;
+
+            case STATE_REG_FAILED:
+            case STATE_DEREG_PENDING:
+            case STATE_DEREGISTERED:
+            default:
+                break;
+        }
+        targetP = targetP->next;
+    }
+
+    return reg_status;
+}
+
 static void prv_handleDeregistrationReply(lwm2m_transaction_t * transacP,
                                         void * message)
 {

--- a/core/utils.c
+++ b/core/utils.c
@@ -337,6 +337,25 @@ lwm2m_binding_t lwm2m_stringToBinding(uint8_t * buffer,
     return BINDING_UNKNOWN;
 }
 
+lwm2m_media_type_t prv_convertMediaType(coap_content_type_t type)
+{
+    // Here we just check the content type is a valid value for LWM2M
+    switch(type)
+    {
+    case TEXT_PLAIN:
+        return LWM2M_CONTENT_TEXT;
+    case APPLICATION_OCTET_STREAM:
+        return LWM2M_CONTENT_OPAQUE;
+    case LWM2M_CONTENT_TLV:
+        return LWM2M_CONTENT_TLV;
+    case LWM2M_CONTENT_JSON:
+        return LWM2M_CONTENT_JSON;
+
+    default:
+        return LWM2M_CONTENT_TEXT;
+    }
+}
+
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP,
                                 void * fromSessionH)

--- a/tests/bootstrap_server/bootstrap_server.c
+++ b/tests/bootstrap_server/bootstrap_server.c
@@ -54,9 +54,11 @@ typedef struct _endpoint_
 
 typedef struct
 {
+    int               sock;
+    connection_t *    connList;
     lwm2m_context_t * lwm2mH;
-    bs_info_t *     bsInfo;
-    endpoint_t *    endpointList;
+    bs_info_t *       bsInfo;
+    endpoint_t *      endpointList;
 } internal_data_t;
 
 /*
@@ -387,14 +389,82 @@ static int prv_bootstrap_callback(void * sessionH,
     return COAP_NO_ERROR;
 }
 
+static void prv_bootstrap_client(char * buffer,
+                                 void * user_data)
+{
+    internal_data_t * dataP = (internal_data_t *)user_data;
+    char * uri;
+    char * name;
+    char* end = NULL;
+    char * host;
+    char * port;
+    connection_t * newConnP = NULL;
+
+    uri = buffer;
+    end = get_end_of_arg(buffer);
+    if (end[0] != 0)
+    {
+        *end = 0;
+        buffer = end + 1;
+        name = get_next_arg(buffer, &end);
+    }
+    if (!check_end_of_args(end)) goto syntax_error;
+
+    // parse uri in the form "coaps://[host]:[port]"
+    if (0==strncmp(uri, "coaps://", strlen("coaps://"))) {
+        host = uri+strlen("coaps://");
+    }
+    else if (0==strncmp(uri, "coap://",  strlen("coap://"))) {
+        host = uri+strlen("coap://");
+    }
+    else {
+        goto syntax_error;
+    }
+    port = strrchr(host, ':');
+    if (port == NULL) goto syntax_error;
+    // remove brackets
+    if (host[0] == '[')
+    {
+        host++;
+        if (*(port - 1) == ']')
+        {
+            *(port - 1) = 0;
+        }
+        else goto syntax_error;
+    }
+    // split strings
+    *port = 0;
+    port++;
+
+    fprintf(stderr, "Trying to connect to LWM2M CLient at %s:%s\r\n", host, port);
+    newConnP = connection_create(dataP->connList, dataP->sock, host, port);
+    if (newConnP == NULL) {
+        fprintf(stderr, "Connection creation failed.\r\n");
+        return;
+    }
+    dataP->connList = newConnP;
+
+    // simulate a client bootstrap request.
+    if (COAP_204_CHANGED == prv_bootstrap_callback(newConnP, COAP_NO_ERROR, NULL, name, user_data))
+    {
+        fprintf(stdout, "OK");
+    }
+    else
+    {
+        fprintf(stdout, "Error");
+    }
+    return;
+
+syntax_error:
+    fprintf(stdout, "Syntax error !");
+}
+
 
 int main(int argc, char *argv[])
 {
-    int sock;
     fd_set readfds;
     struct timeval tv;
     int result;
-    connection_t * connList = NULL;
     char * port = "5685";
     internal_data_t data;
     char * filename = "bootstrap_server.ini";
@@ -402,9 +472,13 @@ int main(int argc, char *argv[])
     FILE * fd;
     command_desc_t commands[] =
     {
-            {"q", "Quit the server.", NULL, prv_quit, NULL},
+        {"boot", "Bootstrap a client (Server Initiated).", " boot URI [NAME]\r\n"
+                                    "   URI: uri of the client to bootstrap\r\n"
+                                    "   NAME: endpoint name of the client as in the .ini file (optionnal)\r\n"
+                                    "Example: boot coap://[::1]:56830 testlwm2mclient", prv_bootstrap_client, &data},
+        {"q", "Quit the server.", NULL, prv_quit, NULL},
 
-            COMMAND_END_LIST
+        COMMAND_END_LIST
     };
 
     while ((opt = getopt(argc, argv, "f:p:")) != -1)
@@ -423,14 +497,14 @@ int main(int argc, char *argv[])
         }
     }
 
-    sock = create_socket(port);
-    if (sock < 0)
+    memset(&data, 0, sizeof(internal_data_t));
+
+    data.sock = create_socket(port);
+    if (data.sock < 0)
     {
         fprintf(stderr, "Error opening socket: %d\r\n", errno);
         return -1;
     }
-
-    memset(&data, 0, sizeof(internal_data_t));
 
     data.lwm2mH = lwm2m_init(NULL, prv_buffer_send, NULL);
     if (NULL == data.lwm2mH)
@@ -466,7 +540,7 @@ int main(int argc, char *argv[])
         endpoint_t * endP;
 
         FD_ZERO(&readfds);
-        FD_SET(sock, &readfds);
+        FD_SET(data.sock, &readfds);
         FD_SET(STDIN_FILENO, &readfds);
 
         tv.tv_sec = 60;
@@ -494,13 +568,13 @@ int main(int argc, char *argv[])
             int numBytes;
 
             // Packet received
-            if (FD_ISSET(sock, &readfds))
+            if (FD_ISSET(data.sock, &readfds))
             {
                 struct sockaddr_storage addr;
                 socklen_t addrLen;
 
                 addrLen = sizeof(addr);
-                numBytes = recvfrom(sock, buffer, MAX_PACKET_SIZE, 0, (struct sockaddr *)&addr, &addrLen);
+                numBytes = recvfrom(data.sock, buffer, MAX_PACKET_SIZE, 0, (struct sockaddr *)&addr, &addrLen);
 
                 if (numBytes == -1)
                 {
@@ -530,13 +604,13 @@ int main(int argc, char *argv[])
 
                     output_buffer(stderr, buffer, numBytes, 0);
 
-                    connP = connection_find(connList, &addr, addrLen);
+                    connP = connection_find(data.connList, &addr, addrLen);
                     if (connP == NULL)
                     {
-                        connP = connection_new_incoming(connList, sock, (struct sockaddr *)&addr, addrLen);
+                        connP = connection_new_incoming(data.connList, data.sock, (struct sockaddr *)&addr, addrLen);
                         if (connP != NULL)
                         {
-                            connList = connP;
+                            data.connList = connP;
                         }
                     }
                     if (connP != NULL)
@@ -600,8 +674,8 @@ int main(int argc, char *argv[])
 
         prv_endpoint_free(endP);
     }
-    close(sock);
-    connection_free(connList);
+    close(data.sock);
+    connection_free(data.connList);
 
     return 0;
 }

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -303,7 +303,6 @@ static void prv_output_servers(char * buffer,
             default:
                 fprintf(stdout, "INVALID (%d)\r\n", (int)targetP->status);
             }
-            fprintf(stdout, "\r\n");
         }
     }
 
@@ -341,7 +340,6 @@ static void prv_output_servers(char * buffer,
             default:
                 fprintf(stdout, "INVALID (%d)\r\n", (int)targetP->status);
             }
-            fprintf(stdout, "\r\n");
         }
     }
 }

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -665,7 +665,6 @@ static void prv_restore_objects(lwm2m_context_t * context)
     }
 
     // restart the old servers
-    lwm2m_start(context);
     fprintf(stdout, "[BOOTSTRAP] ObjectList restored\r\n");
 }
 
@@ -974,16 +973,6 @@ int main(int argc, char *argv[])
     }
 
     signal(SIGINT, handle_sigint);
-
-    /*
-     * This function start your client to the LWM2M servers
-     */
-    result = lwm2m_start(lwm2mH);
-    if (result != 0)
-    {
-        fprintf(stderr, "lwm2m_start() failed: 0x%X\r\n", result);
-        return -1;
-    }
 
     /**
      * Initialize value changed callback.

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -142,11 +142,6 @@ void handle_value_changed(lwm2m_context_t * lwm2mH,
                 return;
             }
             dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA | LWM2M_TLV_FLAG_TEXT_FORMAT;
-#ifdef LWM2M_BOOTSTRAP
-            if (lwm2mH->bsState == BOOTSTRAP_PENDING) {
-                dataP->flags |= LWM2M_TLV_FLAG_BOOTSTRAPPING;
-            }
-#endif
             dataP->id = uri->resourceId;
             dataP->length = valueLength;
             dataP->value = (uint8_t*) value;
@@ -271,41 +266,83 @@ static void prv_output_servers(char * buffer,
     lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     lwm2m_server_t * targetP;
 
-    targetP = lwm2mH->serverList;
+    targetP = lwm2mH->bootstrapServerList;
 
-    if (targetP == NULL)
+    if (lwm2mH->bootstrapServerList == NULL)
     {
-        fprintf(stdout, "No server.\r\n");
-        return;
+        fprintf(stdout, "No Bootstrap Server.\r\n");
+    }
+    else
+    {
+        fprintf(stdout, "Bootstrap Servers:\r\n");
+        for (targetP = lwm2mH->bootstrapServerList ; targetP != NULL ; targetP = targetP->next)
+        {
+            fprintf(stdout, " - Security Object ID %d", targetP->secObjInstID);
+            fprintf(stdout, "\tHold Off Time: %lu s", (unsigned long)targetP->lifetime);
+            fprintf(stdout, "\tstatus: ");
+            switch(targetP->status)
+            {
+            case STATE_DEREGISTERED:
+                fprintf(stdout, "DEREGISTERED\r\n");
+                break;
+            case STATE_BS_HOLD_OFF:
+                fprintf(stdout, "CLIENT HOLD OFF\r\n");
+                break;
+            case STATE_BS_INITIATED:
+                fprintf(stdout, "BOOTSTRAP INITIATED\r\n");
+                break;
+            case STATE_BS_PENDING:
+                fprintf(stdout, "BOOTSTRAP PENDING\r\n");
+                break;
+            case STATE_BS_FINISHED:
+                fprintf(stdout, "BOOTSTRAP FINISHED\r\n");
+                break;
+            case STATE_BS_FAILED:
+                fprintf(stdout, "BOOTSTRAP FAILED\r\n");
+                break;
+            default:
+                fprintf(stdout, "INVALID (%d)\r\n", (int)targetP->status);
+            }
+            fprintf(stdout, "\r\n");
+        }
     }
 
-    for (targetP = lwm2mH->serverList ; targetP != NULL ; targetP = targetP->next)
+    if (lwm2mH->serverList == NULL)
     {
-        fprintf(stdout, "Server ID %d:\r\n", targetP->shortID);
-        fprintf(stdout, "\tstatus: ");
-        switch(targetP->status)
+        fprintf(stdout, "No LWM2M Server.\r\n");
+    }
+    else
+    {
+        fprintf(stdout, "LWM2M Servers:\r\n");
+        for (targetP = lwm2mH->serverList ; targetP != NULL ; targetP = targetP->next)
         {
-        case STATE_DEREGISTERED:
-            fprintf(stdout, "DEREGISTERED\r\n");
-            break;
-        case STATE_REG_PENDING:
-            fprintf(stdout, "REGISTRATION PENDING\r\n");
-            break;
-        case STATE_REGISTERED:
-            fprintf(stdout, "REGISTERED location: \"%s\"\r\n", targetP->location);
-            fprintf(stdout, "\tLifetime: %lu s\r\n", (unsigned long)targetP->lifetime);
-            break;
-        case STATE_REG_UPDATE_PENDING:
-            fprintf(stdout, "REGISTRATION UPDATE PENDING\r\n");
-            break;
-        case STATE_DEREG_PENDING:
-            fprintf(stdout, "DEREGISTRATION PENDING\r\n");
-            break;
-        case STATE_REG_FAILED:
-            fprintf(stdout, "REGISTRATION FAILED\r\n");
-            break;
+            fprintf(stdout, " - Server ID %d", targetP->shortID);
+            fprintf(stdout, "\tstatus: ");
+            switch(targetP->status)
+            {
+            case STATE_DEREGISTERED:
+                fprintf(stdout, "DEREGISTERED\r\n");
+                break;
+            case STATE_REG_PENDING:
+                fprintf(stdout, "REGISTRATION PENDING\r\n");
+                break;
+            case STATE_REGISTERED:
+                fprintf(stdout, "REGISTERED\tlocation: \"%s\"\tLifetime: %lus\r\n", targetP->location, (unsigned long)targetP->lifetime);
+                break;
+            case STATE_REG_UPDATE_PENDING:
+                fprintf(stdout, "REGISTRATION UPDATE PENDING\r\n");
+                break;
+            case STATE_DEREG_PENDING:
+                fprintf(stdout, "DEREGISTRATION PENDING\r\n");
+                break;
+            case STATE_REG_FAILED:
+                fprintf(stdout, "REGISTRATION FAILED\r\n");
+                break;
+            default:
+                fprintf(stdout, "INVALID (%d)\r\n", (int)targetP->status);
+            }
+            fprintf(stdout, "\r\n");
         }
-        fprintf(stdout, "\r\n");
     }
 }
 
@@ -488,9 +525,15 @@ static void prv_initiate_bootstrap(char * buffer,
                                    void * user_data)
 {
     lwm2m_context_t * lwm2mH = (lwm2m_context_t *)user_data;
-    if ((lwm2mH->bsState != BOOTSTRAP_CLIENT_HOLD_OFF)
-            && (lwm2mH->bsState != BOOTSTRAP_PENDING)) {
-        lwm2mH->bsState = BOOTSTRAP_REQUESTED;
+    lwm2m_server_t * targetP;
+    
+    // HACK !!!
+    lwm2mH->state = STATE_BOOTSTRAP_REQUIRED;
+    targetP = lwm2mH->bootstrapServerList;
+    while (targetP != NULL)
+    {
+        targetP->lifetime = 0;
+        targetP = targetP->next;
     }
 }
 
@@ -556,38 +599,6 @@ static void prv_display_backup(char * buffer,
                 }
             }
         }
-    }
-}
-
-static void prv_display_bootstrap_state(lwm2m_bootstrap_state_t bootstrapState)
-{
-    switch (bootstrapState) {
-    case NOT_BOOTSTRAPPED:
-        fprintf(stderr, "NOT BOOTSTRAPPED\r\n");
-        break;
-    case BOOTSTRAP_REQUESTED:
-        fprintf(stderr, "DI BOOTSTRAP REQUESTED\r\n");
-        break;
-    case BOOTSTRAP_CLIENT_HOLD_OFF:
-        fprintf(stderr, "DI BOOTSTRAP CLIENT HOLD OFF\r\n");
-        break;
-    case BOOTSTRAP_INITIATED:
-        fprintf(stderr, "DI BOOTSTRAP INITIATED\r\n");
-        break;
-    case BOOTSTRAP_PENDING:
-        fprintf(stderr, "DI BOOTSTRAP PENDING\r\n");
-        break;
-    case BOOTSTRAP_FINISHED:
-        fprintf(stderr, "DI BOOTSTRAP FINISHED\r\n");
-        break;
-    case BOOTSTRAP_FAILED:
-        fprintf(stderr, "DI BOOTSTRAP FAILED\r\n");
-        break;
-    case BOOTSTRAPPED:
-        fprintf(stderr, "BOOTSTRAPPED\r\n");
-        break;
-    default:
-        break;
     }
 }
 
@@ -680,41 +691,30 @@ static void prv_connections_free(lwm2m_context_t * context)
     }
 }
 
-static void update_bootstrap_info(lwm2m_bootstrap_state_t * previousBootstrapState,
+static void update_bootstrap_info(lwm2m_client_state_t * previousBootstrapState,
         lwm2m_context_t * context)
 {
-    if (*previousBootstrapState != context->bsState)
+    if (*previousBootstrapState != context->state)
     {
-        *previousBootstrapState = context->bsState;
-        switch(context->bsState)
+        *previousBootstrapState = context->state;
+        switch(context->state)
         {
-            case BOOTSTRAP_CLIENT_HOLD_OFF:
+            case STATE_BOOTSTRAPPING:
 #ifdef WITH_LOGS
                 fprintf(stdout, "[BOOTSTRAP] backup security and server objects\r\n");
 #endif
                 prv_backup_objects(context);
                 break;
-            case BOOTSTRAP_FINISHED:
+            case STATE_REGISTER_REQUIRED:
 #ifdef WITH_LOGS
                 fprintf(stdout, "[BOOTSTRAP] free connections\r\n");
 #endif
                 prv_connections_free(context);
                 break;
-            case BOOTSTRAP_FAILED:
-#ifdef WITH_LOGS
-                fprintf(stdout, "[BOOTSTRAP] restore security and server objects\r\n");
-#endif
-                prv_connections_free(context);
-                prv_restore_objects(context);
-                break;
             default:
                 break;
         }
     }
-
-#ifdef WITH_LOGS
-    prv_display_bootstrap_state(context->bsState);
-#endif
 }
 
 static void close_backup_object()
@@ -760,7 +760,7 @@ int main(int argc, char *argv[])
     lwm2m_context_t * lwm2mH = NULL;
     int i;
     const char * localPort = "56830";
-    const char * server = "localhost";
+    const char * server = "[::1]";
     const char * serverPort = LWM2M_STANDARD_PORT_STR;
     char * name = "testlwm2mclient";
     int lifetime = 300;
@@ -769,7 +769,7 @@ int main(int argc, char *argv[])
     int opt;
     bool bootstrapRequested = false;
 #ifdef LWM2M_BOOTSTRAP
-    lwm2m_bootstrap_state_t previousBootstrapState = NOT_BOOTSTRAPPED;
+    lwm2m_client_state_t previousState = STATE_INITIAL;
 #endif
 
     /*
@@ -789,11 +789,11 @@ int main(int argc, char *argv[])
                                                         "   SERVER: short server id such as 123\r\n", prv_update, NULL},
 #ifdef LWM2M_BOOTSTRAP
             {"bootstrap", "Initiate a DI bootstrap process", NULL, prv_initiate_bootstrap, NULL},
-            {"disp", "Display current objects/instances/resources", NULL, prv_display_objects, NULL},
             {"dispb", "Display current backup of objects/instances/resources\r\n"
                     "\t(only security and server objects are backupped)", NULL, prv_display_backup, NULL},
 #endif
             {"ls", "List Objects and Instances", NULL, prv_object_list, NULL},
+            {"disp", "Display current objects/instances/resources", NULL, prv_display_objects, NULL},
             {"dump", "Dump an Object", "dump URI"
                                        "URI: uri of the Object or Instance such as /3/0, /1\r\n", prv_object_dump, NULL},
             {"quit", "Quit the client gracefully.", NULL, prv_quit, NULL},
@@ -947,20 +947,6 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-#ifdef LWM2M_BOOTSTRAP
-    /*
-     * Bootstrap state initialization
-     */
-    if (bootstrapRequested)
-    {
-        lwm2mH->bsState = BOOTSTRAP_REQUESTED;
-    }
-    else
-    {
-        lwm2mH->bsState = NOT_BOOTSTRAPPED;
-    }
-#endif
-
     /*
      * We configure the liblwm2m library with the name of the client - which shall be unique for each client -
      * the number of objects we will be passing through and the objects array
@@ -1045,10 +1031,19 @@ int main(int argc, char *argv[])
         if (result != 0)
         {
             fprintf(stderr, "lwm2m_step() failed: 0x%X\r\n", result);
-            return -1;
+            if(previousState == STATE_BOOTSTRAPPING)
+            {
+#ifdef WITH_LOGS
+                fprintf(stdout, "[BOOTSTRAP] restore security and server objects\r\n");
+#endif
+                prv_connections_free(lwm2mH);
+                prv_restore_objects(lwm2mH);
+                lwm2mH->state = STATE_INITIAL;
+            }
+            else return -1;
         }
 #ifdef LWM2M_BOOTSTRAP
-        update_bootstrap_info(&previousBootstrapState, lwm2mH);
+        update_bootstrap_info(&previousState, lwm2mH);
 #endif
         /*
          * This part will set up an interruption until an event happen on SDTIN or the socket until "tv" timed out (set

--- a/tests/client/object_security.c
+++ b/tests/client/object_security.c
@@ -218,8 +218,6 @@ static uint8_t prv_security_write(uint16_t instanceId,
     int i;
     uint8_t result = COAP_204_CHANGED;
 
-    if ((dataArray->flags & LWM2M_TLV_FLAG_BOOTSTRAPPING) == 0) return COAP_401_UNAUTHORIZED;
-
     targetP = (security_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP)
     {

--- a/tests/client/object_server.c
+++ b/tests/client/object_server.c
@@ -185,11 +185,7 @@ static uint8_t prv_server_write(uint16_t instanceId,
     server_instance_t * targetP;
     int i;
     uint8_t result;
-#ifdef LWM2M_BOOTSTRAP
-    bool bootstrapPending;
 
-    bootstrapPending = (dataArray->flags & LWM2M_TLV_FLAG_BOOTSTRAPPING) != 0;
-#endif
     targetP = (server_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP)
     {
@@ -202,8 +198,6 @@ static uint8_t prv_server_write(uint16_t instanceId,
         switch (dataArray[i].id)
         {
         case LWM2M_SERVER_SHORT_ID_ID:
-#ifdef LWM2M_BOOTSTRAP
-            if (bootstrapPending)
             {
                 uint32_t value = targetP->shortServerId;
                 result = prv_set_int_value(dataArray + i, &value);
@@ -218,14 +212,6 @@ static uint8_t prv_server_write(uint16_t instanceId,
                         result = COAP_406_NOT_ACCEPTABLE;
                     }
                 }
-            }
-            else
-#endif
-            {
-#ifdef WITH_LOGS
-                fprintf(stderr, "    >>>> server is not allowed to write short ID\r\n");
-#endif
-                result = COAP_405_METHOD_NOT_ALLOWED;
             }
             break;
 

--- a/tests/lightclient/lightclient.c
+++ b/tests/lightclient/lightclient.c
@@ -233,7 +233,7 @@ void print_state(lwm2m_context_t * lwm2mH)
         fprintf(stderr, "Bootstrap Servers:\r\n");
         for (targetP = lwm2mH->serverList ; targetP != NULL ; targetP = targetP->next)
         {
-            fprintf(stderr, "Security Object ID %d", targetP->secObjInstID);
+            fprintf(stderr, " - Security Object ID %d", targetP->secObjInstID);
             fprintf(stderr, "\tHold Off Time: %lu s", (unsigned long)targetP->lifetime);
             fprintf(stderr, "\tstatus: ");
             switch(targetP->status)
@@ -272,7 +272,7 @@ void print_state(lwm2m_context_t * lwm2mH)
         fprintf(stderr, "LWM2M Servers:\r\n");
         for (targetP = lwm2mH->serverList ; targetP != NULL ; targetP = targetP->next)
         {
-            fprintf(stderr, "Server ID %d", targetP->shortID);
+            fprintf(stderr, " - Server ID %d", targetP->shortID);
             fprintf(stderr, "\tstatus: ");
             switch(targetP->status)
             {

--- a/tests/lightclient/lightclient.c
+++ b/tests/lightclient/lightclient.c
@@ -295,16 +295,6 @@ int main(int argc, char *argv[])
      */
     signal(SIGINT, handle_sigint);
 
-    /*
-     * This function start your client to the LWM2M servers
-     */
-    result = lwm2m_start(lwm2mH);
-    if (result != 0)
-    {
-        fprintf(stderr, "lwm2m_start() failed: 0x%X\r\n", result);
-        return -1;
-    }
-
     fprintf(stdout, "LWM2M Client \"%s\" started on port %s.\r\nUse Ctrl-C to exit.\r\n\n", name, localPort);
 
     /*

--- a/tests/lightclient/lightclient.c
+++ b/tests/lightclient/lightclient.c
@@ -231,7 +231,7 @@ void print_state(lwm2m_context_t * lwm2mH)
     else
     {
         fprintf(stderr, "Bootstrap Servers:\r\n");
-        for (targetP = lwm2mH->serverList ; targetP != NULL ; targetP = targetP->next)
+        for (targetP = lwm2mH->bootstrapServerList ; targetP != NULL ; targetP = targetP->next)
         {
             fprintf(stderr, " - Security Object ID %d", targetP->secObjInstID);
             fprintf(stderr, "\tHold Off Time: %lu s", (unsigned long)targetP->lifetime);

--- a/tests/lightclient/lightclient.c
+++ b/tests/lightclient/lightclient.c
@@ -193,35 +193,113 @@ void print_usage(void)
 
 void print_state(lwm2m_context_t * lwm2mH)
 {
-    fprintf(stdout, "State: ");
+    lwm2m_server_t * targetP;
+
+    fprintf(stderr, "State: ");
     switch(lwm2mH->state)
     {
     case STATE_INITIAL:
-        fprintf(stdout, "STATE_INITIAL");
+        fprintf(stderr, "STATE_INITIAL");
         break;
     case STATE_BOOTSTRAP_REQUIRED:
-        fprintf(stdout, "STATE_BOOTSTRAP_REQUIRED");
-        break;
-    case STATE_HOLD_OFF:
-        fprintf(stdout, "STATE_HOLD_OFF");
-        break;
-    case STATE_CLIENT_INITIATED:
-        fprintf(stdout, "STATE_CLIENT_INITIATED");
+        fprintf(stderr, "STATE_BOOTSTRAP_REQUIRED");
         break;
     case STATE_BOOTSTRAPPING:
-        fprintf(stdout, "STATE_BOOTSTRAPPING");
+        fprintf(stderr, "STATE_BOOTSTRAPPING");
+        break;
+    case STATE_REGISTER_REQUIRED:
+        fprintf(stderr, "STATE_REGISTER_REQUIRED");
         break;
     case STATE_REGISTERING:
-        fprintf(stdout, "STATE_REGISTERING");
+        fprintf(stderr, "STATE_REGISTERING");
         break;
     case STATE_READY:
-        fprintf(stdout, "STATE_READY");
+        fprintf(stderr, "STATE_READY");
         break;
     default:
-        fprintf(stdout, "Unknown !");
+        fprintf(stderr, "Unknown !");
         break;
     }
-    fprintf(stdout, "\r\n");
+    fprintf(stderr, "\r\n");
+
+    targetP = lwm2mH->bootstrapServerList;
+
+    if (lwm2mH->bootstrapServerList == NULL)
+    {
+        fprintf(stderr, "No Bootstrap Server.\r\n");
+    }
+    else
+    {
+        fprintf(stderr, "Bootstrap Servers:\r\n");
+        for (targetP = lwm2mH->serverList ; targetP != NULL ; targetP = targetP->next)
+        {
+            fprintf(stderr, "Security Object ID %d", targetP->secObjInstID);
+            fprintf(stderr, "\tHold Off Time: %lu s", (unsigned long)targetP->lifetime);
+            fprintf(stderr, "\tstatus: ");
+            switch(targetP->status)
+            {
+            case STATE_DEREGISTERED:
+                fprintf(stderr, "DEREGISTERED\r\n");
+                break;
+            case STATE_BS_HOLD_OFF:
+                fprintf(stderr, "CLIENT HOLD OFF\r\n");
+                break;
+            case STATE_BS_INITIATED:
+                fprintf(stderr, "BOOTSTRAP INITIATED\r\n");
+                break;
+            case STATE_BS_PENDING:
+                fprintf(stderr, "BOOTSTRAP PENDING\r\n");
+                break;
+            case STATE_BS_FINISHED:
+                fprintf(stderr, "BOOTSTRAP FINISHED\r\n");
+                break;
+            case STATE_BS_FAILED:
+                fprintf(stderr, "BOOTSTRAP FAILED\r\n");
+                break;
+            default:
+                fprintf(stderr, "INVALID (%d)\r\n", (int)targetP->status);
+            }
+            fprintf(stderr, "\r\n");
+        }
+    }
+
+    if (lwm2mH->serverList == NULL)
+    {
+        fprintf(stderr, "No LWM2M Server.\r\n");
+    }
+    else
+    {
+        fprintf(stderr, "LWM2M Servers:\r\n");
+        for (targetP = lwm2mH->serverList ; targetP != NULL ; targetP = targetP->next)
+        {
+            fprintf(stderr, "Server ID %d", targetP->shortID);
+            fprintf(stderr, "\tstatus: ");
+            switch(targetP->status)
+            {
+            case STATE_DEREGISTERED:
+                fprintf(stderr, "DEREGISTERED\r\n");
+                break;
+            case STATE_REG_PENDING:
+                fprintf(stderr, "REGISTRATION PENDING\r\n");
+                break;
+            case STATE_REGISTERED:
+                fprintf(stderr, "REGISTERED\tlocation: \"%s\"\tLifetime: %lus\r\n", targetP->location, (unsigned long)targetP->lifetime);
+                break;
+            case STATE_REG_UPDATE_PENDING:
+                fprintf(stderr, "REGISTRATION UPDATE PENDING\r\n");
+                break;
+            case STATE_DEREG_PENDING:
+                fprintf(stderr, "DEREGISTRATION PENDING\r\n");
+                break;
+            case STATE_REG_FAILED:
+                fprintf(stderr, "REGISTRATION FAILED\r\n");
+                break;
+            default:
+                fprintf(stderr, "INVALID (%d)\r\n", (int)targetP->status);
+            }
+            fprintf(stderr, "\r\n");
+        }
+    }
 }
 
 #define OBJ_COUNT 4

--- a/tests/lightclient/lightclient.c
+++ b/tests/lightclient/lightclient.c
@@ -191,6 +191,39 @@ void print_usage(void)
     fprintf(stdout, "\r\n");
 }
 
+void print_state(lwm2m_context_t * lwm2mH)
+{
+    fprintf(stdout, "State: ");
+    switch(lwm2mH->state)
+    {
+    case STATE_INITIAL:
+        fprintf(stdout, "STATE_INITIAL");
+        break;
+    case STATE_BOOTSTRAP_REQUIRED:
+        fprintf(stdout, "STATE_BOOTSTRAP_REQUIRED");
+        break;
+    case STATE_HOLD_OFF:
+        fprintf(stdout, "STATE_HOLD_OFF");
+        break;
+    case STATE_CLIENT_INITIATED:
+        fprintf(stdout, "STATE_CLIENT_INITIATED");
+        break;
+    case STATE_BOOTSTRAPPING:
+        fprintf(stdout, "STATE_BOOTSTRAPPING");
+        break;
+    case STATE_REGISTERING:
+        fprintf(stdout, "STATE_REGISTERING");
+        break;
+    case STATE_READY:
+        fprintf(stdout, "STATE_READY");
+        break;
+    default:
+        fprintf(stdout, "Unknown !");
+        break;
+    }
+    fprintf(stdout, "\r\n");
+}
+
 #define OBJ_COUNT 4
 
 int main(int argc, char *argv[])
@@ -203,7 +236,6 @@ int main(int argc, char *argv[])
     char * name = "testlwm2mclient";
 
     int result;
-    int i;
     int opt;
 
     memset(&data, 0, sizeof(client_data_t));
@@ -310,6 +342,8 @@ int main(int argc, char *argv[])
 
         FD_ZERO(&readfds);
         FD_SET(data.sock, &readfds);
+
+        print_state(lwm2mH);
 
         /*
          * This function does two things:

--- a/tests/secureclient/object_security.c
+++ b/tests/secureclient/object_security.c
@@ -211,13 +211,11 @@ static uint8_t prv_security_write(uint16_t instanceId,
     int i;
     uint8_t result = COAP_204_CHANGED;
 
-    if ((dataArray->flags & LWM2M_TLV_FLAG_BOOTSTRAPPING) == 0) return COAP_401_UNAUTHORIZED;
-
     targetP = (security_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP)
     {
         return COAP_404_NOT_FOUND;
-   }
+    }
 
     i = 0;
     do {
@@ -486,6 +484,7 @@ lwm2m_object_t * get_security_object(int shortId, char* url, char * bsPskId, cha
     securityObj->readFunc = prv_security_read;
     securityObj->writeFunc = prv_security_write;
     securityObj->createFunc = prv_security_create;
+    securityObj->deleteFunc = prv_security_delete;
     return securityObj;
 }
 

--- a/tests/secureclient/secureclient.c
+++ b/tests/secureclient/secureclient.c
@@ -307,16 +307,6 @@ int main(int argc, char *argv[])
      */
     signal(SIGINT, handle_sigint);
 
-    /*
-     * This function start your client to the LWM2M servers
-     */
-    result = lwm2m_start(lwm2mH);
-    if (result != 0)
-    {
-        fprintf(stderr, "lwm2m_start() failed: 0x%X\r\n", result);
-        return -1;
-    }
-
     fprintf(stdout, "LWM2M Client \"%s\" started on port %s.\r\nUse Ctrl-C to exit.\r\n\n", name, localPort);
 
     /*

--- a/tests/utils/connection.c
+++ b/tests/utils/connection.c
@@ -21,6 +21,10 @@
 #include <ctype.h>
 #include "connection.h"
 
+// from commandline.c
+void output_buffer(FILE * stream, uint8_t * buffer, int length, int indent);
+
+
 int create_socket(const char * portStr)
 {
     int s = -1;


### PR DESCRIPTION
When starting in Client mode, there is now a state machine. If LWM2M Servers are provisionned, the core starts to register to them. If all the registrations fail or if there are no LWM2M Servers, we start the bootstrap process. At the end of the bootstrap we return to the initial state.
The bootstrap state is now stored per server. This allows multiple Bootstrap Servers. The bsTimer is gone (for now).
Regarding Bootstrap Operations, the "Delete /" now deletes all instances of all objects. "Delete /n" is now supported.

This is still a Work In Progress for review until next year.
TODOs:
- Unsecure Bootstrap servers accounts cleanup
- Decide client behavior regarding registered LWM2M Servers after a Server Initiated Bootstrap.
- Client can enter a infinite loop if the registration fails
- Fix secure client.
- Test concurrency with multiple Bootstrap Servers.
