### PR TITLE
Fix for issue #96: Infinite bootstrapping loop when the BS delete its…

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -297,7 +297,7 @@ static void prv_tag_server(lwm2m_context_t * contextP,
     }
     if (targetP != NULL)
     {
-        targetP->status = STATE_DIRTY;
+        targetP->dirty = true;
     }
 }
 
@@ -311,14 +311,14 @@ static void prv_tag_all_servers(lwm2m_context_t * contextP,
     {
         if (targetP != serverP)
         {
-            targetP->status = STATE_DIRTY;
+            targetP->dirty = true;
         }
         targetP = targetP->next;
     }
     targetP = contextP->serverList;
     while (targetP != NULL)
     {
-        targetP->status = STATE_DIRTY;
+        targetP->dirty = true;
         targetP = targetP->next;
     }
 }

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -194,7 +194,7 @@ static int refresh_server_list(lwm2m_context_t * contextP)
     while (targetP != NULL)
     {
         nextP = targetP->next;
-        if (targetP->status != STATE_DIRTY)
+        if (!targetP->dirty)
         {
             targetP->status = STATE_DEREGISTERED;
             targetP->next = contextP->bootstrapServerList;
@@ -211,7 +211,7 @@ static int refresh_server_list(lwm2m_context_t * contextP)
     while (targetP != NULL)
     {
         nextP = targetP->next;
-        if (targetP->status != STATE_DIRTY)
+        if (!targetP->dirty)
         {
             // TODO: Should we revert the status to STATE_DEREGISTERED ?
             targetP->next = contextP->serverList;

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -411,7 +411,6 @@ typedef enum
     STATE_BS_PENDING,         // boostrap on going
     STATE_BS_FINISHED,        // bootstrap done
     STATE_BS_FAILED,          // bootstrap failed
-    STATE_DIRTY               // deleted or modified by bootstrap interface
 } lwm2m_status_t;
 
 typedef enum
@@ -436,6 +435,7 @@ typedef struct _lwm2m_server_
     void *            sessionH;
     lwm2m_status_t    status;
     char *            location;
+    bool              dirty;
 } lwm2m_server_t;
 
 


### PR DESCRIPTION
… own account.

Replace STATE_DIRTY with boolean dirty in lwm2m_server_t.

Signed-off-by: Ricky Liu <ieei.liu@gmail.com>