### PR TITLE
Secure Client: Use tinyDTLS as a submodule instead of downloading it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,3 @@ core/cmake_install.cmake
 lwm2mclient
 lwm2mserver
 tlvdecode
-
-tests/utils/tinydtls

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/utils/tinydtls"]
+	path = tests/utils/tinydtls
+	url = https://git.eclipse.org/r/tinydtls/org.eclipse.tinydtls

--- a/tests/secureclient/CMakeLists.txt
+++ b/tests/secureclient/CMakeLists.txt
@@ -16,7 +16,7 @@ set(TINYDTLS_SOURCES
     ${TINYDTLS_SOURCES_DIR}/crypto.c
     ${TINYDTLS_SOURCES_DIR}/ccm.c
     ${TINYDTLS_SOURCES_DIR}/hmac.c
-    ${TINYDTLS_SOURCES_DIR}/debug.c
+    ${TINYDTLS_SOURCES_DIR}/dtls_debug.c
     ${TINYDTLS_SOURCES_DIR}/netq.c
     ${TINYDTLS_SOURCES_DIR}/peer.c
     ${TINYDTLS_SOURCES_DIR}/dtls_time.c

--- a/tests/secureclient/README
+++ b/tests/secureclient/README
@@ -1,2 +1,15 @@
-Unzip [tinydtls](http://sourceforge.net/projects/tinydtls/) in tests/utils/tinydtls to compile secure client.
-(Currently testing with the 0.8.2 version)
+This client requires tinyDTLS.
+TinyDTLS is included as a GIT submodule. On first usage, you need to run the following commands to retrieve the sources:
+git submodule init
+git submodule update
+
+You need to install the packages libtool and autoreconf.
+
+In the wakaama/tests/utils/tinydtls run the following commands:
+autoreconf -i
+./configure
+
+You can then build the secureclient using the commands:
+cmake wakaama/tests/secureclient
+make
+


### PR DESCRIPTION
Signed-off-by: David Navarro <david.navarro@intel.com>