### PR TITLE
Fix for issue #84: Instance ID is no longer required in Bootstrap Wri…

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -341,7 +341,15 @@ coap_status_t handle_bootstrap_command(lwm2m_context_t * contextP,
     {
     case COAP_PUT:
         {
-            if (LWM2M_URI_IS_SET_INSTANCE(uriP))
+            if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
+            {                
+                result = object_create(contextP, uriP, format, message->payload, message->payload_len);
+                if (COAP_201_CREATED == result)
+                {
+                    result = COAP_204_CHANGED;
+                }            
+            }
+            else
             {
                 if (object_isInstanceNew(contextP, uriP->objectId, uriP->instanceId))
                 {
@@ -360,10 +368,6 @@ coap_status_t handle_bootstrap_command(lwm2m_context_t * contextP,
                         prv_tag_server(contextP, uriP->instanceId);
                     }
                 }
-            }
-            else
-            {
-                result = BAD_REQUEST_4_00;
             }
         }
         break;

--- a/core/objects.c
+++ b/core/objects.c
@@ -339,6 +339,7 @@ coap_status_t object_create(lwm2m_context_t * contextP,
     lwm2m_data_t * dataP = NULL;
     int size = 0;
     uint8_t result;
+    int i;
 
     if (length == 0 || buffer == 0)
     {
@@ -365,7 +366,18 @@ coap_status_t object_create(lwm2m_context_t * contextP,
 
     size = lwm2m_data_parse(buffer, length, format, &dataP);
     if (size == 0) return COAP_500_INTERNAL_SERVER_ERROR;
-    result = targetP->createFunc(uriP->instanceId, size, dataP, targetP);
+
+    if( dataP->type == LWM2M_TYPE_OBJECT_INSTANCE)
+    {
+        for (i = 0 ; i < size ; i++)
+        {
+            result = targetP->createFunc(uriP->instanceId, dataP->length, (lwm2m_data_t *)(dataP[i].value), targetP);
+        }
+    }
+    else
+    {
+        result = targetP->createFunc(uriP->instanceId, size, dataP, targetP);
+    }
     lwm2m_data_free(size, dataP);
 
     return result;


### PR DESCRIPTION
…te operation.

Following a specification change, the instance Id is not required.

If no Resource ID is indicated, then the value included payload is an Object Instance containing the Resource values.

Signed-off-by: Ricky Liu <ieei.liu@gmail.com>