### PR TITLE
include time.h instead of sys/time.h for portability reasons.

### DIFF
--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -60,7 +60,7 @@ extern "C" {
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-#include <sys/time.h>
+#include <time.h>
 
 #ifdef LWM2M_SERVER_MODE
 #define LWM2M_SUPPORT_JSON


### PR DESCRIPTION
Signed-off-by: David Navarro <david.navarro@intel.com>