### PR TITLE
Add IPv4 mode for lwm2mclient

### DIFF
--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -723,6 +723,7 @@ void print_usage(void)
     fprintf(stdout, "  -l PORT\tSet the local UDP port of the Client. Default: 56830\r\n");
     fprintf(stdout, "  -h HOST\tSet the hostname of the LWM2M Server to connect to. Default: localhost\r\n");
     fprintf(stdout, "  -p PORT\tSet the port of the LWM2M Server to connect to. Default: "LWM2M_STANDARD_PORT_STR"\r\n");
+    fprintf(stdout, "  -4\t\tUse IPv4 connection. Default: IPv6 connection\r\n");
     fprintf(stdout, "  -t TIME\tSet the lifetime of the Client. Default: 300\r\n");
     fprintf(stdout, "  -b\t\tBootstrap requested.\r\n");
     fprintf(stdout, "  -c\t\tChange battery level over time.\r\n");
@@ -744,6 +745,7 @@ int main(int argc, char *argv[])
     time_t reboot_time = 0;
     int opt;
     bool bootstrapRequested = false;
+    bool useIPv6 = true;
 #ifdef LWM2M_BOOTSTRAP
     lwm2m_client_state_t previousState = STATE_INITIAL;
 #endif
@@ -780,7 +782,7 @@ int main(int argc, char *argv[])
 
     memset(&data, 0, sizeof(client_data_t));
 
-    while ((opt = getopt(argc, argv, "bcl:n:p:t:h:")) != -1)
+    while ((opt = getopt(argc, argv, "bcl:n:p:t:h:4")) != -1)
     {
         switch (opt)
         {
@@ -805,6 +807,9 @@ int main(int argc, char *argv[])
         case 'p':
             serverPort = optarg;
             break;
+        case '4':
+            useIPv6 = false;
+            break;
         default:
             print_usage();
             return 0;
@@ -812,8 +817,9 @@ int main(int argc, char *argv[])
     }
 
     /*
-     *This call an internal function that create an IPV6 socket on the port 5683.
+     *This calls an internal function that creates a socket on the port 5683.
      */
+    connection_enable_IPv6(useIPv6);
     fprintf(stderr, "Trying to bind LWM2M Client to port %s\r\n", localPort);
     data.sock = create_socket(localPort);
     if (data.sock < 0)

--- a/tests/utils/connection.c
+++ b/tests/utils/connection.c
@@ -24,6 +24,8 @@
 // from commandline.c
 void output_buffer(FILE * stream, uint8_t * buffer, int length, int indent);
 
+// status of IPv6 mode
+static bool connection_IPv6_enabled = true;
 
 int create_socket(const char * portStr)
 {
@@ -33,7 +35,7 @@ int create_socket(const char * portStr)
     struct addrinfo *p;
 
     memset(&hints, 0, sizeof hints);
-    hints.ai_family = AF_INET6;
+    hints.ai_family = connection_IPv6_enabled ? AF_INET6 : AF_INET;
     hints.ai_socktype = SOCK_DGRAM;
     hints.ai_flags = AI_PASSIVE;
 
@@ -217,4 +219,12 @@ bool lwm2m_session_is_equal(void * session1,
                             void * userData)
 {
     return (session1 == session2);
+}
+
+// Functions for managment of IPv6 mode
+void connection_enable_IPv6(bool enable) {
+    connection_IPv6_enabled = enable;
+}
+bool connection_is_IPv6_enabled() {
+    return connection_IPv6_enabled;
 }

--- a/tests/utils/connection.h
+++ b/tests/utils/connection.h
@@ -19,6 +19,7 @@
 #define CONNECTION_H_
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -26,9 +27,9 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <liblwm2m.h>
-
 #define LWM2M_STANDARD_PORT_STR "5683"
 #define LWM2M_STANDARD_PORT      5683
+
 
 typedef struct _connection_t
 {
@@ -47,5 +48,8 @@ connection_t * connection_create(connection_t * connList, int sock, char * host,
 void connection_free(connection_t * connList);
 
 int connection_send(connection_t *connP, uint8_t * buffer, size_t length);
+
+void connection_enable_IPv6(bool enable);
+bool connection_is_IPv6_enabled();
 
 #endif


### PR DESCRIPTION
The changes add an IPv4 mode to connection.c/.h as well as a
corresponding command-line parameter -4 to lwm2mclient.c

The default is to establish an IPv6 connection, so the behavior without
the new parameter is the same as in previous versions.

This change is one of several upcoming changes that I implemented to run wakaama on iOS devices.