### PR TITLE
Fix issue #91

### DIFF
--- a/core/er-coap-13/er-coap-13.c
+++ b/core/er-coap-13/er-coap-13.c
@@ -411,6 +411,109 @@ coap_free_header(void *packet)
 }
 
 /*-----------------------------------------------------------------------------------*/
+size_t coap_serialize_get_size(void *packet)
+{
+    coap_packet_t *const coap_pkt = (coap_packet_t *) packet;
+    size_t length = 0;
+
+    length = COAP_HEADER_LEN + coap_pkt->payload_len;
+
+    if (IS_OPTION(coap_pkt, COAP_OPTION_IF_MATCH))
+    {
+        length += COAP_MAX_OPTION_HEADER_LEN + coap_pkt->if_match_len;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_URI_HOST))
+    {
+        length += COAP_MAX_OPTION_HEADER_LEN + coap_pkt->uri_host_len;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_ETAG))
+    {
+        length += COAP_MAX_OPTION_HEADER_LEN + coap_pkt->etag_len;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_IF_NONE_MATCH))
+    {
+        // can be stored in extended fields
+        length += COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_OBSERVE))
+    {
+        // can be stored in extended fields
+        length += COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_URI_PORT))
+    {
+        // can be stored in extended fields
+        length += COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_LOCATION_PATH))
+    {
+        multi_option_t * optP;
+
+        for (optP = coap_pkt->location_path ; optP != NULL ; optP = optP->next)
+        {
+            length += COAP_MAX_OPTION_HEADER_LEN + optP->len;
+        }
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_URI_PATH))
+    {
+        multi_option_t * optP;
+
+        for (optP = coap_pkt->uri_path ; optP != NULL ; optP = optP->next)
+        {
+            length += COAP_MAX_OPTION_HEADER_LEN + optP->len;
+        }
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_CONTENT_TYPE))
+    {
+        // can be stored in extended fields
+        length += COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_MAX_AGE))
+    {
+        // can be stored in extended fields
+        length += COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_URI_QUERY))
+    {
+        multi_option_t * optP;
+
+        for (optP = coap_pkt->uri_query ; optP != NULL ; optP = optP->next)
+        {
+            length += COAP_MAX_OPTION_HEADER_LEN + optP->len;
+        }
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_ACCEPT))
+    {
+        length += coap_pkt->accept_num * COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_LOCATION_QUERY))
+    {
+        length += COAP_MAX_OPTION_HEADER_LEN + coap_pkt->location_query_len;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_BLOCK2))
+    {
+        // can be stored in extended fields
+        length += COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_BLOCK1))
+    {
+        // can be stored in extended fields
+        length += COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_SIZE))
+    {
+        // can be stored in extended fields
+        length += COAP_MAX_OPTION_HEADER_LEN;
+    }
+    if (IS_OPTION(coap_pkt, COAP_OPTION_PROXY_URI))
+    {
+        length += COAP_MAX_OPTION_HEADER_LEN + coap_pkt->proxy_uri_len;
+    }
+
+    return length;
+}
+
+/*-----------------------------------------------------------------------------------*/
 size_t
 coap_serialize_message(void *packet, uint8_t *buffer)
 {

--- a/core/er-coap-13/er-coap-13.c
+++ b/core/er-coap-13/er-coap-13.c
@@ -577,24 +577,14 @@ coap_serialize_message(void *packet, uint8_t *buffer)
   coap_free_header(packet);
 
   /* Pack payload */
-  if ((option - coap_pkt->buffer)<=COAP_MAX_HEADER_SIZE)
+  /* Payload marker */
+  if (coap_pkt->payload_len)
   {
-    /* Payload marker */
-    if (coap_pkt->payload_len)
-    {
-      *option = 0xFF;
-      ++option;
-    }
+    *option = 0xFF;
+    ++option;
+  }
 
-    memmove(option, coap_pkt->payload, coap_pkt->payload_len);
-  }
-  else
-  {
-    /* An error occured. Caller must check for !=0. */
-    coap_pkt->buffer = NULL;
-    coap_error_message = "Serialized header exceeds COAP_MAX_HEADER_SIZE";
-    return 0;
-  }
+  memmove(option, coap_pkt->payload, coap_pkt->payload_len);
 
   PRINTF("-Done %u B (header len %u, payload len %u)-\n", coap_pkt->payload_len + option - buffer, option - buffer, coap_pkt->payload_len);
 

--- a/core/er-coap-13/er-coap-13.h
+++ b/core/er-coap-13/er-coap-13.h
@@ -65,6 +65,8 @@
 #define COAP_TOKEN_LEN                       8 /* The maximum number of bytes for the Token */
 #define COAP_MAX_ACCEPT_NUM                  2 /* The maximum number of accept preferences to parse/store */
 
+#define COAP_MAX_OPTION_HEADER_LEN           5
+
 #define COAP_HEADER_VERSION_MASK             0xC0
 #define COAP_HEADER_VERSION_POSITION         6
 #define COAP_HEADER_TYPE_MASK                0x30
@@ -317,6 +319,7 @@ extern char *coap_error_message;
 uint16_t coap_get_mid(void);
 
 void coap_init_message(void *packet, coap_message_type_t type, uint8_t code, uint16_t mid);
+size_t coap_serialize_get_size(void *packet);
 size_t coap_serialize_message(void *packet, uint8_t *buffer);
 coap_status_t coap_parse_message(void *request, uint8_t *data, uint16_t data_len);
 void coap_free_header(void *packet);

--- a/core/internals.h
+++ b/core/internals.h
@@ -208,7 +208,7 @@ void observation_step(lwm2m_context_t * contextP, time_t currentTime, time_t * t
 coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void registration_deregister(lwm2m_context_t * contextP, lwm2m_server_t * serverP);
 void prv_freeClient(lwm2m_client_t * clientP);
-void registration_start(lwm2m_context_t * contextP);
+uint8_t registration_start(lwm2m_context_t * contextP);
 void registration_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 lwm2m_status_t registration_get_status(lwm2m_context_t * contextP);
 

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -308,6 +308,7 @@ int lwm2m_step(lwm2m_context_t * contextP,
                time_t * timeoutP)
 {
     time_t tv_sec;
+    int result;
 
     tv_sec = lwm2m_gettime();
     if (tv_sec < 0) return COAP_500_INTERNAL_SERVER_ERROR;
@@ -367,7 +368,8 @@ next_step:
         break;
 #endif
     case STATE_REGISTER_REQUIRED:
-        registration_start(contextP);
+        result = registration_start(contextP);
+        if (COAP_NO_ERROR != result) return result;
         contextP->state = STATE_REGISTERING;
         break;
 

--- a/core/packet.c
+++ b/core/packet.c
@@ -373,7 +373,9 @@ coap_status_t message_send(lwm2m_context_t * contextP,
     size_t pktBufferLen = 0;
     size_t allocLen;
 
-    allocLen = COAP_MAX_HEADER_SIZE + message->payload_len;
+    allocLen = coap_serialize_get_size(message);
+    if (allocLen == 0) return COAP_500_INTERNAL_SERVER_ERROR;
+
     pktBuffer = (uint8_t *)lwm2m_malloc(allocLen);
     if (pktBuffer != NULL)
     {

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -374,8 +374,10 @@ int transaction_send(lwm2m_context_t * contextP,
 
     if (transacP->buffer == NULL)
     {
-        transacP->buffer = (uint8_t*)lwm2m_malloc(COAP_MAX_HEADER_SIZE
-                                                + ((coap_packet_t *)(transacP->message))->payload_len);
+        transacP->buffer_len = coap_serialize_get_size(transacP->message);
+        if (transacP->buffer_len == 0) return COAP_500_INTERNAL_SERVER_ERROR;
+
+        transacP->buffer = (uint8_t*)lwm2m_malloc(transacP->buffer_len);
         if (transacP->buffer == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
         transacP->buffer_len = coap_serialize_message(transacP->message, transacP->buffer);
@@ -383,6 +385,7 @@ int transaction_send(lwm2m_context_t * contextP,
         {
             lwm2m_free(transacP->buffer);
             transacP->buffer = NULL;
+            transaction_remove(contextP, transacP);
             return COAP_500_INTERNAL_SERVER_ERROR;
         }
     }


### PR DESCRIPTION
There were two problems:
- the required size for the CoAP header was hard-coded. Now we pre-determine the size of the serialized CoAP packet (not the exact one but slightly superior).
- the registration_start() function was not returning an error code.