### PR TITLE
Observe conditions

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -181,6 +181,7 @@ int prv_get_number(uint8_t * uriString, size_t uriLength);
 // defined in objects.c
 coap_status_t object_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t * formatP, uint8_t ** bufferP, size_t * lengthP);
 coap_status_t object_write(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
+coap_status_t object_write_attributes(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_attributes_t * attrP);
 coap_status_t object_create(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 coap_status_t object_execute(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * buffer, size_t length);
 coap_status_t object_delete(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);

--- a/core/internals.h
+++ b/core/internals.h
@@ -167,13 +167,6 @@ typedef struct
 } bs_data_t;
 #endif
 
-typedef struct _obs_list_
-{
-    struct _obs_list_ * next;
-    lwm2m_observed_t * item;
-} obs_list_t;
-
-
 // defined in uri.c
 int lwm2m_get_number(char * uriString, size_t uriLength);
 lwm2m_uri_t * lwm2m_decode_uri(char * altPath, multi_option_t *uriPath);
@@ -208,6 +201,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, 
 coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
 void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, void * fromSessionH);
 coap_status_t observe_set_parameters(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, lwm2m_attributes_t * attrP);
+void observation_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
 // defined in registration.c
 coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);

--- a/core/internals.h
+++ b/core/internals.h
@@ -181,7 +181,6 @@ int prv_get_number(uint8_t * uriString, size_t uriLength);
 // defined in objects.c
 coap_status_t object_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t * formatP, uint8_t ** bufferP, size_t * lengthP);
 coap_status_t object_write(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
-coap_status_t object_write_attributes(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_attributes_t * attrP);
 coap_status_t object_create(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 coap_status_t object_execute(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * buffer, size_t length);
 coap_status_t object_delete(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);

--- a/core/internals.h
+++ b/core/internals.h
@@ -199,7 +199,7 @@ void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * t
 coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
 
 // defined in observe.c
-coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
+coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, int size, lwm2m_data_t * dataP, coap_packet_t * message, coap_packet_t * response);
 void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, void * fromSessionH);
 coap_status_t observe_set_parameters(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, lwm2m_attributes_t * attrP);
 void observation_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);

--- a/core/internals.h
+++ b/core/internals.h
@@ -173,6 +173,7 @@ lwm2m_uri_t * lwm2m_decode_uri(char * altPath, multi_option_t *uriPath);
 int prv_get_number(uint8_t * uriString, size_t uriLength);
 
 // defined in objects.c
+coap_status_t object_data_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);
 coap_status_t object_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t * formatP, uint8_t ** bufferP, size_t * lengthP);
 coap_status_t object_write(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 coap_status_t object_create(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);

--- a/core/internals.h
+++ b/core/internals.h
@@ -140,6 +140,7 @@
 #define ATTR_DIMENSION_STR       "dim="
 #define ATTR_DIMENSION_LEN       4
 
+#define ATTR_FLAG_NUMERIC (uint8_t)(LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP)
 
 #define LWM2M_URI_FLAG_DM           (uint8_t)0x00
 #define LWM2M_URI_FLAG_DELETE_ALL   (uint8_t)0x10
@@ -185,6 +186,8 @@ coap_status_t object_create(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2
 coap_status_t object_execute(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * buffer, size_t length);
 coap_status_t object_delete(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 coap_status_t object_delete_others(lwm2m_context_t * contextP, uint16_t objectId, uint16_t instanceId);
+uint8_t object_checkReadable(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
+uint8_t object_checkNumeric(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 bool object_isInstanceNew(lwm2m_context_t * contextP, uint16_t objectId, uint16_t instanceId);
 int prv_getRegisterPayload(lwm2m_context_t * contextP, uint8_t * buffer, size_t length);
 int object_getServers(lwm2m_context_t * contextP);
@@ -204,6 +207,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, 
 // defined in observe.c
 coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
 void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, void * fromSessionH);
+coap_status_t observe_set_parameters(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, lwm2m_attributes_t * attrP);
 
 // defined in registration.c
 coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -406,6 +406,7 @@ next_step:
         break;
     }
 
+    observation_step(contextP, tv_sec, timeoutP);
 #endif
 
     registration_step(contextP, tv_sec, timeoutP);

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -128,10 +128,15 @@ void delete_observed_list(lwm2m_context_t * contextP)
     while (NULL != contextP->observedList)
     {
         lwm2m_observed_t * targetP;
+        lwm2m_watcher_t * watcherP;
 
         targetP = contextP->observedList;
         contextP->observedList = contextP->observedList->next;
 
+        for (watcherP = targetP->watcherList ; watcherP != NULL ; watcherP = watcherP->next)
+        {
+            if (watcherP->parameters != NULL) lwm2m_free(watcherP->parameters);
+        }
         LWM2M_LIST_FREE(targetP->watcherList);
 
         lwm2m_free(targetP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -345,6 +345,29 @@ typedef struct
 // Invalid URIs: /, //, //2, /1//, /1//3, /1/2/3/, /1/2/3/4
 int lwm2m_stringToUri(const char * buffer, size_t buffer_len, lwm2m_uri_t * uriP);
 
+/*
+ * LWM2M Link Attributes
+ *
+ * Used for observation parameters.
+ *
+ */
+
+#define LWM2M_ATTR_FLAG_MIN_PERIOD      (uint8_t)0x01
+#define LWM2M_ATTR_FLAG_MAX_PERIOD      (uint8_t)0x02
+#define LWM2M_ATTR_FLAG_GREATER_THAN    (uint8_t)0x04
+#define LWM2M_ATTR_FLAG_LESS_THAN       (uint8_t)0x08
+#define LWM2M_ATTR_FLAG_STEP            (uint8_t)0x10
+
+typedef struct
+{
+    uint8_t     toSet;
+    uint8_t     toClear;
+    uint32_t    minPeriod;
+    uint32_t    maxPeriod;
+    float       greaterThan;
+    float       lessThan;
+    float       step;
+} lwm2m_attributes_t;
 
 /*
  * LWM2M Objects
@@ -358,6 +381,7 @@ typedef struct _lwm2m_object_t lwm2m_object_t;
 
 typedef uint8_t (*lwm2m_read_callback_t) (uint16_t instanceId, int * numDataP, lwm2m_data_t ** dataArrayP, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_write_callback_t) (uint16_t instanceId, int numData, lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
+typedef uint8_t (*lwm2m_attributes_callback_t) (lwm2m_uri_t * uriP, lwm2m_attributes_t * attrP, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_execute_callback_t) (uint16_t instanceId, uint16_t resourceId, uint8_t * buffer, int length, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_create_callback_t) (uint16_t instanceId, int numData, lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_delete_callback_t) (uint16_t instanceId, lwm2m_object_t * objectP);
@@ -371,6 +395,7 @@ struct _lwm2m_object_t
     lwm2m_execute_callback_t executeFunc;
     lwm2m_create_callback_t  createFunc;
     lwm2m_delete_callback_t  deleteFunc;
+    lwm2m_attributes_callback_t attributesFunc;
     void *                   userData;
 };
 
@@ -448,30 +473,6 @@ typedef struct _lwm2m_observation_
     lwm2m_result_callback_t callback;
     void *                  userData;
 } lwm2m_observation_t;
-
-/*
- * LWM2M Link Attributes
- *
- * Used for observation parameters.
- *
- */
-
-#define LWM2M_ATTR_FLAG_MIN_PERIOD      (uint8_t)0x01
-#define LWM2M_ATTR_FLAG_MAX_PERIOD      (uint8_t)0x02
-#define LWM2M_ATTR_FLAG_GREATER_THAN    (uint8_t)0x04
-#define LWM2M_ATTR_FLAG_LESS_THAN       (uint8_t)0x08
-#define LWM2M_ATTR_FLAG_STEP            (uint8_t)0x10
-
-typedef struct
-{
-    uint8_t     toSet;
-    uint8_t     toClear;
-    uint32_t    minPeriod;
-    uint32_t    maxPeriod;
-    float       greaterThan;
-    float       lessThan;
-    float       step;
-} lwm2m_attributes_t;
 
 /*
  * LWM2M Clients

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -550,10 +550,12 @@ typedef struct _lwm2m_watcher_
     struct _lwm2m_watcher_ * next;
 
     bool active;
+    bool update;
     lwm2m_server_t * server;
     lwm2m_attributes_t * parameters;
     uint8_t token[8];
     size_t tokenLen;
+    time_t lastTime;
     uint32_t counter;
     uint16_t lastMid;
 } lwm2m_watcher_t;
@@ -563,7 +565,6 @@ typedef struct _lwm2m_observed_
     struct _lwm2m_observed_ * next;
 
     lwm2m_uri_t uri;
-    bool update;
     lwm2m_watcher_t * watcherList;
 } lwm2m_observed_t;
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -563,6 +563,7 @@ typedef struct _lwm2m_observed_
     struct _lwm2m_observed_ * next;
 
     lwm2m_uri_t uri;
+    bool update;
     lwm2m_watcher_t * watcherList;
 } lwm2m_observed_t;
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -325,8 +325,8 @@ int lwm2m_opaqueToFloat(uint8_t * buffer, size_t buffer_len, double * dataP);
 #define LWM2M_URI_FLAG_INSTANCE_ID  (uint8_t)0x02
 #define LWM2M_URI_FLAG_RESOURCE_ID  (uint8_t)0x01
 
-#define LWM2M_URI_IS_SET_INSTANCE(uri) ((uri->flag & LWM2M_URI_FLAG_INSTANCE_ID) != 0)
-#define LWM2M_URI_IS_SET_RESOURCE(uri) ((uri->flag & LWM2M_URI_FLAG_RESOURCE_ID) != 0)
+#define LWM2M_URI_IS_SET_INSTANCE(uri) (((uri)->flag & LWM2M_URI_FLAG_INSTANCE_ID) != 0)
+#define LWM2M_URI_IS_SET_RESOURCE(uri) (((uri)->flag & LWM2M_URI_FLAG_RESOURCE_ID) != 0)
 
 typedef struct
 {
@@ -468,9 +468,9 @@ typedef struct
     uint8_t     toClear;
     uint32_t    minPeriod;
     uint32_t    maxPeriod;
-    float       greaterThan;
-    float       lessThan;
-    float       step;
+    double      greaterThan;
+    double      lessThan;
+    double      step;
 } lwm2m_attributes_t;
 
 /*
@@ -558,6 +558,11 @@ typedef struct _lwm2m_watcher_
     time_t lastTime;
     uint32_t counter;
     uint16_t lastMid;
+    union
+    {
+        int64_t asInteger;
+        double  asFloat;
+    } lastValue;
 } lwm2m_watcher_t;
 
 typedef struct _lwm2m_observed_

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -549,7 +549,9 @@ typedef struct _lwm2m_watcher_
 {
     struct _lwm2m_watcher_ * next;
 
+    bool active;
     lwm2m_server_t * server;
+    lwm2m_attributes_t * parameters;
     uint8_t token[8];
     size_t tokenLen;
     uint32_t counter;

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -345,29 +345,6 @@ typedef struct
 // Invalid URIs: /, //, //2, /1//, /1//3, /1/2/3/, /1/2/3/4
 int lwm2m_stringToUri(const char * buffer, size_t buffer_len, lwm2m_uri_t * uriP);
 
-/*
- * LWM2M Link Attributes
- *
- * Used for observation parameters.
- *
- */
-
-#define LWM2M_ATTR_FLAG_MIN_PERIOD      (uint8_t)0x01
-#define LWM2M_ATTR_FLAG_MAX_PERIOD      (uint8_t)0x02
-#define LWM2M_ATTR_FLAG_GREATER_THAN    (uint8_t)0x04
-#define LWM2M_ATTR_FLAG_LESS_THAN       (uint8_t)0x08
-#define LWM2M_ATTR_FLAG_STEP            (uint8_t)0x10
-
-typedef struct
-{
-    uint8_t     toSet;
-    uint8_t     toClear;
-    uint32_t    minPeriod;
-    uint32_t    maxPeriod;
-    float       greaterThan;
-    float       lessThan;
-    float       step;
-} lwm2m_attributes_t;
 
 /*
  * LWM2M Objects
@@ -381,7 +358,6 @@ typedef struct _lwm2m_object_t lwm2m_object_t;
 
 typedef uint8_t (*lwm2m_read_callback_t) (uint16_t instanceId, int * numDataP, lwm2m_data_t ** dataArrayP, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_write_callback_t) (uint16_t instanceId, int numData, lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
-typedef uint8_t (*lwm2m_attributes_callback_t) (lwm2m_uri_t * uriP, lwm2m_attributes_t * attrP, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_execute_callback_t) (uint16_t instanceId, uint16_t resourceId, uint8_t * buffer, int length, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_create_callback_t) (uint16_t instanceId, int numData, lwm2m_data_t * dataArray, lwm2m_object_t * objectP);
 typedef uint8_t (*lwm2m_delete_callback_t) (uint16_t instanceId, lwm2m_object_t * objectP);
@@ -395,7 +371,6 @@ struct _lwm2m_object_t
     lwm2m_execute_callback_t executeFunc;
     lwm2m_create_callback_t  createFunc;
     lwm2m_delete_callback_t  deleteFunc;
-    lwm2m_attributes_callback_t attributesFunc;
     void *                   userData;
 };
 
@@ -473,6 +448,30 @@ typedef struct _lwm2m_observation_
     lwm2m_result_callback_t callback;
     void *                  userData;
 } lwm2m_observation_t;
+
+/*
+ * LWM2M Link Attributes
+ *
+ * Used for observation parameters.
+ *
+ */
+
+#define LWM2M_ATTR_FLAG_MIN_PERIOD      (uint8_t)0x01
+#define LWM2M_ATTR_FLAG_MAX_PERIOD      (uint8_t)0x02
+#define LWM2M_ATTR_FLAG_GREATER_THAN    (uint8_t)0x04
+#define LWM2M_ATTR_FLAG_LESS_THAN       (uint8_t)0x08
+#define LWM2M_ATTR_FLAG_STEP            (uint8_t)0x10
+
+typedef struct
+{
+    uint8_t     toSet;
+    uint8_t     toClear;
+    uint32_t    minPeriod;
+    uint32_t    maxPeriod;
+    float       greaterThan;
+    float       lessThan;
+    float       step;
+} lwm2m_attributes_t;
 
 /*
  * LWM2M Clients

--- a/core/management.c
+++ b/core/management.c
@@ -53,6 +53,113 @@
 
 
 #ifdef LWM2M_CLIENT_MODE
+static int prv_readAttributes(multi_option_t * query,
+                              lwm2m_attributes_t * attrP)
+{
+    int64_t intValue;
+    double floatValue;
+
+    memset(attrP, 0, sizeof(lwm2m_attributes_t));
+
+    while (query != NULL)
+    {
+        if (lwm2m_strncmp((char *)query->data, ATTR_MIN_PERIOD_STR, ATTR_MIN_PERIOD_LEN) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_MIN_PERIOD)) return -1;
+            if (query->len == ATTR_MIN_PERIOD_LEN) return -1;
+
+            if (1 != lwm2m_PlainTextToInt64(query->data + ATTR_MIN_PERIOD_LEN, query->len - ATTR_MIN_PERIOD_LEN, &intValue)) return -1;
+            if (intValue < 0) return -1;
+
+            attrP->toSet |= LWM2M_ATTR_FLAG_MIN_PERIOD;
+            attrP->minPeriod = intValue;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_MIN_PERIOD_STR, ATTR_MIN_PERIOD_LEN - 1) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_MIN_PERIOD)) return -1;
+            if (query->len != ATTR_MIN_PERIOD_LEN - 1) return -1;
+
+            attrP->toClear |= LWM2M_ATTR_FLAG_MIN_PERIOD;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_MAX_PERIOD_STR, ATTR_MAX_PERIOD_LEN) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_MAX_PERIOD)) return -1;
+            if (query->len == ATTR_MAX_PERIOD_LEN) return -1;
+
+            if (1 != lwm2m_PlainTextToInt64(query->data + ATTR_MAX_PERIOD_LEN, query->len - ATTR_MAX_PERIOD_LEN, &intValue)) return -1;
+            if (intValue < 0) return -1;
+
+            attrP->toSet |= LWM2M_ATTR_FLAG_MAX_PERIOD;
+            attrP->maxPeriod = intValue;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_MAX_PERIOD_STR, ATTR_MAX_PERIOD_LEN - 1) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_MAX_PERIOD)) return -1;
+            if (query->len != ATTR_MAX_PERIOD_LEN - 1) return -1;
+
+            attrP->toClear |= LWM2M_ATTR_FLAG_MAX_PERIOD;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_GREATER_THAN_STR, ATTR_GREATER_THAN_LEN) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_GREATER_THAN)) return -1;
+            if (query->len == ATTR_GREATER_THAN_LEN) return -1;
+
+            if (1 != lwm2m_PlainTextToFloat64(query->data + ATTR_GREATER_THAN_LEN, query->len - ATTR_GREATER_THAN_LEN, &floatValue)) return -1;
+            if (floatValue < 0) return -1;
+
+            attrP->toSet |= LWM2M_ATTR_FLAG_GREATER_THAN;
+            attrP->greaterThan = floatValue;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_GREATER_THAN_STR, ATTR_GREATER_THAN_LEN - 1) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_GREATER_THAN)) return -1;
+            if (query->len != ATTR_GREATER_THAN_LEN - 1) return -1;
+
+            attrP->toClear |= LWM2M_ATTR_FLAG_GREATER_THAN;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_LESS_THAN_STR, ATTR_LESS_THAN_LEN) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_LESS_THAN)) return -1;
+            if (query->len == ATTR_LESS_THAN_LEN) return -1;
+
+            if (1 != lwm2m_PlainTextToFloat64(query->data + ATTR_LESS_THAN_LEN, query->len - ATTR_LESS_THAN_LEN, &floatValue)) return -1;
+            if (floatValue < 0) return -1;
+
+            attrP->toSet |= LWM2M_ATTR_FLAG_LESS_THAN;
+            attrP->lessThan = floatValue;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_LESS_THAN_STR, ATTR_LESS_THAN_LEN - 1) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_LESS_THAN)) return -1;
+            if (query->len != ATTR_LESS_THAN_LEN - 1) return -1;
+
+            attrP->toClear |= LWM2M_ATTR_FLAG_LESS_THAN;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_STEP_STR, ATTR_STEP_LEN) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_STEP)) return -1;
+            if (query->len == ATTR_STEP_LEN) return -1;
+
+            if (1 != lwm2m_PlainTextToFloat64(query->data + ATTR_STEP_LEN, query->len - ATTR_STEP_LEN, &floatValue)) return -1;
+            if (floatValue < 0) return -1;
+
+            attrP->toSet |= LWM2M_ATTR_FLAG_STEP;
+            attrP->step = floatValue;
+        }
+        else if (lwm2m_strncmp((char *)query->data, ATTR_STEP_STR, ATTR_STEP_LEN - 1) == 0)
+        {
+            if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_STEP)) return -1;
+            if (query->len != ATTR_STEP_LEN - 1) return -1;
+
+            attrP->toClear |= LWM2M_ATTR_FLAG_STEP;
+        }
+
+        query = query->next;
+    }
+
+    return 0;
+}
+
 coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                                 lwm2m_uri_t * uriP,
                                 lwm2m_server_t * serverP,
@@ -149,13 +256,26 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
 
     case COAP_PUT:
         {
-            if (LWM2M_URI_IS_SET_INSTANCE(uriP))
+            if (IS_OPTION(message, COAP_OPTION_URI_QUERY))
+            {
+                lwm2m_attributes_t attr;
+
+                if (0 != prv_readAttributes(message->uri_query, &attr))
+                {
+                    result = COAP_400_BAD_REQUEST;
+                }
+                else
+                {
+                    result = object_write_attributes(contextP, uriP, &attr);
+                }
+            }
+            else if (LWM2M_URI_IS_SET_INSTANCE(uriP))
             {
                 result = object_write(contextP, uriP, format, message->payload, message->payload_len);
             }
             else
             {
-                result = BAD_REQUEST_4_00;
+                result = COAP_400_BAD_REQUEST;
             }
         }
         break;
@@ -164,7 +284,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
         {
             if (!LWM2M_URI_IS_SET_INSTANCE(uriP) || LWM2M_URI_IS_SET_RESOURCE(uriP))
             {
-                result = BAD_REQUEST_4_00;
+                result = COAP_400_BAD_REQUEST;
             }
             else
             {
@@ -174,7 +294,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
         break;
 
     default:
-        result = BAD_REQUEST_4_00;
+        result = COAP_400_BAD_REQUEST;
         break;
     }
 

--- a/core/management.c
+++ b/core/management.c
@@ -266,7 +266,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                 }
                 else
                 {
-                    result = object_write_attributes(contextP, uriP, &attr);
+                    result = COAP_501_NOT_IMPLEMENTED; //object_write_attributes(contextP, uriP, &attr);
                 }
             }
             else if (LWM2M_URI_IS_SET_INSTANCE(uriP))

--- a/core/management.c
+++ b/core/management.c
@@ -153,6 +153,7 @@ static int prv_readAttributes(multi_option_t * query,
 
             attrP->toClear |= LWM2M_ATTR_FLAG_STEP;
         }
+        else return -1;
 
         query = query->next;
     }
@@ -266,7 +267,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                 }
                 else
                 {
-                    result = COAP_501_NOT_IMPLEMENTED; //object_write_attributes(contextP, uriP, &attr);
+                    result = observe_set_parameters(contextP, uriP, serverP, &attr);
                 }
             }
             else if (LWM2M_URI_IS_SET_INSTANCE(uriP))
@@ -532,8 +533,9 @@ int lwm2m_dm_write_attributes(lwm2m_context_t * contextP,
     if (attrP == NULL) return COAP_400_BAD_REQUEST;
 
     if (0 != (attrP->toSet & attrP->toClear)) return COAP_400_BAD_REQUEST;
-    if (0 != (attrP->toSet & (LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP))
-    && (attrP->lessThan + 2 * attrP->step >= attrP->greaterThan)) return COAP_400_BAD_REQUEST;
+    if (0 != (attrP->toSet & ATTR_FLAG_NUMERIC) && !LWM2M_URI_IS_SET_RESOURCE(uriP)) return COAP_400_BAD_REQUEST;
+    if (ATTR_FLAG_NUMERIC == (attrP->toSet & ATTR_FLAG_NUMERIC)
+     && (attrP->lessThan + 2 * attrP->step >= attrP->greaterThan)) return COAP_400_BAD_REQUEST;
 
     clientP = (lwm2m_client_t *)lwm2m_list_find((lwm2m_list_t *)contextP->clientList, clientID);
     if (clientP == NULL) return COAP_404_NOT_FOUND;

--- a/core/objects.c
+++ b/core/objects.c
@@ -238,31 +238,6 @@ coap_status_t object_write(lwm2m_context_t * contextP,
     return result;
 }
 
-coap_status_t object_write_attributes(lwm2m_context_t * contextP,
-                                      lwm2m_uri_t * uriP,
-                                      lwm2m_attributes_t * attrP)
-{
-    coap_status_t result = NO_ERROR;
-    lwm2m_object_t * targetP;
-    lwm2m_data_t * dataP = NULL;
-    int size = 0;
-
-    targetP = prv_find_object(contextP, uriP->objectId);
-    if (NULL == targetP) return COAP_404_NOT_FOUND;
-    if (NULL == targetP->readFunc) return COAP_405_METHOD_NOT_ALLOWED;
-    if (NULL == targetP->attributesFunc) return COAP_501_NOT_IMPLEMENTED;
-
-    if (LWM2M_URI_IS_SET_INSTANCE(uriP)
-        && (LWM2M_LIST_FIND(targetP->instanceList, uriP->instanceId) == NULL)) return COAP_404_NOT_FOUND;
-
-    if (0 != (attrP->toSet & (LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP))
-        && (attrP->lessThan + 2 * attrP->step >= attrP->greaterThan)) return COAP_400_BAD_REQUEST;
-
-    result = targetP->attributesFunc(uriP, attrP, targetP);
-
-    return result;
-}
-
 coap_status_t object_execute(lwm2m_context_t * contextP,
                              lwm2m_uri_t * uriP,
                              uint8_t * buffer,

--- a/core/objects.c
+++ b/core/objects.c
@@ -238,6 +238,31 @@ coap_status_t object_write(lwm2m_context_t * contextP,
     return result;
 }
 
+coap_status_t object_write_attributes(lwm2m_context_t * contextP,
+                                      lwm2m_uri_t * uriP,
+                                      lwm2m_attributes_t * attrP)
+{
+    coap_status_t result = NO_ERROR;
+    lwm2m_object_t * targetP;
+    lwm2m_data_t * dataP = NULL;
+    int size = 0;
+
+    targetP = prv_find_object(contextP, uriP->objectId);
+    if (NULL == targetP) return COAP_404_NOT_FOUND;
+    if (NULL == targetP->readFunc) return COAP_405_METHOD_NOT_ALLOWED;
+    if (NULL == targetP->attributesFunc) return COAP_501_NOT_IMPLEMENTED;
+
+    if (LWM2M_URI_IS_SET_INSTANCE(uriP)
+        && (LWM2M_LIST_FIND(targetP->instanceList, uriP->instanceId) == NULL)) return COAP_404_NOT_FOUND;
+
+    if (0 != (attrP->toSet & (LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP))
+        && (attrP->lessThan + 2 * attrP->step >= attrP->greaterThan)) return COAP_400_BAD_REQUEST;
+
+    result = targetP->attributesFunc(uriP, attrP, targetP);
+
+    return result;
+}
+
 coap_status_t object_execute(lwm2m_context_t * contextP,
                              lwm2m_uri_t * uriP,
                              uint8_t * buffer,

--- a/core/observe.c
+++ b/core/observe.c
@@ -533,17 +533,6 @@ void observation_step(lwm2m_context_t * contextP,
                         }
                     }
 
-                    // Is the Maximum Period reached ?
-                    if (notify == false
-                     && watcherP->parameters != NULL
-                     && (watcherP->parameters->toSet & LWM2M_ATTR_FLAG_MAX_PERIOD) != 0)
-                    {
-                        if (watcherP->lastTime + watcherP->parameters->maxPeriod <= currentTime)
-                        {
-                            notify = true;
-                        }
-                    }
-
                     if ((watcherP->parameters->toSet & LWM2M_ATTR_FLAG_MIN_PERIOD) != 0)
                     {
                         if (watcherP->lastTime + watcherP->parameters->minPeriod > currentTime)
@@ -557,6 +546,17 @@ void observation_step(lwm2m_context_t * contextP,
                         {
                             notify = true;
                         }
+                    }
+                }
+
+                // Is the Maximum Period reached ?
+                if (notify == false
+                 && watcherP->parameters != NULL
+                 && (watcherP->parameters->toSet & LWM2M_ATTR_FLAG_MAX_PERIOD) != 0)
+                {
+                    if (watcherP->lastTime + watcherP->parameters->maxPeriod <= currentTime)
+                    {
+                        notify = true;
                     }
                 }
 

--- a/core/observe.c
+++ b/core/observe.c
@@ -148,13 +148,56 @@ static lwm2m_watcher_t * prv_findWatcher(lwm2m_observed_t * observedP,
     return targetP;
 }
 
+static lwm2m_watcher_t * prv_getWatcher(lwm2m_context_t * contextP,
+                                        lwm2m_uri_t * uriP,
+                                        lwm2m_server_t * serverP)
+{
+    lwm2m_observed_t * observedP;
+    bool allocatedObserver;
+    lwm2m_watcher_t * watcherP;
+
+    allocatedObserver = false;
+
+    observedP = prv_findObserved(contextP, uriP);
+    if (observedP == NULL)
+    {
+        observedP = (lwm2m_observed_t *)lwm2m_malloc(sizeof(lwm2m_observed_t));
+        if (observedP == NULL) return NULL;
+        allocatedObserver = true;
+        memset(observedP, 0, sizeof(lwm2m_observed_t));
+        memcpy(&(observedP->uri), uriP, sizeof(lwm2m_uri_t));
+        observedP->next = contextP->observedList;
+        contextP->observedList = observedP;
+    }
+
+    watcherP = prv_findWatcher(observedP, serverP);
+    if (watcherP == NULL)
+    {
+        watcherP = (lwm2m_watcher_t *)lwm2m_malloc(sizeof(lwm2m_watcher_t));
+        if (watcherP == NULL)
+        {
+            if (allocatedObserver == true)
+            {
+                lwm2m_free(observedP);
+            }
+            return NULL;
+        }
+        memset(watcherP, 0, sizeof(lwm2m_watcher_t));
+        watcherP->active = false;
+        watcherP->server = serverP;
+        watcherP->next = observedP->watcherList;
+        observedP->watcherList = watcherP;
+    }
+
+    return watcherP;
+}
+
 coap_status_t handle_observe_request(lwm2m_context_t * contextP,
                                      lwm2m_uri_t * uriP,
                                      lwm2m_server_t * serverP,
                                      coap_packet_t * message,
                                      coap_packet_t * response)
 {
-    lwm2m_observed_t * observedP;
     lwm2m_watcher_t * watcherP;
     uint32_t count;
 
@@ -168,30 +211,12 @@ coap_status_t handle_observe_request(lwm2m_context_t * contextP,
         if (!LWM2M_URI_IS_SET_INSTANCE(uriP) && LWM2M_URI_IS_SET_RESOURCE(uriP)) return COAP_400_BAD_REQUEST;
         if (message->token_len == 0) return COAP_400_BAD_REQUEST;
 
-        observedP = prv_findObserved(contextP, uriP);
-        if (observedP == NULL)
-        {
-            observedP = (lwm2m_observed_t *)lwm2m_malloc(sizeof(lwm2m_observed_t));
-            if (observedP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
-            memset(observedP, 0, sizeof(lwm2m_observed_t));
-            memcpy(&(observedP->uri), uriP, sizeof(lwm2m_uri_t));
-            observedP->next = contextP->observedList;
-            contextP->observedList = observedP;
-        }
-
-        watcherP = prv_findWatcher(observedP, serverP);
-        if (watcherP == NULL)
-        {
-            watcherP = (lwm2m_watcher_t *)lwm2m_malloc(sizeof(lwm2m_watcher_t));
-            if (watcherP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
-            memset(watcherP, 0, sizeof(lwm2m_watcher_t));
-            watcherP->server = serverP;
-            watcherP->next = observedP->watcherList;
-            observedP->watcherList = watcherP;
-        }
+        watcherP = prv_getWatcher(contextP, uriP, serverP);
+        if (watcherP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
         watcherP->tokenLen = message->token_len;
         memcpy(watcherP->token, message->token, message->token_len);
+        watcherP->active = true;
 
         coap_set_header_observe(response, watcherP->counter++);
 
@@ -257,6 +282,102 @@ void cancel_observe(lwm2m_context_t * contextP,
     }
 }
 
+coap_status_t observe_set_parameters(lwm2m_context_t * contextP,
+                                     lwm2m_uri_t * uriP,
+                                     lwm2m_server_t * serverP,
+                                     lwm2m_attributes_t * attrP)
+{
+    uint8_t result;
+    lwm2m_watcher_t * watcherP;
+
+    LOG("observe_set_parameters()\r\n");
+
+    if (!LWM2M_URI_IS_SET_INSTANCE(uriP) && LWM2M_URI_IS_SET_RESOURCE(uriP)) return COAP_400_BAD_REQUEST;
+
+    result = object_checkReadable(contextP, uriP);
+    if (COAP_205_CONTENT != result) return result;
+
+    if (0 != (attrP->toSet & ATTR_FLAG_NUMERIC))
+    {
+        result = object_checkNumeric(contextP, uriP);
+        if (COAP_205_CONTENT != result) return result;
+    }
+
+    watcherP = prv_getWatcher(contextP, uriP, serverP);
+    if (watcherP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
+
+    // Check rule “lt” value + 2*”stp” values < “gt” value
+    if ((((attrP->toSet | (watcherP->parameters?watcherP->parameters->toSet:0)) & ~attrP->toClear) & ATTR_FLAG_NUMERIC) == ATTR_FLAG_NUMERIC)
+    {
+        float gt;
+        float lt;
+        float stp;
+
+        if (0 != (attrP->toSet & LWM2M_ATTR_FLAG_GREATER_THAN))
+        {
+            gt = attrP->greaterThan;
+        }
+        else
+        {
+            gt = watcherP->parameters->greaterThan;
+        }
+        if (0 != (attrP->toSet & LWM2M_ATTR_FLAG_LESS_THAN))
+        {
+            lt = attrP->lessThan;
+        }
+        else
+        {
+            lt = watcherP->parameters->lessThan;
+        }
+        if (0 != (attrP->toSet & LWM2M_ATTR_FLAG_STEP))
+        {
+            gt = attrP->step;
+        }
+        else
+        {
+            gt = watcherP->parameters->step;
+        }
+
+        if (lt + (2 * stp) < gt) return COAP_400_BAD_REQUEST;
+    }
+
+    if (watcherP->parameters == NULL)
+    {
+        if (attrP->toSet != 0)
+        {
+            watcherP->parameters = (lwm2m_attributes_t *)lwm2m_malloc(sizeof(lwm2m_attributes_t));
+            if (watcherP->parameters == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
+            memcpy(watcherP->parameters, attrP, sizeof(lwm2m_attributes_t));
+        }
+    }
+    else
+    {
+        watcherP->parameters->toSet &= ~attrP->toClear;
+        if (attrP->toSet & LWM2M_ATTR_FLAG_MIN_PERIOD)
+        {
+            watcherP->parameters->minPeriod = attrP->minPeriod;
+        }
+        if (attrP->toSet & LWM2M_ATTR_FLAG_MAX_PERIOD)
+        {
+            watcherP->parameters->maxPeriod = attrP->maxPeriod;
+        }
+        if (attrP->toSet & LWM2M_ATTR_FLAG_GREATER_THAN)
+        {
+            watcherP->parameters->greaterThan = attrP->greaterThan;
+        }
+        if (attrP->toSet & LWM2M_ATTR_FLAG_LESS_THAN)
+        {
+            watcherP->parameters->lessThan = attrP->lessThan;
+        }
+        if (attrP->toSet & LWM2M_ATTR_FLAG_STEP)
+        {
+            watcherP->parameters->step = attrP->step;
+        }
+    }
+
+    return COAP_204_CHANGED;
+}
+
 void lwm2m_resource_value_changed(lwm2m_context_t * contextP,
                                   lwm2m_uri_t * uriP)
 {
@@ -284,11 +405,14 @@ void lwm2m_resource_value_changed(lwm2m_context_t * contextP,
 
             for (watcherP = listP->item->watcherList ; watcherP != NULL ; watcherP = watcherP->next)
             {
-                watcherP->lastMid = contextP->nextMID++;
-                message->mid = watcherP->lastMid;
-                coap_set_header_token(message, watcherP->token, watcherP->tokenLen);
-                coap_set_header_observe(message, watcherP->counter++);
-                (void)message_send(contextP, message, watcherP->server->sessionH);
+                if (watcherP->active == true)
+                {
+                    watcherP->lastMid = contextP->nextMID++;
+                    message->mid = watcherP->lastMid;
+                    coap_set_header_token(message, watcherP->token, watcherP->tokenLen);
+                    coap_set_header_observe(message, watcherP->counter++);
+                    (void)message_send(contextP, message, watcherP->server->sessionH);
+                }
             }
         }
 

--- a/core/observe.c
+++ b/core/observe.c
@@ -455,6 +455,7 @@ void observation_step(lwm2m_context_t * contextP,
                 }
             }
         }
+        if (buffer != NULL) lwm2m_free(buffer);
     }
 }
 

--- a/core/observe.c
+++ b/core/observe.c
@@ -203,7 +203,7 @@ coap_status_t handle_observe_request(lwm2m_context_t * contextP,
 
     case 1:
         // cancellation
-        cancel_observe(contextP, message->mid, serverP->sessionH);
+        cancel_observe(contextP, LWM2M_MAX_ID, serverP->sessionH);
         return COAP_205_CONTENT;
 
     default:
@@ -225,7 +225,7 @@ void cancel_observe(lwm2m_context_t * contextP,
     {
         lwm2m_watcher_t * targetP = NULL;
 
-        if (observedP->watcherList->lastMid == mid
+        if ((LWM2M_MAX_ID == mid || observedP->watcherList->lastMid == mid)
          && observedP->watcherList->server->sessionH == fromSessionH)
         {
             targetP = observedP->watcherList;

--- a/tests/client/test_object.c
+++ b/tests/client/test_object.c
@@ -89,8 +89,11 @@ typedef struct _prv_instance_
      */
     struct _prv_instance_ * next;   // matches lwm2m_list_t::next
     uint16_t shortID;               // matches lwm2m_list_t::id
+    lwm2m_attributes_t * meta;
     uint8_t  test;
+    lwm2m_attributes_t * testMeta;
     double   dec;
+    lwm2m_attributes_t * decMeta;
 } prv_instance_t;
 
 static void prv_output_buffer(uint8_t * buffer,
@@ -286,6 +289,97 @@ static uint8_t prv_exec(uint16_t instanceId,
     }
 }
 
+uint8_t prv_attributes(lwm2m_uri_t * uriP,
+                       lwm2m_attributes_t * attrP,
+                       lwm2m_object_t * objectP)
+{
+    lwm2m_attributes_t ** targetP;
+
+    if (LWM2M_URI_IS_SET_INSTANCE(uriP))
+    {
+        prv_instance_t * instP;
+
+        instP = (prv_instance_t *)lwm2m_list_find(objectP->instanceList, uriP->instanceId);
+        if (NULL == instP) return COAP_404_NOT_FOUND;
+
+        if (LWM2M_URI_IS_SET_RESOURCE(uriP))
+        {
+            switch (uriP->resourceId)
+            {
+            case 1:
+                targetP = &(instP->testMeta);
+                break;
+            case 3:
+                targetP = &(instP->decMeta);
+                break;
+            case 2:
+                return COAP_405_METHOD_NOT_ALLOWED;
+            default:
+                return COAP_404_NOT_FOUND;
+            }
+        }
+        else
+        {
+            targetP = &(instP->meta);
+        }
+    }
+    else
+    {
+        targetP = (lwm2m_attributes_t **)&(objectP->userData);
+    }
+
+    if ((attrP->toClear | attrP->toSet) == 0)
+    {
+        // this is a get
+        if (*targetP != NULL)
+        {
+            memcpy(attrP, *targetP, sizeof(lwm2m_attributes_t));
+        }
+        else
+        {
+            memset(attrP, 0, sizeof(lwm2m_attributes_t));
+        }
+    }
+    else
+    {
+        // this is a set
+        if (*targetP == NULL)
+        {
+            if (attrP->toSet == 0) return COAP_204_CHANGED;
+            *targetP = lwm2m_malloc(sizeof(lwm2m_attributes_t));
+            if (*targetP == NULL) COAP_500_INTERNAL_SERVER_ERROR;
+            memcpy(*targetP, attrP, sizeof(lwm2m_attributes_t));
+            (*targetP)->toClear = 0;
+        }
+        else
+        {
+            (*targetP)->toSet &= ~(attrP->toClear);
+            if (attrP->toSet & LWM2M_ATTR_FLAG_MIN_PERIOD)
+            {
+                (*targetP)->minPeriod = attrP->minPeriod;
+            }
+            if (attrP->toSet & LWM2M_ATTR_FLAG_MAX_PERIOD)
+            {
+                (*targetP)->maxPeriod = attrP->maxPeriod;
+            }
+            if (attrP->toSet & LWM2M_ATTR_FLAG_GREATER_THAN)
+            {
+                (*targetP)->greaterThan = attrP->greaterThan;
+            }
+            if (attrP->toSet & LWM2M_ATTR_FLAG_LESS_THAN)
+            {
+                (*targetP)->lessThan = attrP->lessThan;
+            }
+            if (attrP->toSet & LWM2M_ATTR_FLAG_STEP)
+            {
+                (*targetP)->step = attrP->step;
+            }
+        }
+    }
+
+    return COAP_204_CHANGED;
+}
+
 void display_test_object(lwm2m_object_t * object)
 {
 #ifdef WITH_LOGS
@@ -337,6 +431,7 @@ lwm2m_object_t * get_test_object(void)
         testObj->executeFunc = prv_exec;
         testObj->createFunc = prv_create;
         testObj->deleteFunc = prv_delete;
+        testObj->attributesFunc = prv_attributes;
     }
 
     return testObj;

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -201,7 +201,7 @@ static void prv_result_callback(uint16_t clientID,
                                 int dataLength,
                                 void * userData)
 {
-    fprintf(stdout, "\r\nClient #%d %d", clientID, uriP->objectId);
+    fprintf(stdout, "\r\nClient #%d /%d", clientID, uriP->objectId);
     if (LWM2M_URI_IS_SET_INSTANCE(uriP))
         fprintf(stdout, "/%d", uriP->instanceId);
     else if (LWM2M_URI_IS_SET_RESOURCE(uriP))
@@ -398,7 +398,7 @@ static void prv_attr_client(char * buffer,
     if (result == 0) goto syntax_error;
 
     memset(&attr, 0, sizeof(lwm2m_attributes_t));
-    attr.toSet = LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP;
+    attr.toSet = LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN;
 
     buffer = get_next_arg(end, &end);
     if (buffer[0] == 0) goto syntax_error;
@@ -415,11 +415,14 @@ static void prv_attr_client(char * buffer,
     attr.greaterThan = value;
 
     buffer = get_next_arg(end, &end);
-    if (buffer[0] == 0) goto syntax_error;
+    if (buffer[0] != 0)
+    {
+        nb = sscanf(buffer, "%f", &value);
+        if (nb != 1) goto syntax_error;
+        attr.step = value;
 
-    nb = sscanf(buffer, "%f", &value);
-    if (nb != 1) goto syntax_error;
-    attr.step = value;
+        attr.toSet |= LWM2M_ATTR_FLAG_STEP;
+    }
 
     if (!check_end_of_args(end)) goto syntax_error;
 
@@ -784,7 +787,7 @@ int main(int argc, char *argv[])
                                             "   PMIN: Minimum period\r\n"
                                             "   PMAX: Maximum period\r\n"
                                             "Result will be displayed asynchronously.", prv_time_client, NULL},
-            {"attr", "Write value-related attributes to a client.", " attr CLIENT# URI LT GT STEP\r\n"
+            {"attr", "Write value-related attributes to a client.", " attr CLIENT# URI LT GT [STEP]\r\n"
                                             "   CLIENT#: client number as returned by command 'list'\r\n"
                                             "   URI: uri to write attributes to such as /3, /3/0/2, /1024/11, /1024//1\r\n"
                                             "   LT: \"Less than\" value\r\n"


### PR DESCRIPTION
On the server-side, a new API to set or clear link attributes.
On the client-side, these attributes are stored in the core as parameters to the observation (their only use for now).

To test: launch the tests/lwm2mclient with the -c command-line argument.
On the server, observe the resource /3/0/9 and use the new "time" command to set pmin and pmax and "attr" command to set lt, gt and stp.