### PR TITLE
Object add and remove APIs

### DIFF
--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -664,6 +664,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int lengt
 int lwm2m_configure(lwm2m_context_t * contextP, const char * endpointName, const char * msisdn, const char * altPath, uint16_t numObject, lwm2m_object_t * objectList[]);
 
 // send a registration update to the server specified by the server short identifier
+// or all if the ID is 0
 int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID);
 
 void lwm2m_resource_value_changed(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -662,10 +662,13 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int lengt
 // LWM2M Security Object (ID 0) must be present with either a bootstrap server or a LWM2M server and
 // its matching LWM2M Server Object (ID 1) instance
 int lwm2m_configure(lwm2m_context_t * contextP, const char * endpointName, const char * msisdn, const char * altPath, uint16_t numObject, lwm2m_object_t * objectList[]);
+int lwm2m_add_object(lwm2m_context_t * contextP, lwm2m_object_t * objectP);
+int lwm2m_remove_object(lwm2m_context_t * contextP, uint16_t id);
 
 // send a registration update to the server specified by the server short identifier
-// or all if the ID is 0
-int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID);
+// or all if the ID is 0.
+// If withObjects is true, the registration update contains the object list.
+int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID, bool withObjects);
 
 void lwm2m_resource_value_changed(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 #endif

--- a/tests/client/lwm2mclient.c
+++ b/tests/client/lwm2mclient.c
@@ -458,7 +458,7 @@ static void prv_update(char * buffer,
     if (buffer[0] == 0) goto syntax_error;
 
     uint16_t serverId = (uint16_t) atoi(buffer);
-    int res = lwm2m_update_registration(lwm2mH, serverId);
+    int res = lwm2m_update_registration(lwm2mH, serverId, false);
     if (res != 0)
     {
         fprintf(stdout, "Registration update error: ");
@@ -497,6 +497,53 @@ static void update_battery_level(lwm2m_context_t * context)
         if (0 > level) level = -level;
         next_change_time = tv_sec + level + 10;
     }
+}
+
+static void prv_add(char * buffer,
+                    void * user_data)
+{
+    lwm2m_context_t * lwm2mH = (lwm2m_context_t *)user_data;
+    lwm2m_object_t * objectP;
+    int res;
+
+    objectP = get_test_object();
+    if (objectP == NULL)
+    {
+        fprintf(stdout, "Creating object 1024 failed.\r\n");
+        return;
+    }
+    res = lwm2m_add_object(lwm2mH, objectP);
+    if (res != 0)
+    {
+        fprintf(stdout, "Adding object 1024 failed: ");
+        print_status(stdout, res);
+        fprintf(stdout, "\r\n");
+    }
+    else
+    {
+        fprintf(stdout, "Object 1024 added.\r\n");
+    }
+    return;
+}
+
+static void prv_remove(char * buffer,
+                       void * user_data)
+{
+    lwm2m_context_t * lwm2mH = (lwm2m_context_t *)user_data;
+    int res;
+
+    res = lwm2m_remove_object(lwm2mH, 1024);
+    if (res != 0)
+    {
+        fprintf(stdout, "Removing object 1024 failed: ");
+        print_status(stdout, res);
+        fprintf(stdout, "\r\n");
+    }
+    else
+    {
+        fprintf(stdout, "Object 1024 removed.\r\n");
+    }
+    return;
 }
 
 #ifdef LWM2M_BOOTSTRAP
@@ -777,6 +824,8 @@ int main(int argc, char *argv[])
             {"disp", "Display current objects/instances/resources", NULL, prv_display_objects, NULL},
             {"dump", "Dump an Object", "dump URI"
                                        "URI: uri of the Object or Instance such as /3/0, /1\r\n", prv_object_dump, NULL},
+            {"add", "Add support of object 1024", NULL, prv_add, NULL},
+            {"rm", "Remove support of object 1024", NULL, prv_remove, NULL},
             {"quit", "Quit the client gracefully.", NULL, prv_quit, NULL},
             {"^C", "Quit the client abruptly (without sending a de-register message).", NULL, NULL, NULL},
 


### PR DESCRIPTION
two new APIs:
```C
int lwm2m_add_object(lwm2m_context_t * contextP, lwm2m_object_t * objectP);
int lwm2m_remove_object(lwm2m_context_t * contextP, uint16_t id);
```
to add or remove an object support from the client.
The test client has two new commands: "add" and "rm" to add or remove the /1024 object.

lwm2m_update_registration() prototype changed to:
```C
int lwm2m_update_registration(lwm2m_context_t * contextP, uint16_t shortServerID, bool withObjects);
```
If withObjects is true, the registration update contains the object list. If shortServerID is 0, the registration update is sent to all servers.