### PR TITLE
Add IPv4 mode for test servers & clients

### DIFF
--- a/README
+++ b/README
@@ -60,10 +60,13 @@ To compile the test server
 In the any directory, run the following commands:
     cmake [liblwm2m directory]/tests/server
     make
-    ./lwm2mserver
+    ./lwm2mserver [Options]
 
 The lwm2mserver listens on UDP port 5683. It features a basic command line
 interface. Type 'help' for a list of supported commands.
+
+Options are:
+  -4		Use IPv4 connection. Default: IPv6 connection
 
 
 To compile the test client
@@ -85,18 +88,18 @@ The lwm2mclient features nine LWM2M objects:
     - Location Object (id: 6) as a skeleton.
     - Connectivity Statistics Object (id: 7) as a skeleton.
     - a test object (id: 1024) with the following description:
-    
+
                            Multiple
           Object |  ID  | Instances | Mandatoty |
            Test  | 1024 |    Yes    |    No     |
-         
+
            Ressources:
                        Supported    Multiple
            Name | ID | Operations | Instances | Mandatory |  Type   | Range |
            test |  1 |    R/W     |    No     |    Yes    | Integer | 0-255 |
            exec |  2 |     E      |    No     |    Yes    |         |       |
            dec  |  3 |    R/W     |    No     |    Yes    |  Float  |       |
-    
+
 The lwm2mclient opens udp port 56830 and tries to register to a LWM2M Server at
 127.0.0.1:5683. It features a basic command line interface. Type 'help' for a
 list of supported commands.
@@ -106,6 +109,7 @@ Options are:
   -l PORT	Set the local UDP port of the Client. Default: 56830
   -h HOST	Set the hostname of the LWM2M Server to connect to. Default: localhost
   -p HOST	Set the port of the LWM2M Server to connect to. Default: 5683
+  -4		Use IPv4 connection. Default: IPv6 connection
   -t TIME	Set the lifetime of the Client. Default: 300
   -b		Bootstrap requested.
   -c		Change battery level over time.
@@ -135,3 +139,4 @@ The lightclient does not feature any command-line interface.
 Options are:
   -n NAME	Set the endpoint name of the Client. Default: testlightclient
   -l PORT	Set the local UDP port of the Client. Default: 56830
+  -4		Use IPv4 connection. Default: IPv6 connection

--- a/tests/server/lwm2mserver.c
+++ b/tests/server/lwm2mserver.c
@@ -17,6 +17,7 @@
  *    Toby Jaffey - Please refer to git log
  *    Julien Vermillard - Please refer to git log
  *    Bosch Software Innovations GmbH - Please refer to git log
+ *    Christian Renz - Please refer to git log
  *
  *******************************************************************************/
 
@@ -740,8 +741,11 @@ void handle_sigint(int signum)
 
 void print_usage(void)
 {
-    fprintf(stderr, "Usage: lwm2mserver\r\n");
+    fprintf(stderr, "Usage: lwm2mserver [OPTION]\r\n");
     fprintf(stderr, "Launch a LWM2M server on localhost port "LWM2M_STANDARD_PORT_STR".\r\n\n");
+    fprintf(stdout, "Options:\r\n");
+    fprintf(stdout, "  -4\t\tUse IPv4 connection. Default: IPv6 connection\r\n");
+    fprintf(stdout, "\r\n");
 }
 
 
@@ -754,6 +758,8 @@ int main(int argc, char *argv[])
     lwm2m_context_t * lwm2mH = NULL;
     int i;
     connection_t * connList = NULL;
+    int addressFamily = AF_INET6;
+    int opt;
 
     command_desc_t commands[] =
     {
@@ -811,7 +817,21 @@ int main(int argc, char *argv[])
             COMMAND_END_LIST
     };
 
-    sock = create_socket(LWM2M_STANDARD_PORT_STR);
+    while ((opt = getopt(argc, argv, "4")) != -1)
+    {
+        switch (opt)
+        {
+        case '4':
+            addressFamily = AF_INET;
+            break;
+        default:
+            print_usage();
+            return 0;
+        }
+    }
+
+
+    sock = create_socket(LWM2M_STANDARD_PORT_STR, addressFamily);
     if (sock < 0)
     {
         fprintf(stderr, "Error opening socket: %d\r\n", errno);

--- a/tests/utils/connection.h
+++ b/tests/utils/connection.h
@@ -38,11 +38,11 @@ typedef struct _connection_t
     size_t                  addrLen;
 } connection_t;
 
-int create_socket(const char * portStr);
+int create_socket(const char * portStr, int ai_family);
 
 connection_t * connection_find(connection_t * connList, struct sockaddr_storage * addr, size_t addrLen);
 connection_t * connection_new_incoming(connection_t * connList, int sock, struct sockaddr * addr, size_t addrLen);
-connection_t * connection_create(connection_t * connList, int sock, char * host, char * port);
+connection_t * connection_create(connection_t * connList, int sock, char * host, char * port, int addressFamily);
 
 void connection_free(connection_t * connList);
 

--- a/tests/utils/dtlsconnection.c
+++ b/tests/utils/dtlsconnection.c
@@ -12,6 +12,7 @@
  *
  * Contributors:
  *    David Navarro, Intel Corporation - initial API and implementation
+ *    Christian Renz - Please refer to git log
  *
  *******************************************************************************/
 
@@ -311,7 +312,7 @@ int sockaddr_cmp(struct sockaddr *x, struct sockaddr *y)
     }
 }
 
-int create_socket(const char * portStr)
+int create_socket(const char * portStr, int ai_family)
 {
     int s = -1;
     struct addrinfo hints;
@@ -319,7 +320,7 @@ int create_socket(const char * portStr)
     struct addrinfo *p;
 
     memset(&hints, 0, sizeof hints);
-    hints.ai_family = AF_INET6;
+    hints.ai_family = ai_family;
     hints.ai_socktype = SOCK_DGRAM;
     hints.ai_flags = AI_PASSIVE;
 
@@ -393,7 +394,8 @@ dtls_connection_t * connection_create(dtls_connection_t * connList,
                                  int sock,
                                  lwm2m_object_t * securityObj,
                                  int instanceId,
-                                 lwm2m_context_t * lwm2mH)
+                                 lwm2m_context_t * lwm2mH,
+                                 int addressFamily)
 {
     struct addrinfo hints;
     struct addrinfo *servinfo = NULL;
@@ -408,7 +410,7 @@ dtls_connection_t * connection_create(dtls_connection_t * connList,
     char * port;
 
     memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
+    hints.ai_family = addressFamily;
     hints.ai_socktype = SOCK_DGRAM;
 
     uri = security_get_uri(securityObj, instanceId, uriBuf, URI_LENGTH);
@@ -487,12 +489,12 @@ dtls_connection_t * connection_create(dtls_connection_t * connList,
             {
                 connP->dtlsContext = get_dtls_context(connP);
             }
-            else 
+            else
             {
                 // no dtls session
                 connP->dtlsSession = NULL;
             }
-        } 
+        }
     }
 
     if (NULL != servinfo) free(servinfo);

--- a/tests/utils/dtlsconnection.h
+++ b/tests/utils/dtlsconnection.h
@@ -12,6 +12,7 @@
  *
  * Contributors:
  *    Simon Bernard - initial API and implementation
+ *    Christian Renz - Please refer to git log
  *
  *******************************************************************************/
 
@@ -46,11 +47,11 @@ typedef struct _dtls_connection_t
     dtls_context_t * dtlsContext;
 } dtls_connection_t;
 
-int create_socket(const char * portStr);
+int create_socket(const char * portStr, int ai_family);
 
 dtls_connection_t * connection_find(dtls_connection_t * connList, const struct sockaddr_storage * addr, size_t addrLen);
 dtls_connection_t * connection_new_incoming(dtls_connection_t * connList, int sock, const struct sockaddr * addr, size_t addrLen);
-dtls_connection_t * connection_create(dtls_connection_t * connList, int sock, lwm2m_object_t * securityObj, int instanceId, lwm2m_context_t * lwm2mH);
+dtls_connection_t * connection_create(dtls_connection_t * connList, int sock, lwm2m_object_t * securityObj, int instanceId, lwm2m_context_t * lwm2mH, int addressFamily);
 
 void connection_free(dtls_connection_t * connList);
 


### PR DESCRIPTION
The changes add an IPv4 mode to connection.c/.h as well as a
corresponding command-line parameter -4 to the test clients and servers.

See pull request #85 for history.