### PR TITLE
Fix for issue #105: memory overwrite in message_send.

### DIFF
--- a/core/er-coap-13/er-coap-13.c
+++ b/core/er-coap-13/er-coap-13.c
@@ -416,7 +416,7 @@ size_t coap_serialize_get_size(void *packet)
     coap_packet_t *const coap_pkt = (coap_packet_t *) packet;
     size_t length = 0;
 
-    length = COAP_HEADER_LEN + coap_pkt->payload_len;
+    length = COAP_HEADER_LEN + coap_pkt->payload_len + coap_pkt->token_len;
 
     if (IS_OPTION(coap_pkt, COAP_OPTION_IF_MATCH))
     {


### PR DESCRIPTION
coap_serialize_get_size need to add token_len.

Signed-off-by: Ricky Liu <ricky.jh.liu@wnc.com.tw>