### PR TITLE
Spring cleaning

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -16,5 +16,6 @@ SET(CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/management.c
     ${CMAKE_CURRENT_LIST_DIR}/observe.c
     ${CMAKE_CURRENT_LIST_DIR}/json.c
+    ${CMAKE_CURRENT_LIST_DIR}/discover.c
     ${EXT_SOURCES}
     PARENT_SCOPE)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/utils.c
     ${CMAKE_CURRENT_LIST_DIR}/objects.c
     ${CMAKE_CURRENT_LIST_DIR}/tlv.c
+    ${CMAKE_CURRENT_LIST_DIR}/data.c
     ${CMAKE_CURRENT_LIST_DIR}/list.c
     ${CMAKE_CURRENT_LIST_DIR}/packet.c
     ${CMAKE_CURRENT_LIST_DIR}/transaction.c

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -332,7 +332,7 @@ coap_status_t bootstrap_handleCommand(lwm2m_context_t * contextP,
     coap_status_t result;
     lwm2m_media_type_t format;
 
-    format = prv_convertMediaType(message->content_type);
+    format = utils_convertMediaType(message->content_type);
 
     result = prv_checkServerStatus(serverP);
     if (result != COAP_NO_ERROR) return result;

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -369,7 +369,7 @@ coap_status_t bootstrap_handleCommand(lwm2m_context_t * contextP,
 
                 if (message->payload_len == 0 || message->payload == 0)
                 {
-                    result = BAD_REQUEST_4_00;
+                    result = COAP_400_BAD_REQUEST;
                 }
                 else
                 {
@@ -422,7 +422,7 @@ coap_status_t bootstrap_handleCommand(lwm2m_context_t * contextP,
         {
             if (LWM2M_URI_IS_SET_RESOURCE(uriP))
             {
-                result = BAD_REQUEST_4_00;
+                result = COAP_400_BAD_REQUEST;
             }
             else
             {
@@ -446,7 +446,7 @@ coap_status_t bootstrap_handleCommand(lwm2m_context_t * contextP,
     case COAP_GET:
     case COAP_POST:
     default:
-        result = BAD_REQUEST_4_00;
+        result = COAP_400_BAD_REQUEST;
         break;
     }
 
@@ -513,7 +513,7 @@ coap_status_t bootstrap_handleDeleteAll(lwm2m_context_t * contextP,
         else
         {
             result = object_delete(contextP, &uri);
-            if (result == METHOD_NOT_ALLOWED_4_05)
+            if (result == COAP_405_METHOD_NOT_ALLOWED)
             {
                 // Fake a successful deletion for static objects like the Device object.
                 result = COAP_202_DELETED;
@@ -614,7 +614,7 @@ int lwm2m_bootstrap_delete(lwm2m_context_t * contextP,
     bs_data_t * dataP;
 
     transaction = transaction_new(COAP_TYPE_CON, COAP_DELETE, NULL, uriP, contextP->nextMID++, 4, NULL, ENDPOINT_UNKNOWN, sessionH);
-    if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
+    if (transaction == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
     dataP = (bs_data_t *)lwm2m_malloc(sizeof(bs_data_t));
     if (dataP == NULL)
@@ -660,7 +660,7 @@ int lwm2m_bootstrap_write(lwm2m_context_t * contextP,
     }
 
     transaction = transaction_new(COAP_TYPE_CON, COAP_PUT, NULL, uriP, contextP->nextMID++, 4, NULL, ENDPOINT_UNKNOWN, sessionH);
-    if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
+    if (transaction == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
     coap_set_header_content_type(transaction->message, format);
     coap_set_payload(transaction->message, buffer, length);
@@ -691,7 +691,7 @@ int lwm2m_bootstrap_finish(lwm2m_context_t * contextP,
     bs_data_t * dataP;
 
     transaction = transaction_new(COAP_TYPE_CON, COAP_POST, NULL, NULL, contextP->nextMID++, 4, NULL, ENDPOINT_UNKNOWN, sessionH);
-    if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
+    if (transaction == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
     coap_set_header_uri_path(transaction->message, "/"URI_BOOTSTRAP_SEGMENT);
 

--- a/core/data.c
+++ b/core/data.c
@@ -79,7 +79,7 @@ void lwm2m_data_encode_int(int64_t value,
         uint8_t buffer[_PRV_64BIT_BUFFER_SIZE];
         size_t length = 0;
 
-        utils_encodeInt(value, buffer, &length);
+        length = utils_encodeInt(value, buffer);
 
         dataP->value = (uint8_t *)lwm2m_malloc(length);
         if (dataP->value != NULL)

--- a/core/data.c
+++ b/core/data.c
@@ -312,7 +312,7 @@ int lwm2m_data_parse(lwm2m_uri_t * uriP,
 
 #ifdef LWM2M_SUPPORT_JSON
     case LWM2M_CONTENT_JSON:
-        return lwm2m_json_parse(uriP, buffer, bufferLen, dataP);
+        return json_parse(uriP, buffer, bufferLen, dataP);
 #endif
 
     default:
@@ -356,11 +356,11 @@ int lwm2m_data_serialize(lwm2m_uri_t * uriP,
 
 #ifdef LWM2M_CLIENT_MODE
     case LWM2M_CONTENT_LINK:
-        return prv_serializeLink(NULL, uriP, size, dataP, bufferP);
+        return discover_serialize(NULL, uriP, size, dataP, bufferP);
 #endif
 #ifdef LWM2M_SUPPORT_JSON
     case LWM2M_CONTENT_JSON:
-        return lwm2m_json_serialize(uriP, size, dataP, bufferP);
+        return json_serialize(uriP, size, dataP, bufferP);
 #endif
 
     default:

--- a/core/data.c
+++ b/core/data.c
@@ -72,7 +72,7 @@ void lwm2m_data_encode_int(int64_t value,
     if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
     {
         dataP->flags &= ~LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->length = lwm2m_int64ToPlainText(value, &dataP->value);
+        dataP->length = utils_int64ToPlainText(value, &dataP->value);
     }
     else
     {
@@ -102,7 +102,7 @@ int lwm2m_data_decode_int(const lwm2m_data_t * dataP,
 
     if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
     {
-        result = lwm2m_PlainTextToInt64(dataP->value, dataP->length, valueP);
+        result = utils_plainTextToInt64(dataP->value, dataP->length, valueP);
     }
     else
     {
@@ -129,7 +129,7 @@ void lwm2m_data_encode_float(double value,
     if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
     {
         dataP->flags &= ~LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->length = lwm2m_float64ToPlainText(value, &dataP->value);
+        dataP->length = utils_float64ToPlainText(value, &dataP->value);
     }
     else
     {
@@ -175,7 +175,7 @@ int lwm2m_data_decode_float(const lwm2m_data_t * dataP,
 
     if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
     {
-        result = lwm2m_PlainTextToFloat64(dataP->value, dataP->length, valueP);
+        result = utils_plainTextToFloat64(dataP->value, dataP->length, valueP);
     }
     else
     {

--- a/core/data.c
+++ b/core/data.c
@@ -1,0 +1,370 @@
+/*******************************************************************************
+*
+* Copyright (c) 2013, 2014 Intel Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* and Eclipse Distribution License v1.0 which accompany this distribution.
+*
+* The Eclipse Public License is available at
+*    http://www.eclipse.org/legal/epl-v10.html
+* The Eclipse Distribution License is available at
+*    http://www.eclipse.org/org/documents/edl-v10.php.
+*
+* Contributors:
+*    David Navarro, Intel Corporation - initial API and implementation
+*    Fabien Fleutot - Please refer to git log
+*    Bosch Software Innovations GmbH - Please refer to git log
+*
+*******************************************************************************/
+
+#include "internals.h"
+#include <float.h>
+
+
+lwm2m_data_t * lwm2m_data_new(int size)
+{
+    lwm2m_data_t * dataP;
+
+    if (size <= 0) return NULL;
+
+    dataP = (lwm2m_data_t *)lwm2m_malloc(size * sizeof(lwm2m_data_t));
+
+    if (dataP != NULL)
+    {
+        memset(dataP, 0, size * sizeof(lwm2m_data_t));
+    }
+
+    return dataP;
+}
+
+void lwm2m_data_free(int size,
+                     lwm2m_data_t * dataP)
+{
+    int i;
+
+    if (size == 0 || dataP == NULL) return;
+
+    for (i = 0; i < size; i++)
+    {
+        if ((dataP[i].flags & LWM2M_TLV_FLAG_STATIC_DATA) == 0)
+        {
+            if (dataP[i].type == LWM2M_TYPE_MULTIPLE_RESOURCE
+                || dataP[i].type == LWM2M_TYPE_OBJECT_INSTANCE
+                || dataP[i].type == LWM2M_TYPE_OBJECT)
+            {
+                lwm2m_data_free(dataP[i].length, (lwm2m_data_t *)(dataP[i].value));
+            }
+            else if (dataP[i].value != NULL)
+            {
+                lwm2m_free(dataP[i].value);
+            }
+        }
+    }
+    lwm2m_free(dataP);
+}
+
+void lwm2m_data_encode_int(int64_t value,
+                           lwm2m_data_t * dataP)
+{
+    dataP->length = 0;
+    dataP->dataType = LWM2M_TYPE_INTEGER;
+
+    if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
+    {
+        dataP->flags &= ~LWM2M_TLV_FLAG_STATIC_DATA;
+        dataP->length = lwm2m_int64ToPlainText(value, &dataP->value);
+    }
+    else
+    {
+        uint8_t buffer[_PRV_64BIT_BUFFER_SIZE];
+        size_t length = 0;
+
+        prv_encodeInt(value, buffer, &length);
+
+        dataP->value = (uint8_t *)lwm2m_malloc(length);
+        if (dataP->value != NULL)
+        {
+            memcpy(dataP->value,
+                   buffer,
+                   length);
+            dataP->flags &= ~LWM2M_TLV_FLAG_STATIC_DATA;
+            dataP->length = length;
+        }
+    }
+}
+
+int lwm2m_data_decode_int(const lwm2m_data_t * dataP,
+                          int64_t * valueP)
+{
+    int result;
+
+    if (dataP->length == 0) return 0;
+
+    if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
+    {
+        result = lwm2m_PlainTextToInt64(dataP->value, dataP->length, valueP);
+    }
+    else
+    {
+        result = lwm2m_opaqueToInt(dataP->value, dataP->length, valueP);
+        if (result == dataP->length)
+        {
+            result = 1;
+        }
+        else
+        {
+            result = 0;
+        }
+    }
+
+    return result;
+}
+
+void lwm2m_data_encode_float(double value,
+                             lwm2m_data_t * dataP)
+{
+    dataP->length = 0;
+    dataP->dataType = LWM2M_TYPE_FLOAT;
+
+    if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
+    {
+        dataP->flags &= ~LWM2M_TLV_FLAG_STATIC_DATA;
+        dataP->length = lwm2m_float64ToPlainText(value, &dataP->value);
+    }
+    else
+    {
+        size_t length = 0;
+
+        if (value > FLT_MAX || value < (0 - FLT_MAX))
+        {
+            length = 8;
+        }
+        else
+        {
+            length = 4;
+        }
+
+        dataP->value = (uint8_t *)lwm2m_malloc(length);
+        if (dataP->value != NULL)
+        {
+            if (length == 4)
+            {
+                float temp;
+
+                temp = value;
+
+                utils_copyValue(dataP->value, &temp, length);
+            }
+            else
+            {
+                utils_copyValue(dataP->value, &value, length);
+            }
+
+            dataP->flags &= ~LWM2M_TLV_FLAG_STATIC_DATA;
+            dataP->length = length;
+        }
+    }
+}
+
+int lwm2m_data_decode_float(const lwm2m_data_t * dataP,
+                            double * valueP)
+{
+    int result;
+
+    if (dataP->length == 0) return 0;
+
+    if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
+    {
+        result = lwm2m_PlainTextToFloat64(dataP->value, dataP->length, valueP);
+    }
+    else
+    {
+        result = lwm2m_opaqueToFloat(dataP->value, dataP->length, valueP);
+        if (result == dataP->length)
+        {
+            result = 1;
+        }
+        else
+        {
+            result = 0;
+        }
+    }
+
+    return result;
+}
+
+void lwm2m_data_encode_bool(bool value,
+                            lwm2m_data_t * dataP)
+{
+    dataP->length = 0;
+    dataP->dataType = LWM2M_TYPE_BOOLEAN;
+
+    dataP->value = (uint8_t *)lwm2m_malloc(1);
+    if (dataP->value != NULL)
+    {
+        if (value == true)
+        {
+            if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
+            {
+                dataP->value[0] = '1';
+            }
+            else
+            {
+                dataP->value[0] = 1;
+            }
+        }
+        else
+        {
+            if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
+            {
+                dataP->value[0] = '0';
+            }
+            else
+            {
+                dataP->value[0] = 0;
+            }
+        }
+        dataP->flags &= ~LWM2M_TLV_FLAG_STATIC_DATA;
+        dataP->length = 1;
+    }
+}
+
+int lwm2m_data_decode_bool(const lwm2m_data_t * dataP,
+                           bool * valueP)
+{
+    if (dataP->length != 1) return 0;
+
+    if ((dataP->flags & LWM2M_TLV_FLAG_TEXT_FORMAT) != 0)
+    {
+        switch (dataP->value[0])
+        {
+        case '0':
+            *valueP = false;
+            break;
+        case '1':
+            *valueP = true;
+            break;
+        default:
+            return 0;
+        }
+    }
+    else
+    {
+        switch (dataP->value[0])
+        {
+        case 0:
+            *valueP = false;
+            break;
+        case 1:
+            *valueP = true;
+            break;
+        default:
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+void lwm2m_data_include(lwm2m_data_t * subDataP,
+                        size_t count,
+                        lwm2m_data_t * dataP)
+{
+    if (subDataP == NULL || count == 0) return;
+
+    switch (subDataP[0].type)
+    {
+    case LWM2M_TYPE_RESOURCE:
+    case LWM2M_TYPE_MULTIPLE_RESOURCE:
+        dataP->type = LWM2M_TYPE_OBJECT_INSTANCE;
+        break;
+    case LWM2M_TYPE_RESOURCE_INSTANCE:
+        dataP->type = LWM2M_TYPE_MULTIPLE_RESOURCE;
+        break;
+    default:
+        break;
+    }
+    dataP->flags = 0;
+    dataP->dataType = LWM2M_TYPE_UNDEFINED;
+    dataP->length = count;
+    dataP->value = (uint8_t *)subDataP;
+}
+
+int lwm2m_data_parse(lwm2m_uri_t * uriP,
+                     uint8_t * buffer,
+                     size_t bufferLen,
+                     lwm2m_media_type_t format,
+                     lwm2m_data_t ** dataP)
+{
+    switch (format)
+    {
+    case LWM2M_CONTENT_TEXT:
+    case LWM2M_CONTENT_OPAQUE:
+        *dataP = lwm2m_data_new(1);
+        if (*dataP == NULL) return 0;
+        (*dataP)->length = bufferLen;
+        (*dataP)->value = buffer;
+        (*dataP)->flags = LWM2M_TLV_FLAG_STATIC_DATA;
+        return 1;
+
+    case LWM2M_CONTENT_TLV:
+        return lwm2m_tlv_parse(buffer, bufferLen, dataP);
+
+#ifdef LWM2M_SUPPORT_JSON
+    case LWM2M_CONTENT_JSON:
+        return lwm2m_json_parse(uriP, buffer, bufferLen, dataP);
+#endif
+
+    default:
+        return 0;
+    }
+}
+
+int lwm2m_data_serialize(lwm2m_uri_t * uriP,
+                         int size,
+                         lwm2m_data_t * dataP,
+                         lwm2m_media_type_t * formatP,
+                         uint8_t ** bufferP)
+{
+
+    // Check format
+    if (*formatP == LWM2M_CONTENT_TEXT
+        || *formatP == LWM2M_CONTENT_OPAQUE)
+    {
+        if ((size != 1)
+            || (dataP->type != LWM2M_TYPE_RESOURCE))
+        {
+#ifdef LWM2M_SUPPORT_JSON
+            *formatP = LWM2M_CONTENT_JSON;
+#else
+            *formatP = LWM2M_CONTENT_TLV;
+#endif
+        }
+    }
+
+    switch (*formatP)
+    {
+    case LWM2M_CONTENT_TEXT:
+    case LWM2M_CONTENT_OPAQUE:
+        *bufferP = (uint8_t *)lwm2m_malloc(dataP->length);
+        if (*bufferP == NULL) return 0;
+        memcpy(*bufferP, dataP->value, dataP->length);
+        return dataP->length;
+
+    case LWM2M_CONTENT_TLV:
+        return lwm2m_tlv_serialize(size, dataP, bufferP);
+
+#ifdef LWM2M_CLIENT_MODE
+    case LWM2M_CONTENT_LINK:
+        return prv_serializeLink(NULL, uriP, size, dataP, bufferP);
+#endif
+#ifdef LWM2M_SUPPORT_JSON
+    case LWM2M_CONTENT_JSON:
+        return lwm2m_json_serialize(uriP, size, dataP, bufferP);
+#endif
+
+    default:
+        return 0;
+    }
+}
+

--- a/core/data.c
+++ b/core/data.c
@@ -79,7 +79,7 @@ void lwm2m_data_encode_int(int64_t value,
         uint8_t buffer[_PRV_64BIT_BUFFER_SIZE];
         size_t length = 0;
 
-        prv_encodeInt(value, buffer, &length);
+        utils_encodeInt(value, buffer, &length);
 
         dataP->value = (uint8_t *)lwm2m_malloc(length);
         if (dataP->value != NULL)
@@ -106,7 +106,7 @@ int lwm2m_data_decode_int(const lwm2m_data_t * dataP,
     }
     else
     {
-        result = lwm2m_opaqueToInt(dataP->value, dataP->length, valueP);
+        result = utils_opaqueToInt(dataP->value, dataP->length, valueP);
         if (result == dataP->length)
         {
             result = 1;
@@ -179,7 +179,7 @@ int lwm2m_data_decode_float(const lwm2m_data_t * dataP,
     }
     else
     {
-        result = lwm2m_opaqueToFloat(dataP->value, dataP->length, valueP);
+        result = utils_opaqueToFloat(dataP->value, dataP->length, valueP);
         if (result == dataP->length)
         {
             result = 1;
@@ -308,7 +308,7 @@ int lwm2m_data_parse(lwm2m_uri_t * uriP,
         return 1;
 
     case LWM2M_CONTENT_TLV:
-        return lwm2m_tlv_parse(buffer, bufferLen, dataP);
+        return tlv_parse(buffer, bufferLen, dataP);
 
 #ifdef LWM2M_SUPPORT_JSON
     case LWM2M_CONTENT_JSON:
@@ -352,7 +352,7 @@ int lwm2m_data_serialize(lwm2m_uri_t * uriP,
         return dataP->length;
 
     case LWM2M_CONTENT_TLV:
-        return lwm2m_tlv_serialize(size, dataP, bufferP);
+        return tlv_serialize(size, dataP, bufferP);
 
 #ifdef LWM2M_CLIENT_MODE
     case LWM2M_CONTENT_LINK:

--- a/core/discover.c
+++ b/core/discover.c
@@ -1,0 +1,329 @@
+/*******************************************************************************
+*
+* Copyright (c) 2015 Intel Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* and Eclipse Distribution License v1.0 which accompany this distribution.
+*
+* The Eclipse Public License is available at
+*    http://www.eclipse.org/legal/epl-v10.html
+* The Eclipse Distribution License is available at
+*    http://www.eclipse.org/org/documents/edl-v10.php.
+*
+* Contributors:
+*    David Navarro, Intel Corporation - initial API and implementation
+*
+*******************************************************************************/
+
+
+#include "internals.h"
+
+#define PRV_LINK_BUFFER_SIZE  1024
+
+
+#define PRV_CONCAT_STR(buf, len, index, str, str_len)    \
+    {                                                    \
+        if ((len)-(index) < (str_len)) return -1;        \
+        memcpy((buf)+(index), (str), (str_len));         \
+        (index) += (str_len);                            \
+    }
+
+
+#ifdef LWM2M_CLIENT_MODE
+static int prv_serializeAttributes(lwm2m_context_t * contextP,
+                                   lwm2m_uri_t * uriP,
+                                   uint8_t * buffer,
+                                   size_t uriLen,
+                                   size_t bufferLen)
+{
+    lwm2m_observed_t * observedP;
+    lwm2m_watcher_t * watcherP;
+    int head;
+    int res;
+
+    if (contextP == NULL) return 0;
+
+    observedP = observe_findByUri(contextP, uriP);
+    if (observedP == NULL || observedP->watcherList == NULL) return 0;
+
+    head = 0;
+    for (watcherP = observedP->watcherList; watcherP != NULL; watcherP = watcherP->next)
+    {
+        lwm2m_attributes_t * paramP;
+
+        paramP = watcherP->parameters;
+        if (paramP == NULL || paramP->toSet == 0) continue;
+
+        if (observedP->watcherList->next != NULL)
+        {
+            // multiple servers
+            memcpy(buffer + head, buffer, uriLen);
+
+            PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
+            PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_SERVER_ID_STR, ATTR_SERVER_ID_LEN);
+
+            res = utils_intToText(watcherP->server->shortID, buffer + head, bufferLen - head);
+            if (res <= 0) return -1;
+            head += res;
+        }
+        else
+        {
+            head = uriLen;
+        }
+
+        if (paramP->toSet & LWM2M_ATTR_FLAG_MIN_PERIOD)
+        {
+            PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
+            PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_MIN_PERIOD_STR, ATTR_MIN_PERIOD_LEN);
+
+            res = utils_intToText(paramP->minPeriod, buffer + head, bufferLen - head);
+            if (res <= 0) return -1;
+            head += res;
+        }
+        if (paramP->toSet & LWM2M_ATTR_FLAG_MAX_PERIOD)
+        {
+            PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
+            PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_MAX_PERIOD_STR, ATTR_MAX_PERIOD_LEN);
+
+            res = utils_intToText(paramP->maxPeriod, buffer + head, bufferLen - head);
+            if (res <= 0) return -1;
+            head += res;
+        }
+        if (paramP->toSet & LWM2M_ATTR_FLAG_GREATER_THAN)
+        {
+            PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
+            PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_GREATER_THAN_STR, ATTR_GREATER_THAN_LEN);
+
+            res = utils_floatToText(paramP->greaterThan, buffer + head, bufferLen - head);
+            if (res <= 0) return -1;
+            head += res;
+        }
+        if (paramP->toSet & LWM2M_ATTR_FLAG_LESS_THAN)
+        {
+            PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
+            PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_LESS_THAN_STR, ATTR_LESS_THAN_LEN);
+
+            res = utils_floatToText(paramP->lessThan, buffer + head, bufferLen - head);
+            if (res <= 0) return -1;
+            head += res;
+        }
+        if (paramP->toSet & LWM2M_ATTR_FLAG_STEP)
+        {
+            PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
+            PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_STEP_STR, ATTR_STEP_LEN);
+
+            res = utils_floatToText(paramP->step, buffer + head, bufferLen - head);
+            if (res <= 0) return -1;
+            head += res;
+        }
+        PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ITEM_ATTR_END, LINK_ITEM_ATTR_END_SIZE);
+    }
+
+    if (head > 0) head -= uriLen;
+
+    return head;
+}
+
+static int prv_serializeLinkData(lwm2m_context_t * contextP,
+                                 lwm2m_data_t * tlvP,
+                                 lwm2m_uri_t * parentUriP,
+                                 uint8_t * parentUriStr,
+                                 size_t parentUriLen,
+                                 uint8_t * buffer,
+                                 size_t bufferLen)
+{
+    int head;
+    int res;
+    lwm2m_uri_t uri;
+
+    head = 0;
+
+    switch (tlvP->type)
+    {
+    case LWM2M_TYPE_RESOURCE:
+    case LWM2M_TYPE_MULTIPLE_RESOURCE:
+        if (bufferLen < LINK_ITEM_START_SIZE) return -1;
+        memcpy(buffer + head, LINK_ITEM_START, LINK_ITEM_START_SIZE);
+        head = LINK_ITEM_START_SIZE;
+
+        if (parentUriLen > 0)
+        {
+            if (bufferLen - head < parentUriLen) return -1;
+            memcpy(buffer + head, parentUriStr, parentUriLen);
+            head += parentUriLen;
+        }
+
+        if (bufferLen - head < LINK_URI_SEPARATOR_SIZE) return -1;
+        memcpy(buffer + head, LINK_URI_SEPARATOR, LINK_URI_SEPARATOR_SIZE);
+        head += LINK_URI_SEPARATOR_SIZE;
+
+        res = utils_intToText(tlvP->id, buffer + head, bufferLen - head);
+        if (res <= 0) return -1;
+        head += res;
+
+        if (tlvP->type == LWM2M_TYPE_MULTIPLE_RESOURCE)
+        {
+            if (bufferLen - head < LINK_ITEM_DIM_START_SIZE) return -1;
+            memcpy(buffer + head, LINK_ITEM_DIM_START, LINK_ITEM_DIM_START_SIZE);
+            head += LINK_ITEM_DIM_START_SIZE;
+
+            res = utils_intToText(tlvP->length, buffer + head, bufferLen - head);
+            if (res <= 0) return -1;
+            head += res;
+
+            if (bufferLen - head < LINK_ITEM_ATTR_END_SIZE) return -1;
+            memcpy(buffer + head, LINK_ITEM_ATTR_END, LINK_ITEM_ATTR_END_SIZE);
+            head += LINK_ITEM_ATTR_END_SIZE;
+        }
+        else
+        {
+            if (bufferLen - head < LINK_ITEM_END_SIZE) return -1;
+            memcpy(buffer + head, LINK_ITEM_END, LINK_ITEM_END_SIZE);
+            head += LINK_ITEM_END_SIZE;
+        }
+
+        memcpy(&uri, parentUriP, sizeof(lwm2m_uri_t));
+        uri.resourceId = tlvP->id;
+        uri.flag |= LWM2M_URI_FLAG_RESOURCE_ID;
+        res = prv_serializeAttributes(contextP, &uri, buffer, head - 1, bufferLen);
+        if (res < 0) return -1;    // careful, 0 is valid
+        if (res > 0) head += res - 1;
+
+        break;
+
+    case LWM2M_TYPE_OBJECT_INSTANCE:
+    {
+        char uriStr[URI_MAX_STRING_LEN];
+        size_t uriLen;
+        int index;
+
+        if (parentUriLen > 0)
+        {
+            if (URI_MAX_STRING_LEN < parentUriLen) return -1;
+            memcpy(uriStr, parentUriStr, parentUriLen);
+            uriLen = parentUriLen;
+        }
+        else
+        {
+            uriLen = 0;
+        }
+
+        if (URI_MAX_STRING_LEN - uriLen < LINK_URI_SEPARATOR_SIZE) return -1;
+        memcpy(uriStr + uriLen, LINK_URI_SEPARATOR, LINK_URI_SEPARATOR_SIZE);
+        uriLen += LINK_URI_SEPARATOR_SIZE;
+
+        res = utils_intToText(tlvP->id, uriStr + uriLen, URI_MAX_STRING_LEN - uriLen);
+        if (res <= 0) return -1;
+        uriLen += res;
+
+        memcpy(&uri, parentUriP, sizeof(lwm2m_uri_t));
+        uri.instanceId = tlvP->id;
+        uri.flag |= LWM2M_URI_FLAG_INSTANCE_ID;
+
+        head = 0;
+        PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ITEM_START, LINK_ITEM_START_SIZE);
+        PRV_CONCAT_STR(buffer, bufferLen, head, uriStr, uriLen);
+        PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ITEM_END, LINK_ITEM_END_SIZE);
+        res = prv_serializeAttributes(contextP, &uri, buffer, head - 1, bufferLen);
+        if (res < 0) return -1;    // careful, 0 is valid
+        if (res == 0) head = 0;    // rewind
+        else head += res - 1;
+
+        for (index = 0; index < tlvP->length; index++)
+        {
+            res = prv_serializeLinkData(contextP, ((lwm2m_data_t *)tlvP->value) + index, &uri, uriStr, uriLen, buffer + head, bufferLen - head);
+            if (res < 0) return -1;
+            head += res;
+        }
+    }
+    break;
+
+    case LWM2M_TYPE_OBJECT:
+    default:
+        return -1;
+    }
+
+    return head;
+}
+
+int discover_serialize(lwm2m_context_t * contextP,
+                      lwm2m_uri_t * uriP,
+                      int size,
+                      lwm2m_data_t * dataP,
+                      uint8_t ** bufferP)
+{
+    uint8_t bufferLink[PRV_LINK_BUFFER_SIZE];
+    char baseUriStr[URI_MAX_STRING_LEN];
+    int baseUriLen;
+    lwm2m_tlv_type_t level;
+    int index;
+    size_t head;
+    int res;
+    lwm2m_uri_t tempUri;
+
+    baseUriLen = uri_toString(uriP, baseUriStr, URI_MAX_STRING_LEN, &level);
+    if (baseUriLen < 0) return -1;
+    baseUriLen -= 1;
+
+    head = 0;
+    memset(&tempUri, 0, sizeof(lwm2m_uri_t));
+
+    // get object level attributes
+    PRV_CONCAT_STR(bufferLink, PRV_LINK_BUFFER_SIZE, head, LINK_ITEM_START, LINK_ITEM_START_SIZE);
+    PRV_CONCAT_STR(bufferLink, PRV_LINK_BUFFER_SIZE, head, LINK_URI_SEPARATOR, LINK_URI_SEPARATOR_SIZE);
+    res = utils_intToText(uriP->objectId, bufferLink + head, PRV_LINK_BUFFER_SIZE - head);
+    if (res <= 0) return -1;
+    head += res;
+    PRV_CONCAT_STR(bufferLink, PRV_LINK_BUFFER_SIZE, head, LINK_ITEM_END, LINK_ITEM_END_SIZE);
+    tempUri.objectId = uriP->objectId;
+    res = prv_serializeAttributes(contextP, &tempUri, bufferLink, head - 1, PRV_LINK_BUFFER_SIZE);
+    if (res < 0) return -1;    // careful, 0 is valid
+    if (res == 0) head = 0;    // rewind
+    else head += res - 1;
+    if (LWM2M_URI_IS_SET_INSTANCE(uriP))
+    {
+        size_t subHead;
+
+        // get object instance level attributes
+        subHead = 0;
+        PRV_CONCAT_STR(bufferLink + head, PRV_LINK_BUFFER_SIZE - head, subHead, LINK_ITEM_START, LINK_ITEM_START_SIZE);
+        PRV_CONCAT_STR(bufferLink + head, PRV_LINK_BUFFER_SIZE - head, subHead, LINK_URI_SEPARATOR, LINK_URI_SEPARATOR_SIZE);
+        res = utils_intToText(uriP->objectId, bufferLink + head + subHead, PRV_LINK_BUFFER_SIZE - head - subHead);
+        if (res <= 0) return -1;
+        subHead += res;
+        PRV_CONCAT_STR(bufferLink + head, PRV_LINK_BUFFER_SIZE - head, subHead, LINK_URI_SEPARATOR, LINK_URI_SEPARATOR_SIZE);
+        res = utils_intToText(uriP->instanceId, bufferLink + head + subHead, PRV_LINK_BUFFER_SIZE - head - subHead);
+        if (res <= 0) return -1;
+        subHead += res;
+        PRV_CONCAT_STR(bufferLink + head, PRV_LINK_BUFFER_SIZE - head, subHead, LINK_ITEM_END, LINK_ITEM_END_SIZE);
+        tempUri.instanceId = uriP->instanceId;
+        tempUri.flag = LWM2M_URI_FLAG_INSTANCE_ID;
+        res = prv_serializeAttributes(contextP, &tempUri, bufferLink + head, head + subHead - 1, PRV_LINK_BUFFER_SIZE);
+        if (res < 0) return -1;    // careful, 0 is valid
+        if (res == 0) subHead = 0;    // rewind
+        else subHead += res - 1;
+
+        head += subHead;
+    }
+
+    for (index = 0; index < size && head < PRV_LINK_BUFFER_SIZE; index++)
+    {
+        int res;
+
+        res = prv_serializeLinkData(contextP, dataP + index, uriP, baseUriStr, baseUriLen, bufferLink + head, PRV_LINK_BUFFER_SIZE - head);
+        if (res < 0) return -1;
+        head += res;
+    }
+
+    if (head > 0)
+    {
+        head -= 1;
+
+        *bufferP = (uint8_t *)lwm2m_malloc(head);
+        if (*bufferP == NULL) return 0;
+        memcpy(*bufferP, bufferLink, head);
+    }
+
+    return (int)head;
+}
+#endif

--- a/core/internals.h
+++ b/core/internals.h
@@ -173,9 +173,8 @@ typedef struct
 #endif
 
 // defined in uri.c
-int lwm2m_get_number(char * uriString, size_t uriLength);
-lwm2m_uri_t * lwm2m_decode_uri(char * altPath, multi_option_t *uriPath);
-int prv_get_number(uint8_t * uriString, size_t uriLength);
+lwm2m_uri_t * uri_decode(char * altPath, multi_option_t *uriPath);
+int uri_getNumber(uint8_t * uriString, size_t uriLength);
 
 // defined in objects.c
 coap_status_t object_data_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);

--- a/core/internals.h
+++ b/core/internals.h
@@ -145,6 +145,7 @@
 #define ATTR_FLAG_NUMERIC (uint8_t)(LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP)
 
 #define LWM2M_TLV_HEADER_MAX_LENGTH 6
+#define _PRV_64BIT_BUFFER_SIZE 8
 
 #define LWM2M_URI_FLAG_DM           (uint8_t)0x00
 #define LWM2M_URI_FLAG_DELETE_ALL   (uint8_t)0x10
@@ -261,6 +262,7 @@ int lwm2m_PlainTextToFloat64(uint8_t * buffer, int length, double * dataP);
 size_t lwm2m_int64ToPlainText(int64_t data, uint8_t ** bufferP);
 size_t lwm2m_float64ToPlainText(double data, uint8_t ** bufferP);
 size_t lwm2m_boolToPlainText(bool data, uint8_t ** bufferP);
+void utils_copyValue(void * dst, const void * src, size_t len);
 
 // defined in tlv.c
 int lwm2m_intToTLV(lwm2m_tlv_type_t type, int64_t data, uint16_t id, uint8_t * buffer, size_t buffer_len);
@@ -268,6 +270,9 @@ int lwm2m_boolToTLV(lwm2m_tlv_type_t type, bool value, uint16_t id, uint8_t * bu
 int lwm2m_opaqueToTLV(lwm2m_tlv_type_t type, uint8_t * dataP, size_t data_len, uint16_t id, uint8_t * buffer, size_t buffer_len);
 int lwm2m_opaqueToInt(const uint8_t * buffer, size_t buffer_len, int64_t * dataP);
 int lwm2m_opaqueToFloat(const uint8_t * buffer, size_t buffer_len, double * dataP);
+void prv_encodeInt(int64_t data, uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE], size_t * lengthP);
+int lwm2m_tlv_parse(uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
+int lwm2m_tlv_serialize(int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
 
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP, void * fromSessionH);

--- a/core/internals.h
+++ b/core/internals.h
@@ -144,6 +144,8 @@
 
 #define ATTR_FLAG_NUMERIC (uint8_t)(LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP)
 
+#define LWM2M_TLV_HEADER_MAX_LENGTH 6
+
 #define LWM2M_URI_FLAG_DM           (uint8_t)0x00
 #define LWM2M_URI_FLAG_DELETE_ALL   (uint8_t)0x10
 #define LWM2M_URI_FLAG_REGISTRATION (uint8_t)0x20
@@ -193,7 +195,6 @@ coap_status_t object_writeInstance(lwm2m_context_t * contextP, lwm2m_uri_t * uri
 
 // defined in transaction.c
 lwm2m_transaction_t * transaction_new(coap_message_type_t type, coap_method_t method, char * altPath, lwm2m_uri_t * uriP, uint16_t mID, uint8_t token_len, uint8_t* token, lwm2m_endpoint_type_t peerType, void * peerP);
-
 int transaction_send(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
 void transaction_free(lwm2m_transaction_t * transacP);
 void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
@@ -255,6 +256,19 @@ int utils_stringCopy(char * buffer, size_t length, const char * str);
 int utils_intCopy(char * buffer, size_t length, int32_t value);
 size_t utils_intToText(int64_t data, uint8_t * string, size_t length);
 size_t utils_floatToText(double data, uint8_t * string, size_t length);
+int lwm2m_PlainTextToInt64(uint8_t * buffer, int length, int64_t * dataP);
+int lwm2m_PlainTextToFloat64(uint8_t * buffer, int length, double * dataP);
+size_t lwm2m_int64ToPlainText(int64_t data, uint8_t ** bufferP);
+size_t lwm2m_float64ToPlainText(double data, uint8_t ** bufferP);
+size_t lwm2m_boolToPlainText(bool data, uint8_t ** bufferP);
+
+// defined in tlv.c
+int lwm2m_intToTLV(lwm2m_tlv_type_t type, int64_t data, uint16_t id, uint8_t * buffer, size_t buffer_len);
+int lwm2m_boolToTLV(lwm2m_tlv_type_t type, bool value, uint16_t id, uint8_t * buffer, size_t buffer_len);
+int lwm2m_opaqueToTLV(lwm2m_tlv_type_t type, uint8_t * dataP, size_t data_len, uint16_t id, uint8_t * buffer, size_t buffer_len);
+int lwm2m_opaqueToInt(const uint8_t * buffer, size_t buffer_len, int64_t * dataP);
+int lwm2m_opaqueToFloat(const uint8_t * buffer, size_t buffer_len, double * dataP);
+
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP, void * fromSessionH);
 lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP, void * fromSessionH);

--- a/core/internals.h
+++ b/core/internals.h
@@ -197,7 +197,7 @@ lwm2m_transaction_t * transaction_new(coap_message_type_t type, coap_method_t me
 int transaction_send(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
 void transaction_free(lwm2m_transaction_t * transacP);
 void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
-bool transaction_handle_response(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
+bool transaction_handleResponse(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
 // defined in management.c

--- a/core/internals.h
+++ b/core/internals.h
@@ -142,6 +142,21 @@
 #define ATTR_DIMENSION_STR       "dim="
 #define ATTR_DIMENSION_LEN       4
 
+#define URI_MAX_STRING_LEN    18      // /65535/65535/65535
+
+#define LINK_ITEM_START             "<"
+#define LINK_ITEM_START_SIZE        1
+#define LINK_ITEM_END               ">,"
+#define LINK_ITEM_END_SIZE          2
+#define LINK_ITEM_DIM_START         ">;dim="
+#define LINK_ITEM_DIM_START_SIZE    6
+#define LINK_ITEM_ATTR_END          ","
+#define LINK_ITEM_ATTR_END_SIZE     1
+#define LINK_URI_SEPARATOR          "/"
+#define LINK_URI_SEPARATOR_SIZE     1
+#define LINK_ATTR_SEPARATOR         ";"
+#define LINK_ATTR_SEPARATOR_SIZE    1
+
 #define ATTR_FLAG_NUMERIC (uint8_t)(LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP)
 
 #define LWM2M_TLV_HEADER_MAX_LENGTH 6
@@ -175,6 +190,7 @@ typedef struct
 // defined in uri.c
 lwm2m_uri_t * uri_decode(char * altPath, multi_option_t *uriPath);
 int uri_getNumber(uint8_t * uriString, size_t uriLength);
+int uri_toString(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, lwm2m_tlv_type_t * depthP);
 
 // defined in objects.c
 coap_status_t object_readData(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);
@@ -234,10 +250,10 @@ lwm2m_status_t bootstrap_getStatus(lwm2m_context_t * contextP);
 
 // defined in json.c
 #ifdef LWM2M_SUPPORT_JSON
-int lwm2m_json_parse(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
-int lwm2m_json_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * tlvP, uint8_t ** bufferP);
+int json_parse(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
+int json_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * tlvP, uint8_t ** bufferP);
 #endif
-int prv_serializeLink(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
+int discover_serialize(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
 
 // defined in utils.c
 lwm2m_binding_t lwm2m_stringToBinding(uint8_t *buffer, size_t length);

--- a/core/internals.h
+++ b/core/internals.h
@@ -201,7 +201,7 @@ bool transaction_handleResponse(lwm2m_context_t * contextP, void * fromSessionH,
 void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 
 // defined in management.c
-coap_status_t handle_dm_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
+coap_status_t dm_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
 
 // defined in observe.c
 coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, int size, lwm2m_data_t * dataP, coap_packet_t * message, coap_packet_t * response);

--- a/core/internals.h
+++ b/core/internals.h
@@ -204,10 +204,13 @@ void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * t
 coap_status_t dm_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
 
 // defined in observe.c
-coap_status_t handle_observe_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, int size, lwm2m_data_t * dataP, coap_packet_t * message, coap_packet_t * response);
-void cancel_observe(lwm2m_context_t * contextP, uint16_t mid, void * fromSessionH);
-coap_status_t observe_set_parameters(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, lwm2m_attributes_t * attrP);
-void observation_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
+coap_status_t observe_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, int size, lwm2m_data_t * dataP, coap_packet_t * message, coap_packet_t * response);
+void observe_cancel(lwm2m_context_t * contextP, uint16_t mid, void * fromSessionH);
+coap_status_t observe_setParameters(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, lwm2m_attributes_t * attrP);
+void observe_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
+bool observe_handleNotify(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
+void observe_remove(lwm2m_client_t * clientP, lwm2m_observation_t * observationP);
+lwm2m_observed_t * observe_findByUri(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 
 // defined in registration.c
 coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
@@ -219,11 +222,6 @@ lwm2m_status_t registration_get_status(lwm2m_context_t * contextP);
 
 // defined in packet.c
 coap_status_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, void * sessionH);
-
-// defined in observe.c
-bool handle_observe_notify(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
-void observation_remove(lwm2m_client_t * clientP, lwm2m_observation_t * observationP);
-lwm2m_observed_t * observed_find(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 
 // defined in bootstrap.c
 void bootstrap_step(lwm2m_context_t * contextP, uint32_t currentTime, time_t* timeoutP);

--- a/core/internals.h
+++ b/core/internals.h
@@ -177,18 +177,17 @@ lwm2m_uri_t * uri_decode(char * altPath, multi_option_t *uriPath);
 int uri_getNumber(uint8_t * uriString, size_t uriLength);
 
 // defined in objects.c
-coap_status_t object_data_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);
+coap_status_t object_readData(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);
 coap_status_t object_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t * formatP, uint8_t ** bufferP, size_t * lengthP);
 coap_status_t object_write(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 coap_status_t object_create(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 coap_status_t object_execute(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * buffer, size_t length);
 coap_status_t object_delete(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
-coap_status_t object_delete_others(lwm2m_context_t * contextP, uint16_t objectId, uint16_t instanceId);
 coap_status_t object_discover(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t ** bufferP, size_t * lengthP);
 uint8_t object_checkReadable(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 uint8_t object_checkNumeric(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 bool object_isInstanceNew(lwm2m_context_t * contextP, uint16_t objectId, uint16_t instanceId);
-int prv_getRegisterPayload(lwm2m_context_t * contextP, uint8_t * buffer, size_t length);
+int object_getRegisterPayload(lwm2m_context_t * contextP, uint8_t * buffer, size_t length);
 int object_getServers(lwm2m_context_t * contextP);
 coap_status_t object_createInstance(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_data_t * dataP);
 coap_status_t object_writeInstance(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_data_t * dataP);

--- a/core/internals.h
+++ b/core/internals.h
@@ -213,12 +213,12 @@ void observe_remove(lwm2m_client_t * clientP, lwm2m_observation_t * observationP
 lwm2m_observed_t * observe_findByUri(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 
 // defined in registration.c
-coap_status_t handle_registration_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
+coap_status_t registration_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void registration_deregister(lwm2m_context_t * contextP, lwm2m_server_t * serverP);
-void prv_freeClient(lwm2m_client_t * clientP);
+void registration_freeClient(lwm2m_client_t * clientP);
 uint8_t registration_start(lwm2m_context_t * contextP);
 void registration_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
-lwm2m_status_t registration_get_status(lwm2m_context_t * contextP);
+lwm2m_status_t registration_getStatus(lwm2m_context_t * contextP);
 
 // defined in packet.c
 coap_status_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, void * sessionH);

--- a/core/internals.h
+++ b/core/internals.h
@@ -277,7 +277,7 @@ size_t utils_boolToPlainText(bool data, uint8_t ** bufferP);
 void utils_copyValue(void * dst, const void * src, size_t len);
 int utils_opaqueToInt(const uint8_t * buffer, size_t buffer_len, int64_t * dataP);
 int utils_opaqueToFloat(const uint8_t * buffer, size_t buffer_len, double * dataP);
-void utils_encodeInt(int64_t data, uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE], size_t * lengthP);
+size_t utils_encodeInt(int64_t data, uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE]);
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * utils_findServer(lwm2m_context_t * contextP, void * fromSessionH);
 lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP, void * fromSessionH);

--- a/core/internals.h
+++ b/core/internals.h
@@ -225,18 +225,12 @@ coap_status_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, 
 
 // defined in bootstrap.c
 void bootstrap_step(lwm2m_context_t * contextP, uint32_t currentTime, time_t* timeoutP);
-void delete_bootstrap_server_list(lwm2m_context_t * contextP);
-coap_status_t handle_bootstrap_command(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
-coap_status_t handle_delete_all(lwm2m_context_t * context, void * fromSessionH);
+coap_status_t bootstrap_handleCommand(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
+coap_status_t bootstrap_handleDeleteAll(lwm2m_context_t * context, void * fromSessionH);
+coap_status_t bootstrap_handleFinish(lwm2m_context_t * context, void * fromSessionH);
+uint8_t bootstrap_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void bootstrap_start(lwm2m_context_t * contextP);
-lwm2m_status_t bootstrap_get_status(lwm2m_context_t * contextP);
-coap_status_t handle_bootstrap_finish(lwm2m_context_t * context, void * fromSessionH);
-uint8_t handle_bootstrap_request(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
-
-// defined in liblwm2m.c
-void delete_transaction_list(lwm2m_context_t * context);
-void delete_server_list(lwm2m_context_t * context);
-void delete_observed_list(lwm2m_context_t * contextP);
+lwm2m_status_t bootstrap_getStatus(lwm2m_context_t * contextP);
 
 // defined in json.c
 #ifdef LWM2M_SUPPORT_JSON

--- a/core/internals.h
+++ b/core/internals.h
@@ -248,6 +248,10 @@ uint8_t bootstrap_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, 
 void bootstrap_start(lwm2m_context_t * contextP);
 lwm2m_status_t bootstrap_getStatus(lwm2m_context_t * contextP);
 
+// defined in tlv.c
+int tlv_parse(uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
+int tlv_serialize(int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
+
 // defined in json.c
 #ifdef LWM2M_SUPPORT_JSON
 int json_parse(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
@@ -271,19 +275,11 @@ size_t utils_int64ToPlainText(int64_t data, uint8_t ** bufferP);
 size_t utils_float64ToPlainText(double data, uint8_t ** bufferP);
 size_t utils_boolToPlainText(bool data, uint8_t ** bufferP);
 void utils_copyValue(void * dst, const void * src, size_t len);
-
-// defined in tlv.c
-int lwm2m_intToTLV(lwm2m_tlv_type_t type, int64_t data, uint16_t id, uint8_t * buffer, size_t buffer_len);
-int lwm2m_boolToTLV(lwm2m_tlv_type_t type, bool value, uint16_t id, uint8_t * buffer, size_t buffer_len);
-int lwm2m_opaqueToTLV(lwm2m_tlv_type_t type, uint8_t * dataP, size_t data_len, uint16_t id, uint8_t * buffer, size_t buffer_len);
-int lwm2m_opaqueToInt(const uint8_t * buffer, size_t buffer_len, int64_t * dataP);
-int lwm2m_opaqueToFloat(const uint8_t * buffer, size_t buffer_len, double * dataP);
-void prv_encodeInt(int64_t data, uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE], size_t * lengthP);
-int lwm2m_tlv_parse(uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
-int lwm2m_tlv_serialize(int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
-
+int utils_opaqueToInt(const uint8_t * buffer, size_t buffer_len, int64_t * dataP);
+int utils_opaqueToFloat(const uint8_t * buffer, size_t buffer_len, double * dataP);
+void utils_encodeInt(int64_t data, uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE], size_t * lengthP);
 #ifdef LWM2M_CLIENT_MODE
-lwm2m_server_t * prv_findServer(lwm2m_context_t * contextP, void * fromSessionH);
+lwm2m_server_t * utils_findServer(lwm2m_context_t * contextP, void * fromSessionH);
 lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP, void * fromSessionH);
 #endif
 

--- a/core/internals.h
+++ b/core/internals.h
@@ -253,21 +253,23 @@ lwm2m_status_t bootstrap_getStatus(lwm2m_context_t * contextP);
 int json_parse(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
 int json_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * tlvP, uint8_t ** bufferP);
 #endif
+
+// defined in discover.c
 int discover_serialize(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
 
 // defined in utils.c
-lwm2m_binding_t lwm2m_stringToBinding(uint8_t *buffer, size_t length);
-lwm2m_media_type_t prv_convertMediaType(coap_content_type_t type);
-int prv_isAltPathValid(const char * altPath);
+lwm2m_binding_t utils_stringToBinding(uint8_t *buffer, size_t length);
+lwm2m_media_type_t utils_convertMediaType(coap_content_type_t type);
+int utils_isAltPathValid(const char * altPath);
 int utils_stringCopy(char * buffer, size_t length, const char * str);
 int utils_intCopy(char * buffer, size_t length, int32_t value);
 size_t utils_intToText(int64_t data, uint8_t * string, size_t length);
 size_t utils_floatToText(double data, uint8_t * string, size_t length);
-int lwm2m_PlainTextToInt64(uint8_t * buffer, int length, int64_t * dataP);
-int lwm2m_PlainTextToFloat64(uint8_t * buffer, int length, double * dataP);
-size_t lwm2m_int64ToPlainText(int64_t data, uint8_t ** bufferP);
-size_t lwm2m_float64ToPlainText(double data, uint8_t ** bufferP);
-size_t lwm2m_boolToPlainText(bool data, uint8_t ** bufferP);
+int utils_plainTextToInt64(uint8_t * buffer, int length, int64_t * dataP);
+int utils_plainTextToFloat64(uint8_t * buffer, int length, double * dataP);
+size_t utils_int64ToPlainText(int64_t data, uint8_t ** bufferP);
+size_t utils_float64ToPlainText(double data, uint8_t ** bufferP);
+size_t utils_boolToPlainText(bool data, uint8_t ** bufferP);
 void utils_copyValue(void * dst, const void * src, size_t len);
 
 // defined in tlv.c

--- a/core/json.c
+++ b/core/json.c
@@ -452,7 +452,7 @@ static bool prv_convertValue(_record_t * recordP,
         {
             int64_t value;
 
-            if ( 1 != lwm2m_PlainTextToInt64(recordP->value,
+            if ( 1 != utils_plainTextToInt64(recordP->value,
                                              recordP->valueLen,
                                              &value))
             {
@@ -465,7 +465,7 @@ static bool prv_convertValue(_record_t * recordP,
         {
             double value;
 
-            if ( 1 != lwm2m_PlainTextToFloat64(recordP->value,
+            if ( 1 != utils_plainTextToFloat64(recordP->value,
                                                recordP->valueLen,
                                                &value))
             {

--- a/core/json.c
+++ b/core/json.c
@@ -1378,7 +1378,7 @@ static int prv_serializeAttributes(lwm2m_context_t * contextP,
 
     if (contextP == NULL) return 0;
 
-    observedP = observed_find(contextP, uriP);
+    observedP = observe_findByUri(contextP, uriP);
     if (observedP == NULL || observedP->watcherList == NULL) return 0;
 
     head = 0;

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -84,7 +84,7 @@ void lwm2m_deregister(lwm2m_context_t * context)
     }
 }
 
-static void delete_server(lwm2m_server_t * serverP)
+static void prv_deleteServer(lwm2m_server_t * serverP)
 {
     // TODO parse transaction and observation to remove the ones related to this server
     if (NULL != serverP->location)
@@ -94,14 +94,14 @@ static void delete_server(lwm2m_server_t * serverP)
     lwm2m_free(serverP);
 }
 
-void delete_server_list(lwm2m_context_t * context)
+static void prv_deleteServerList(lwm2m_context_t * context)
 {
     while (NULL != context->serverList)
     {
         lwm2m_server_t * server;
         server = context->serverList;
         context->serverList = server->next;
-        delete_server(server);
+        prv_deleteServer(server);
     }
 }
 
@@ -111,7 +111,7 @@ static void prv_deleteBootstrapServerList(lwm2m_context_t * contextP)
     contextP->bootstrapServerList = NULL;
 }
 
-void delete_observed_list(lwm2m_context_t * contextP)
+static void prv_deleteObservedList(lwm2m_context_t * contextP)
 {
     while (NULL != contextP->observedList)
     {
@@ -132,7 +132,7 @@ void delete_observed_list(lwm2m_context_t * contextP)
 }
 #endif
 
-void delete_transaction_list(lwm2m_context_t * context)
+void prv_deleteTransactionList(lwm2m_context_t * context)
 {
     while (NULL != context->transactionList)
     {
@@ -150,9 +150,9 @@ void lwm2m_close(lwm2m_context_t * contextP)
     int i;
 
     lwm2m_deregister(contextP);
-    delete_server_list(contextP);
+    prv_deleteServerList(contextP);
     prv_deleteBootstrapServerList(contextP);
-    delete_observed_list(contextP);
+    prv_deleteObservedList(contextP);
     lwm2m_free(contextP->objectList);
     lwm2m_free(contextP->endpointName);
     if (contextP->msisdn != NULL)
@@ -178,12 +178,12 @@ void lwm2m_close(lwm2m_context_t * contextP)
     }
 #endif
 
-    delete_transaction_list(contextP);
+    prv_deleteTransactionList(contextP);
     lwm2m_free(contextP);
 }
 
 #ifdef LWM2M_CLIENT_MODE
-static int refresh_server_list(lwm2m_context_t * contextP)
+static int prv_refreshServerList(lwm2m_context_t * contextP)
 {
     lwm2m_server_t * targetP;
     lwm2m_server_t * nextP;
@@ -202,7 +202,7 @@ static int refresh_server_list(lwm2m_context_t * contextP)
         }
         else
         {
-            delete_server(targetP);
+            prv_deleteServer(targetP);
         }
         targetP = nextP;
     }
@@ -219,7 +219,7 @@ static int refresh_server_list(lwm2m_context_t * contextP)
         }
         else
         {
-            delete_server(targetP);
+            prv_deleteServer(targetP);
         }
         targetP = nextP;
     }
@@ -392,7 +392,7 @@ next_step:
     switch (contextP->state)
     {
     case STATE_INITIAL:
-        if (0 != refresh_server_list(contextP)) return COAP_503_SERVICE_UNAVAILABLE;
+        if (0 != prv_refreshServerList(contextP)) return COAP_503_SERVICE_UNAVAILABLE;
         if (contextP->serverList != NULL)
         {
             contextP->state = STATE_REGISTER_REQUIRED;

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -105,7 +105,7 @@ void delete_server_list(lwm2m_context_t * context)
     }
 }
 
-void delete_bootstrap_server_list(lwm2m_context_t * contextP)
+static void prv_deleteBootstrapServerList(lwm2m_context_t * contextP)
 {
     LWM2M_LIST_FREE(contextP->bootstrapServerList);
     contextP->bootstrapServerList = NULL;
@@ -151,7 +151,7 @@ void lwm2m_close(lwm2m_context_t * contextP)
 
     lwm2m_deregister(contextP);
     delete_server_list(contextP);
-    delete_bootstrap_server_list(contextP);
+    prv_deleteBootstrapServerList(contextP);
     delete_observed_list(contextP);
     lwm2m_free(contextP->objectList);
     lwm2m_free(contextP->endpointName);
@@ -386,7 +386,7 @@ int lwm2m_step(lwm2m_context_t * contextP,
     if (tv_sec < 0) return COAP_500_INTERNAL_SERVER_ERROR;
 
 #ifdef LWM2M_CLIENT_MODE
-    // state can also be modified in handle_bootstrap_command().
+    // state can also be modified in bootstrap_handleCommand().
 
 next_step:
     switch (contextP->state)
@@ -422,7 +422,7 @@ next_step:
 
 #ifdef LWM2M_BOOTSTRAP
     case STATE_BOOTSTRAPPING:
-        switch (bootstrap_get_status(contextP))
+        switch (bootstrap_getStatus(contextP))
         {
         case STATE_BS_FINISHED:
             contextP->state = STATE_INITIAL;

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -174,7 +174,7 @@ void lwm2m_close(lwm2m_context_t * contextP)
         clientP = contextP->clientList;
         contextP->clientList = contextP->clientList->next;
 
-        prv_freeClient(clientP);
+        registration_freeClient(clientP);
     }
 #endif
 
@@ -447,7 +447,7 @@ next_step:
 
     case STATE_REGISTERING:
     {
-        switch (registration_get_status(contextP))
+        switch (registration_getStatus(contextP))
         {
         case STATE_REGISTERED:
             contextP->state = STATE_READY;

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -253,7 +253,7 @@ int lwm2m_configure(lwm2m_context_t * contextP,
     if (found != 0x07) return COAP_400_BAD_REQUEST;
     if (altPath != NULL)
     {
-        if (0 == prv_isAltPathValid(altPath))
+        if (0 == utils_isAltPathValid(altPath))
         {
             return COAP_400_BAD_REQUEST;
         }

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -473,7 +473,7 @@ next_step:
         break;
     }
 
-    observation_step(contextP, tv_sec, timeoutP);
+    observe_step(contextP, tv_sec, timeoutP);
 #endif
 
     registration_step(contextP, tv_sec, timeoutP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -256,25 +256,6 @@ typedef struct
 int lwm2m_stringToUri(const char * buffer, size_t buffer_len, lwm2m_uri_t * uriP);
 
 /*
- *  Resource values
- */
-
-// defined in utils.c
-int lwm2m_PlainTextToInt64(uint8_t * buffer, int length, int64_t * dataP);
-int lwm2m_PlainTextToFloat64(uint8_t * buffer, int length, double * dataP);
-
-/*
- * These utility functions allocate a new buffer storing the plain text
- * representation of data. They return the size in bytes of the buffer
- * or 0 in case of error.
- * There is no trailing '\0' character in the buffer.
- */
-size_t lwm2m_int64ToPlainText(int64_t data, uint8_t ** bufferP);
-size_t lwm2m_float64ToPlainText(double data, uint8_t ** bufferP);
-size_t lwm2m_boolToPlainText(bool data, uint8_t ** bufferP);
-
-
-/*
  * TLV
  */
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -139,6 +139,7 @@ bool lwm2m_session_is_equal(void * session1, void * session2, void * userData);
 #define COAP_205_CONTENT                (uint8_t)0x45
 #define COAP_400_BAD_REQUEST            (uint8_t)0x80
 #define COAP_401_UNAUTHORIZED           (uint8_t)0x81
+#define COAP_402_BAD_OPTION             (uint8_t)0x82
 #define COAP_404_NOT_FOUND              (uint8_t)0x84
 #define COAP_405_METHOD_NOT_ALLOWED     (uint8_t)0x85
 #define COAP_406_NOT_ACCEPTABLE         (uint8_t)0x86
@@ -661,8 +662,8 @@ void lwm2m_resource_value_changed(lwm2m_context_t * contextP, lwm2m_uri_t * uriP
 
 #ifdef LWM2M_SERVER_MODE
 // Clients registration/deregistration monitoring API.
-// When a LWM2M client registers, the callback is called with status CREATED_2_01.
-// When a LWM2M client deregisters, the callback is called with status DELETED_2_02.
+// When a LWM2M client registers, the callback is called with status COAP_201_CREATED.
+// When a LWM2M client deregisters, the callback is called with status COAP_202_DELETED.
 // clientID is the internal ID of the LWM2M Client.
 // The callback's parameters uri, data, dataLength are always NULL.
 // The lwm2m_client_t is present in the lwm2m_context_t's clientList when the callback is called. On a deregistration, it deleted when the callback returns.

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -225,7 +225,7 @@ void lwm2m_list_free(lwm2m_list_t * head);
  * URI
  *
  * objectId is always set
- * if instanceId or resourceId is greater than LWM2M_URI_MAX_ID, it means it is not specified
+ * instanceId or resourceId are set according to the flag bit-field
  *
  */
 
@@ -256,10 +256,8 @@ typedef struct
 int lwm2m_stringToUri(const char * buffer, size_t buffer_len, lwm2m_uri_t * uriP);
 
 /*
- * TLV
+ * The lwm2m_data_t is used to store LWM2M resource values in a hierarchical way.
  */
-
-#define LWM2M_TLV_HEADER_MAX_LENGTH 6
 
 /*
  * Bitmask for the lwm2m_data_t::flag
@@ -331,6 +329,7 @@ void lwm2m_data_encode_bool(bool value, lwm2m_data_t * dataP);
 int lwm2m_data_decode_bool(const lwm2m_data_t * dataP, bool * valueP);
 void lwm2m_data_include(lwm2m_data_t * subDataP, size_t count, lwm2m_data_t * dataP);
 
+
 /*
  * Utility function to parse TLV buffers directly
  *
@@ -342,7 +341,10 @@ void lwm2m_data_include(lwm2m_data_t * subDataP, size_t count, lwm2m_data_t * da
  * oDataIndex: (OUT) index of the data of the parsed TLV record in the buffer
  * oDataLen: (OUT) length of the data of the parsed TLV record
  */
-int lwm2m_decodeTLV(const uint8_t * buffer, size_t buffer_len, lwm2m_tlv_type_t * oType, uint16_t * oID, size_t * oDataIndex, size_t * oDataLen);
+
+#define LWM2M_TLV_HEADER_MAX_LENGTH 6
+
+int lwm2m_decode_TLV(const uint8_t * buffer, size_t buffer_len, lwm2m_tlv_type_t * oType, uint16_t * oID, size_t * oDataIndex, size_t * oDataLen);
 
 
 /*

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -63,8 +63,9 @@ extern "C" {
 #include <time.h>
 
 #ifdef LWM2M_SERVER_MODE
-#undef LWM2M_SUPPORT_JSON
+#ifndef LWM2M_SUPPORT_JSON
 #define LWM2M_SUPPORT_JSON
+#endif
 #endif
 
 #if defined(LWM2M_BOOTSTRAP) && defined(LWM2M_BOOTSTRAP_SERVER_MODE)
@@ -349,18 +350,19 @@ void lwm2m_data_encode_bool(bool value, lwm2m_data_t * dataP);
 int lwm2m_data_decode_bool(const lwm2m_data_t * dataP, bool * valueP);
 void lwm2m_data_include(lwm2m_data_t * subDataP, size_t count, lwm2m_data_t * dataP);
 
-
 /*
- * These utility functions fill the buffer with a TLV record containing
- * the data. They return the size in bytes of the TLV record, 0 in case
- * of error.
+ * Utility function to parse TLV buffers directly
+ *
+ * Returned value: number of bytes parsed
+ * buffer: buffer to parse
+ * buffer_len: length in bytes of buffer
+ * oType: (OUT) type of the parsed TLV record
+ * oID: (OUT) ID of the parsed TLV record
+ * oDataIndex: (OUT) index of the data of the parsed TLV record in the buffer
+ * oDataLen: (OUT) length of the data of the parsed TLV record
  */
-int lwm2m_intToTLV(lwm2m_tlv_type_t type, int64_t data, uint16_t id, uint8_t * buffer, size_t buffer_len);
-int lwm2m_boolToTLV(lwm2m_tlv_type_t type, bool value, uint16_t id, uint8_t * buffer, size_t buffer_len);
-int lwm2m_opaqueToTLV(lwm2m_tlv_type_t type, uint8_t * dataP, size_t data_len, uint16_t id, uint8_t * buffer, size_t buffer_len);
 int lwm2m_decodeTLV(const uint8_t * buffer, size_t buffer_len, lwm2m_tlv_type_t * oType, uint16_t * oID, size_t * oDataIndex, size_t * oDataLen);
-int lwm2m_opaqueToInt(const uint8_t * buffer, size_t buffer_len, int64_t * dataP);
-int lwm2m_opaqueToFloat(const uint8_t * buffer, size_t buffer_len, double * dataP);
+
 
 /*
  * LWM2M Objects

--- a/core/management.c
+++ b/core/management.c
@@ -68,7 +68,7 @@ static int prv_readAttributes(multi_option_t * query,
             if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_MIN_PERIOD)) return -1;
             if (query->len == ATTR_MIN_PERIOD_LEN) return -1;
 
-            if (1 != lwm2m_PlainTextToInt64(query->data + ATTR_MIN_PERIOD_LEN, query->len - ATTR_MIN_PERIOD_LEN, &intValue)) return -1;
+            if (1 != utils_plainTextToInt64(query->data + ATTR_MIN_PERIOD_LEN, query->len - ATTR_MIN_PERIOD_LEN, &intValue)) return -1;
             if (intValue < 0) return -1;
 
             attrP->toSet |= LWM2M_ATTR_FLAG_MIN_PERIOD;
@@ -86,7 +86,7 @@ static int prv_readAttributes(multi_option_t * query,
             if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_MAX_PERIOD)) return -1;
             if (query->len == ATTR_MAX_PERIOD_LEN) return -1;
 
-            if (1 != lwm2m_PlainTextToInt64(query->data + ATTR_MAX_PERIOD_LEN, query->len - ATTR_MAX_PERIOD_LEN, &intValue)) return -1;
+            if (1 != utils_plainTextToInt64(query->data + ATTR_MAX_PERIOD_LEN, query->len - ATTR_MAX_PERIOD_LEN, &intValue)) return -1;
             if (intValue < 0) return -1;
 
             attrP->toSet |= LWM2M_ATTR_FLAG_MAX_PERIOD;
@@ -104,7 +104,7 @@ static int prv_readAttributes(multi_option_t * query,
             if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_GREATER_THAN)) return -1;
             if (query->len == ATTR_GREATER_THAN_LEN) return -1;
 
-            if (1 != lwm2m_PlainTextToFloat64(query->data + ATTR_GREATER_THAN_LEN, query->len - ATTR_GREATER_THAN_LEN, &floatValue)) return -1;
+            if (1 != utils_plainTextToFloat64(query->data + ATTR_GREATER_THAN_LEN, query->len - ATTR_GREATER_THAN_LEN, &floatValue)) return -1;
 
             attrP->toSet |= LWM2M_ATTR_FLAG_GREATER_THAN;
             attrP->greaterThan = floatValue;
@@ -121,7 +121,7 @@ static int prv_readAttributes(multi_option_t * query,
             if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_LESS_THAN)) return -1;
             if (query->len == ATTR_LESS_THAN_LEN) return -1;
 
-            if (1 != lwm2m_PlainTextToFloat64(query->data + ATTR_LESS_THAN_LEN, query->len - ATTR_LESS_THAN_LEN, &floatValue)) return -1;
+            if (1 != utils_plainTextToFloat64(query->data + ATTR_LESS_THAN_LEN, query->len - ATTR_LESS_THAN_LEN, &floatValue)) return -1;
 
             attrP->toSet |= LWM2M_ATTR_FLAG_LESS_THAN;
             attrP->lessThan = floatValue;
@@ -138,7 +138,7 @@ static int prv_readAttributes(multi_option_t * query,
             if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_STEP)) return -1;
             if (query->len == ATTR_STEP_LEN) return -1;
 
-            if (1 != lwm2m_PlainTextToFloat64(query->data + ATTR_STEP_LEN, query->len - ATTR_STEP_LEN, &floatValue)) return -1;
+            if (1 != utils_plainTextToFloat64(query->data + ATTR_STEP_LEN, query->len - ATTR_STEP_LEN, &floatValue)) return -1;
             if (floatValue < 0) return -1;
 
             attrP->toSet |= LWM2M_ATTR_FLAG_STEP;
@@ -168,7 +168,7 @@ coap_status_t dm_handleRequest(lwm2m_context_t * contextP,
     coap_status_t result;
     lwm2m_media_type_t format;
 
-    format = prv_convertMediaType(message->content_type);
+    format = utils_convertMediaType(message->content_type);
 
     if (uriP->objectId == LWM2M_SECURITY_OBJECT_ID)
     {
@@ -375,7 +375,7 @@ static void prv_resultCallback(lwm2m_transaction_t * transacP,
         dataP->callback(((lwm2m_client_t*)transacP->peerP)->internalID,
                         &dataP->uri,
                         packet->code,
-                        prv_convertMediaType(packet->content_type),
+                        utils_convertMediaType(packet->content_type),
                         packet->payload,
                         packet->payload_len,
                         dataP->userData);

--- a/core/management.c
+++ b/core/management.c
@@ -195,7 +195,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
                 lwm2m_data_t * dataP = NULL;
                 int size = 0;
 
-                result = object_data_read(contextP, uriP, &size, &dataP);
+                result = object_readData(contextP, uriP, &size, &dataP);
                 if (COAP_205_CONTENT == result)
                 {
                     result = handle_observe_request(contextP, uriP, serverP, size, dataP, message, response);

--- a/core/management.c
+++ b/core/management.c
@@ -401,7 +401,7 @@ static int prv_makeOperation(lwm2m_context_t * contextP,
     if (clientP == NULL) return COAP_404_NOT_FOUND;
 
     transaction = transaction_new(COAP_TYPE_CON, method, clientP->altPath, uriP, contextP->nextMID++, 4, NULL, ENDPOINT_CLIENT, (void *)clientP);
-    if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
+    if (transaction == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
     if (buffer != NULL)
     {
@@ -686,7 +686,7 @@ int lwm2m_dm_discover(lwm2m_context_t * contextP,
     if (clientP == NULL) return COAP_404_NOT_FOUND;
 
     transaction = transaction_new(COAP_TYPE_CON, COAP_GET, clientP->altPath, uriP, contextP->nextMID++, 4, NULL, ENDPOINT_CLIENT, (void *)clientP);
-    if (transaction == NULL) return INTERNAL_SERVER_ERROR_5_00;
+    if (transaction == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
     coap_set_header_accept(transaction->message, LWM2M_CONTENT_LINK);
 

--- a/core/management.c
+++ b/core/management.c
@@ -198,7 +198,7 @@ coap_status_t dm_handleRequest(lwm2m_context_t * contextP,
                 result = object_readData(contextP, uriP, &size, &dataP);
                 if (COAP_205_CONTENT == result)
                 {
-                    result = handle_observe_request(contextP, uriP, serverP, size, dataP, message, response);
+                    result = observe_handleRequest(contextP, uriP, serverP, size, dataP, message, response);
                     if (COAP_205_CONTENT == result)
                     {
                         length = lwm2m_data_serialize(uriP, size, dataP, &format, &buffer);
@@ -285,7 +285,7 @@ coap_status_t dm_handleRequest(lwm2m_context_t * contextP,
                 }
                 else
                 {
-                    result = observe_set_parameters(contextP, uriP, serverP, &attr);
+                    result = observe_setParameters(contextP, uriP, serverP, &attr);
                 }
             }
             else if (LWM2M_URI_IS_SET_INSTANCE(uriP))

--- a/core/management.c
+++ b/core/management.c
@@ -159,7 +159,7 @@ static int prv_readAttributes(multi_option_t * query,
     return 0;
 }
 
-coap_status_t handle_dm_request(lwm2m_context_t * contextP,
+coap_status_t dm_handleRequest(lwm2m_context_t * contextP,
                                 lwm2m_uri_t * uriP,
                                 lwm2m_server_t * serverP,
                                 coap_packet_t * message,
@@ -326,7 +326,7 @@ coap_status_t handle_dm_request(lwm2m_context_t * contextP,
 
 #define ID_AS_STRING_MAX_LEN 8
 
-static void dm_result_callback(lwm2m_transaction_t * transacP,
+static void prv_resultCallback(lwm2m_transaction_t * transacP,
                                void * message)
 {
     dm_data_t * dataP = (dm_data_t *)transacP->userData;
@@ -354,14 +354,14 @@ static void dm_result_callback(lwm2m_transaction_t * transacP,
             locationString = coap_get_multi_option_as_string(packet->location_path);
             if (locationString == NULL)
             {
-                LOG("Error: coap_get_multi_option_as_string() failed for Location_path option in dm_result_callback()\n");
+                LOG("Error: coap_get_multi_option_as_string() failed for Location_path option in prv_resultCallback()\n");
                 return;
             }
 
             result = lwm2m_stringToUri(locationString, strlen(locationString), &locationUri);
             if (result == 0)
             {
-                LOG("Error: lwm2m_stringToUri() failed for Location_path option in dm_result_callback()\n");
+                LOG("Error: lwm2m_stringToUri() failed for Location_path option in prv_resultCallback()\n");
                 lwm2m_free(locationString);
                 return;
             }
@@ -383,15 +383,15 @@ static void dm_result_callback(lwm2m_transaction_t * transacP,
     lwm2m_free(dataP);
 }
 
-static int prv_make_operation(lwm2m_context_t * contextP,
-                              uint16_t clientID,
-                              lwm2m_uri_t * uriP,
-                              coap_method_t method,
-                              lwm2m_media_type_t format,
-                              uint8_t * buffer,
-                              int length,
-                              lwm2m_result_callback_t callback,
-                              void * userData)
+static int prv_makeOperation(lwm2m_context_t * contextP,
+                             uint16_t clientID,
+                             lwm2m_uri_t * uriP,
+                             coap_method_t method,
+                             lwm2m_media_type_t format,
+                             uint8_t * buffer,
+                             int length,
+                             lwm2m_result_callback_t callback,
+                             void * userData)
 {
     lwm2m_client_t * clientP;
     lwm2m_transaction_t * transaction;
@@ -422,7 +422,7 @@ static int prv_make_operation(lwm2m_context_t * contextP,
         dataP->callback = callback;
         dataP->userData = userData;
 
-        transaction->callback = dm_result_callback;
+        transaction->callback = prv_resultCallback;
         transaction->userData = (void *)dataP;
     }
 
@@ -437,7 +437,7 @@ int lwm2m_dm_read(lwm2m_context_t * contextP,
                   lwm2m_result_callback_t callback,
                   void * userData)
 {
-    return prv_make_operation(contextP, clientID, uriP,
+    return prv_makeOperation(contextP, clientID, uriP,
                               COAP_GET,
                               LWM2M_CONTENT_TEXT,
                               NULL, 0,
@@ -461,14 +461,14 @@ int lwm2m_dm_write(lwm2m_context_t * contextP,
 
     if (LWM2M_URI_IS_SET_RESOURCE(uriP))
     {
-        return prv_make_operation(contextP, clientID, uriP,
+        return prv_makeOperation(contextP, clientID, uriP,
                                   COAP_PUT,
                                   format, buffer, length,
                                   callback, userData);
     }
     else
     {
-        return prv_make_operation(contextP, clientID, uriP,
+        return prv_makeOperation(contextP, clientID, uriP,
                                   COAP_POST,
                                   format, buffer, length,
                                   callback, userData);
@@ -489,7 +489,7 @@ int lwm2m_dm_execute(lwm2m_context_t * contextP,
         return COAP_400_BAD_REQUEST;
     }
 
-    return prv_make_operation(contextP, clientID, uriP,
+    return prv_makeOperation(contextP, clientID, uriP,
                               COAP_POST,
                               format, buffer, length,
                               callback, userData);
@@ -510,7 +510,7 @@ int lwm2m_dm_create(lwm2m_context_t * contextP,
         return COAP_400_BAD_REQUEST;
     }
 
-    return prv_make_operation(contextP, clientID, uriP,
+    return prv_makeOperation(contextP, clientID, uriP,
                               COAP_POST,
                               format, buffer, length,
                               callback, userData);
@@ -528,7 +528,7 @@ int lwm2m_dm_delete(lwm2m_context_t * contextP,
         return COAP_400_BAD_REQUEST;
     }
 
-    return prv_make_operation(contextP, clientID, uriP,
+    return prv_makeOperation(contextP, clientID, uriP,
                               COAP_DELETE,
                               LWM2M_CONTENT_TEXT, NULL, 0,
                               callback, userData);
@@ -575,7 +575,7 @@ int lwm2m_dm_write_attributes(lwm2m_context_t * contextP,
         dataP->callback = callback;
         dataP->userData = userData;
 
-        transaction->callback = dm_result_callback;
+        transaction->callback = prv_resultCallback;
         transaction->userData = (void *)dataP;
     }
 
@@ -702,7 +702,7 @@ int lwm2m_dm_discover(lwm2m_context_t * contextP,
         dataP->callback = callback;
         dataP->userData = userData;
 
-        transaction->callback = dm_result_callback;
+        transaction->callback = prv_resultCallback;
         transaction->userData = (void *)dataP;
     }
 

--- a/core/objects.c
+++ b/core/objects.c
@@ -59,8 +59,8 @@
 #include <stdio.h>
 
 
-static lwm2m_object_t * prv_find_object(lwm2m_context_t * contextP,
-                                        uint16_t Id)
+static lwm2m_object_t * prv_findObject(lwm2m_context_t * contextP,
+                                       uint16_t Id)
 {
     int i;
 
@@ -83,7 +83,7 @@ uint8_t object_checkReadable(lwm2m_context_t * contextP,
     lwm2m_data_t * dataP = NULL;
     int size;
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
     if (NULL == targetP->readFunc) return COAP_405_METHOD_NOT_ALLOWED;
 
@@ -116,7 +116,7 @@ uint8_t object_checkNumeric(lwm2m_context_t * contextP,
 
     if (!LWM2M_URI_IS_SET_RESOURCE(uriP)) return COAP_405_METHOD_NOT_ALLOWED;
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
     if (NULL == targetP->readFunc) return COAP_405_METHOD_NOT_ALLOWED;
 
@@ -153,7 +153,7 @@ coap_status_t object_readData(lwm2m_context_t * contextP,
     coap_status_t result;
     lwm2m_object_t * targetP;
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
     if (NULL == targetP->readFunc) return COAP_405_METHOD_NOT_ALLOWED;
     if (targetP->instanceList == NULL) return COAP_404_NOT_FOUND;
@@ -259,7 +259,7 @@ coap_status_t object_write(lwm2m_context_t * contextP,
     lwm2m_data_t * dataP = NULL;
     int size = 0;
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP)
     {
         result = NOT_FOUND_4_04;
@@ -309,7 +309,7 @@ coap_status_t object_execute(lwm2m_context_t * contextP,
 {
     lwm2m_object_t * targetP;
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP) return NOT_FOUND_4_04;
     if (NULL == targetP->executeFunc) return METHOD_NOT_ALLOWED_4_05;
 
@@ -332,7 +332,7 @@ coap_status_t object_create(lwm2m_context_t * contextP,
         return BAD_REQUEST_4_00;
     }
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP) return NOT_FOUND_4_04;
     if (NULL == targetP->createFunc) return METHOD_NOT_ALLOWED_4_05;
 
@@ -364,7 +364,7 @@ coap_status_t object_delete(lwm2m_context_t * contextP,
     lwm2m_object_t * objectP;
     coap_status_t result;
 
-    objectP = prv_find_object(contextP, uriP->objectId);
+    objectP = prv_findObject(contextP, uriP->objectId);
     if (NULL == objectP) return NOT_FOUND_4_04;
     if (NULL == objectP->deleteFunc) return METHOD_NOT_ALLOWED_4_05;
 
@@ -401,7 +401,7 @@ coap_status_t object_discover(lwm2m_context_t * contextP,
     lwm2m_data_t * dataP = NULL;
     int size = 0;
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
     if (NULL == targetP->discoverFunc) return COAP_501_NOT_IMPLEMENTED;
     if (targetP->instanceList == NULL) return COAP_404_NOT_FOUND;
@@ -471,7 +471,7 @@ bool object_isInstanceNew(lwm2m_context_t * contextP,
 {
     lwm2m_object_t * targetP;
 
-    targetP = prv_find_object(contextP, objectId);
+    targetP = prv_findObject(contextP, objectId);
     if (targetP != NULL)
     {
         if (NULL != lwm2m_list_find(targetP->instanceList, instanceId))
@@ -790,7 +790,7 @@ coap_status_t object_createInstance(lwm2m_context_t * contextP,
     lwm2m_object_t * targetP;
     coap_status_t result;
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP) return NOT_FOUND_4_04;
 
     if (NULL == targetP->createFunc) 
@@ -808,7 +808,7 @@ coap_status_t object_writeInstance(lwm2m_context_t * contextP,
     lwm2m_object_t * targetP;
     coap_status_t result;
 
-    targetP = prv_find_object(contextP, uriP->objectId);
+    targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP) return NOT_FOUND_4_04;
 
     if (NULL == targetP->writeFunc) 

--- a/core/objects.c
+++ b/core/objects.c
@@ -145,7 +145,7 @@ uint8_t object_checkNumeric(lwm2m_context_t * contextP,
     return result;
 }
 
-coap_status_t object_data_read(lwm2m_context_t * contextP,
+coap_status_t object_readData(lwm2m_context_t * contextP,
                                lwm2m_uri_t * uriP,
                                int * sizeP,
                                lwm2m_data_t ** dataP)
@@ -218,7 +218,7 @@ coap_status_t object_read(lwm2m_context_t * contextP,
     lwm2m_data_t * dataP = NULL;
     int size = 0;
 
-    result = object_data_read(contextP, uriP, &size, &dataP);
+    result = object_readData(contextP, uriP, &size, &dataP);
 
     if (result == COAP_205_CONTENT)
     {
@@ -391,42 +391,6 @@ coap_status_t object_delete(lwm2m_context_t * contextP,
     return result;
 }
 
-/*
- * Delete all instances of an object except for the one with instanceId
- */
-coap_status_t object_delete_others(lwm2m_context_t * contextP,
-                                   uint16_t objectId,
-                                   uint16_t instanceId)
-{
-    lwm2m_object_t * objectP;
-    lwm2m_list_t * instanceP;
-    coap_status_t result;
-
-    objectP = prv_find_object(contextP, objectId);
-    if (NULL == objectP) return NOT_FOUND_4_04;
-    if (NULL == objectP->deleteFunc) return METHOD_NOT_ALLOWED_4_05;
-
-    LOG("    Call to object_delete_others\r\n");
-
-    result = COAP_202_DELETED;
-    instanceP = objectP->instanceList;
-    while (NULL != instanceP
-        && result == COAP_202_DELETED)
-    {
-        if (instanceP->id == instanceId)
-        {
-            instanceP = instanceP->next;
-        }
-        else
-        {
-            result = objectP->deleteFunc(instanceP->id, objectP);
-            instanceP = objectP->instanceList;
-        }
-    }
-
-    return result;
-}
-
 coap_status_t object_discover(lwm2m_context_t * contextP,
                               lwm2m_uri_t * uriP,
                               uint8_t ** bufferP,
@@ -543,7 +507,7 @@ static int prv_getObjectTemplate(uint8_t * buffer,
     return index;
 }
 
-int prv_getRegisterPayload(lwm2m_context_t * contextP,
+int object_getRegisterPayload(lwm2m_context_t * contextP,
                            uint8_t * buffer,
                            size_t bufferLen)
 {

--- a/core/objects.c
+++ b/core/objects.c
@@ -262,11 +262,11 @@ coap_status_t object_write(lwm2m_context_t * contextP,
     targetP = prv_findObject(contextP, uriP->objectId);
     if (NULL == targetP)
     {
-        result = NOT_FOUND_4_04;
+        result = COAP_404_NOT_FOUND;
     }
     else if (NULL == targetP->writeFunc)
     {
-        result = METHOD_NOT_ALLOWED_4_05;
+        result = COAP_405_METHOD_NOT_ALLOWED;
     }
     else
     {
@@ -310,8 +310,8 @@ coap_status_t object_execute(lwm2m_context_t * contextP,
     lwm2m_object_t * targetP;
 
     targetP = prv_findObject(contextP, uriP->objectId);
-    if (NULL == targetP) return NOT_FOUND_4_04;
-    if (NULL == targetP->executeFunc) return METHOD_NOT_ALLOWED_4_05;
+    if (NULL == targetP) return COAP_404_NOT_FOUND;
+    if (NULL == targetP->executeFunc) return COAP_405_METHOD_NOT_ALLOWED;
 
     return targetP->executeFunc(uriP->instanceId, uriP->resourceId, buffer, length, targetP);
 }
@@ -329,12 +329,12 @@ coap_status_t object_create(lwm2m_context_t * contextP,
 
     if (length == 0 || buffer == 0)
     {
-        return BAD_REQUEST_4_00;
+        return COAP_400_BAD_REQUEST;
     }
 
     targetP = prv_findObject(contextP, uriP->objectId);
-    if (NULL == targetP) return NOT_FOUND_4_04;
-    if (NULL == targetP->createFunc) return METHOD_NOT_ALLOWED_4_05;
+    if (NULL == targetP) return COAP_404_NOT_FOUND;
+    if (NULL == targetP->createFunc) return COAP_405_METHOD_NOT_ALLOWED;
 
     if (LWM2M_URI_IS_SET_INSTANCE(uriP))
     {
@@ -365,8 +365,8 @@ coap_status_t object_delete(lwm2m_context_t * contextP,
     coap_status_t result;
 
     objectP = prv_findObject(contextP, uriP->objectId);
-    if (NULL == objectP) return NOT_FOUND_4_04;
-    if (NULL == objectP->deleteFunc) return METHOD_NOT_ALLOWED_4_05;
+    if (NULL == objectP) return COAP_404_NOT_FOUND;
+    if (NULL == objectP->deleteFunc) return COAP_405_METHOD_NOT_ALLOWED;
 
     LOG("    Call to object_delete\r\n");
 
@@ -791,11 +791,11 @@ coap_status_t object_createInstance(lwm2m_context_t * contextP,
     coap_status_t result;
 
     targetP = prv_findObject(contextP, uriP->objectId);
-    if (NULL == targetP) return NOT_FOUND_4_04;
+    if (NULL == targetP) return COAP_404_NOT_FOUND;
 
     if (NULL == targetP->createFunc) 
     {
-        return METHOD_NOT_ALLOWED_4_05;
+        return COAP_405_METHOD_NOT_ALLOWED;
     }
 
     result = targetP->createFunc(lwm2m_list_newId(targetP->instanceList), dataP->length, (lwm2m_data_t *)(dataP->value), targetP);
@@ -809,11 +809,11 @@ coap_status_t object_writeInstance(lwm2m_context_t * contextP,
     coap_status_t result;
 
     targetP = prv_findObject(contextP, uriP->objectId);
-    if (NULL == targetP) return NOT_FOUND_4_04;
+    if (NULL == targetP) return COAP_404_NOT_FOUND;
 
     if (NULL == targetP->writeFunc) 
     {
-        return METHOD_NOT_ALLOWED_4_05;
+        return COAP_405_METHOD_NOT_ALLOWED;
     }
 
     result = targetP->writeFunc(dataP->id, dataP->length, (lwm2m_data_t *)(dataP->value), targetP);

--- a/core/objects.c
+++ b/core/objects.c
@@ -456,7 +456,7 @@ coap_status_t object_discover(lwm2m_context_t * contextP,
     {
         int len;
 
-        len = prv_serializeLink(contextP, uriP, size, dataP, bufferP);
+        len = discover_serialize(contextP, uriP, size, dataP, bufferP);
         if (len <= 0) result = COAP_500_INTERNAL_SERVER_ERROR;
         else *lengthP = len;
     }

--- a/core/objects.c
+++ b/core/objects.c
@@ -657,7 +657,7 @@ static int prv_getMandatoryInfo(lwm2m_object_t * objectP,
     }
     targetP->lifetime = value;
 
-    targetP->binding = lwm2m_stringToBinding(dataP[1].value, dataP[1].length);
+    targetP->binding = utils_stringToBinding(dataP[1].value, dataP[1].length);
 
     lwm2m_data_free(size, dataP);
 

--- a/core/observe.c
+++ b/core/observe.c
@@ -153,18 +153,18 @@ static lwm2m_watcher_t * prv_getWatcher(lwm2m_context_t * contextP,
     return watcherP;
 }
 
-coap_status_t handle_observe_request(lwm2m_context_t * contextP,
-                                     lwm2m_uri_t * uriP,
-                                     lwm2m_server_t * serverP,
-                                     int size,
-                                     lwm2m_data_t * dataP,
-                                     coap_packet_t * message,
-                                     coap_packet_t * response)
+coap_status_t observe_handleRequest(lwm2m_context_t * contextP,
+                                    lwm2m_uri_t * uriP,
+                                    lwm2m_server_t * serverP,
+                                    int size,
+                                    lwm2m_data_t * dataP,
+                                    coap_packet_t * message,
+                                    coap_packet_t * response)
 {
     lwm2m_watcher_t * watcherP;
     uint32_t count;
 
-    LOG("handle_observe_request()\r\n");
+    LOG("observe_handleRequest()\r\n");
 
     coap_get_header_observe(message, &count);
 
@@ -203,7 +203,7 @@ coap_status_t handle_observe_request(lwm2m_context_t * contextP,
 
     case 1:
         // cancellation
-        cancel_observe(contextP, LWM2M_MAX_ID, serverP->sessionH);
+        observe_cancel(contextP, LWM2M_MAX_ID, serverP->sessionH);
         return COAP_205_CONTENT;
 
     default:
@@ -211,13 +211,13 @@ coap_status_t handle_observe_request(lwm2m_context_t * contextP,
     }
 }
 
-void cancel_observe(lwm2m_context_t * contextP,
+void observe_cancel(lwm2m_context_t * contextP,
                     uint16_t mid,
                     void * fromSessionH)
 {
     lwm2m_observed_t * observedP;
 
-    LOG("cancel_observe()\r\n");
+    LOG("observe_cancel()\r\n");
 
     for (observedP = contextP->observedList;
          observedP != NULL;
@@ -261,15 +261,15 @@ void cancel_observe(lwm2m_context_t * contextP,
     }
 }
 
-coap_status_t observe_set_parameters(lwm2m_context_t * contextP,
-                                     lwm2m_uri_t * uriP,
-                                     lwm2m_server_t * serverP,
-                                     lwm2m_attributes_t * attrP)
+coap_status_t observe_setParameters(lwm2m_context_t * contextP,
+                                    lwm2m_uri_t * uriP,
+                                    lwm2m_server_t * serverP,
+                                    lwm2m_attributes_t * attrP)
 {
     uint8_t result;
     lwm2m_watcher_t * watcherP;
 
-    LOG("observe_set_parameters()\r\n");
+    LOG("observe_setParameters()\r\n");
 
     if (!LWM2M_URI_IS_SET_INSTANCE(uriP) && LWM2M_URI_IS_SET_RESOURCE(uriP)) return COAP_400_BAD_REQUEST;
 
@@ -357,8 +357,8 @@ coap_status_t observe_set_parameters(lwm2m_context_t * contextP,
     return COAP_204_CHANGED;
 }
 
-lwm2m_observed_t * observed_find(lwm2m_context_t * contextP,
-                                 lwm2m_uri_t * uriP)
+lwm2m_observed_t * observe_findByUri(lwm2m_context_t * contextP,
+                                     lwm2m_uri_t * uriP)
 {
     lwm2m_observed_t * targetP;
 
@@ -414,9 +414,9 @@ void lwm2m_resource_value_changed(lwm2m_context_t * contextP,
     }
 }
 
-void observation_step(lwm2m_context_t * contextP,
-                      time_t currentTime,
-                      time_t * timeoutP)
+void observe_step(lwm2m_context_t * contextP,
+                  time_t currentTime,
+                  time_t * timeoutP)
 {
     lwm2m_observed_t * targetP;
 
@@ -679,7 +679,7 @@ static lwm2m_observation_t * prv_findObservationByURI(lwm2m_client_t * clientP,
     return targetP;
 }
 
-void observation_remove(lwm2m_client_t * clientP,
+void observe_remove(lwm2m_client_t * clientP,
                         lwm2m_observation_t * observationP)
 {
     clientP->observationList = (lwm2m_observation_t *) LWM2M_LIST_RM(clientP->observationList, observationP->id, NULL);
@@ -697,7 +697,7 @@ static void prv_obsRequestCallback(lwm2m_transaction_t * transacP,
     {
     case STATE_DEREG_PENDING:
         // Observation was canceled by the user.
-        observation_remove(((lwm2m_client_t*)transacP->peerP), observationP);
+        observe_remove(((lwm2m_client_t*)transacP->peerP), observationP);
         return;
 
     case STATE_REG_PENDING:
@@ -729,7 +729,7 @@ static void prv_obsRequestCallback(lwm2m_transaction_t * transacP,
                                code,
                                LWM2M_CONTENT_TEXT, NULL, 0,
                                observationP->userData);
-        observation_remove(((lwm2m_client_t*)transacP->peerP), observationP);
+        observe_remove(((lwm2m_client_t*)transacP->peerP), observationP);
     }
     else
     {
@@ -775,7 +775,7 @@ static void prv_obsCancelRequestCallback(lwm2m_transaction_t * transacP,
                            cancelP->userDataP);
     }
 
-    observation_remove(((lwm2m_client_t*)transacP->peerP), cancelP->observationP);
+    observe_remove(((lwm2m_client_t*)transacP->peerP), cancelP->observationP);
 
     lwm2m_free(cancelP);
 }
@@ -893,7 +893,7 @@ int lwm2m_observe_cancel(lwm2m_context_t * contextP,
     return COAP_NO_ERROR;
 }
 
-bool handle_observe_notify(lwm2m_context_t * contextP,
+bool observe_handleNotify(lwm2m_context_t * contextP,
                            void * fromSessionH,
                            coap_packet_t * message,
         				   coap_packet_t * response)

--- a/core/observe.c
+++ b/core/observe.c
@@ -436,7 +436,7 @@ void observation_step(lwm2m_context_t * contextP,
 
         if (LWM2M_URI_IS_SET_RESOURCE(&targetP->uri))
         {
-            if (COAP_205_CONTENT != object_data_read(contextP, &targetP->uri, &size, &dataP)) continue;
+            if (COAP_205_CONTENT != object_readData(contextP, &targetP->uri, &size, &dataP)) continue;
             switch (dataP->dataType)
             {
             case LWM2M_TYPE_INTEGER:

--- a/core/packet.c
+++ b/core/packet.c
@@ -166,7 +166,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
 
 #ifdef LWM2M_SERVER_MODE
     case LWM2M_URI_FLAG_REGISTRATION:
-        result = handle_registration_request(contextP, uriP, fromSessionH, message, response);
+        result = registration_handleRequest(contextP, uriP, fromSessionH, message, response);
         break;
 #endif
 #ifdef LWM2M_BOOTSTRAP_SERVER_MODE

--- a/core/packet.c
+++ b/core/packet.c
@@ -111,9 +111,9 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
     coap_status_t result = COAP_IGNORE;
 
 #ifdef LWM2M_CLIENT_MODE
-    uriP = lwm2m_decode_uri(contextP->altPath, message->uri_path);
+    uriP = uri_decode(contextP->altPath, message->uri_path);
 #else
-    uriP = lwm2m_decode_uri(NULL, message->uri_path);
+    uriP = uri_decode(NULL, message->uri_path);
 #endif
 
     if (uriP == NULL) return COAP_400_BAD_REQUEST;

--- a/core/packet.c
+++ b/core/packet.c
@@ -98,7 +98,7 @@ static void handle_reset(lwm2m_context_t * contextP,
                          coap_packet_t * message)
 {
 #ifdef LWM2M_CLIENT_MODE
-    cancel_observe(contextP, message->mid, fromSessionH);
+    observe_cancel(contextP, message->mid, fromSessionH);
 #endif
 }
 
@@ -315,7 +315,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
                     if (!done && IS_OPTION(message, COAP_OPTION_OBSERVE) &&
                         ((message->code == COAP_204_CHANGED) || (message->code == COAP_205_CONTENT)))
                     {
-                        done = handle_observe_notify(contextP, fromSessionH, message, response);
+                        done = observe_handleNotify(contextP, fromSessionH, message, response);
                     }
 #endif
                     if (!done && message->type == COAP_TYPE_CON )

--- a/core/packet.c
+++ b/core/packet.c
@@ -136,7 +136,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
             serverP = utils_findBootstrapServer(contextP, fromSessionH);
             if (serverP != NULL)
             {
-                result = handle_bootstrap_command(contextP, uriP, serverP, message, response);
+                result = bootstrap_handleCommand(contextP, uriP, serverP, message, response);
             }
         }
 #endif
@@ -151,14 +151,14 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
         }
         else
         {
-            result = handle_delete_all(contextP, fromSessionH);
+            result = bootstrap_handleDeleteAll(contextP, fromSessionH);
         }
         break;
 
     case LWM2M_URI_FLAG_BOOTSTRAP:
         if (message->code == COAP_POST)
         {
-            result = handle_bootstrap_finish(contextP, fromSessionH);
+            result = bootstrap_handleFinish(contextP, fromSessionH);
         }
         break;
 #endif
@@ -171,7 +171,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
 #endif
 #ifdef LWM2M_BOOTSTRAP_SERVER_MODE
     case LWM2M_URI_FLAG_BOOTSTRAP:
-        result = handle_bootstrap_request(contextP, uriP, fromSessionH, message, response);
+        result = bootstrap_handleRequest(contextP, uriP, fromSessionH, message, response);
         break;
 #endif
     default:

--- a/core/packet.c
+++ b/core/packet.c
@@ -125,7 +125,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
     {
         lwm2m_server_t * serverP;
 
-        serverP = prv_findServer(contextP, fromSessionH);
+        serverP = utils_findServer(contextP, fromSessionH);
         if (serverP != NULL)
         {
             result = dm_handleRequest(contextP, uriP, serverP, message, response);

--- a/core/packet.c
+++ b/core/packet.c
@@ -309,7 +309,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
             case COAP_TYPE_NON:
             case COAP_TYPE_CON:
                 {
-                    bool done = transaction_handle_response(contextP, fromSessionH, message, response);
+                    bool done = transaction_handleResponse(contextP, fromSessionH, message, response);
 
 #ifdef LWM2M_SERVER_MODE
                     if (!done && IS_OPTION(message, COAP_OPTION_OBSERVE) &&
@@ -329,11 +329,11 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
             case COAP_TYPE_RST:
                 /* Cancel possible subscriptions. */
                 handle_reset(contextP, fromSessionH, message);
-                transaction_handle_response(contextP, fromSessionH, message, NULL);
+                transaction_handleResponse(contextP, fromSessionH, message, NULL);
                 break;
 
             case COAP_TYPE_ACK:
-                transaction_handle_response(contextP, fromSessionH, message, NULL);
+                transaction_handleResponse(contextP, fromSessionH, message, NULL);
                 break;
 
             default:

--- a/core/packet.c
+++ b/core/packet.c
@@ -128,7 +128,7 @@ static coap_status_t handle_request(lwm2m_context_t * contextP,
         serverP = prv_findServer(contextP, fromSessionH);
         if (serverP != NULL)
         {
-            result = handle_dm_request(contextP, uriP, serverP, message, response);
+            result = dm_handleRequest(contextP, uriP, serverP, message, response);
         }
 #ifdef LWM2M_BOOTSTRAP
         else

--- a/core/packet.c
+++ b/core/packet.c
@@ -219,12 +219,12 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
             if (message->type == COAP_TYPE_CON)
             {
                 /* Reliable CON requests are answered with an ACK. */
-                coap_init_message(response, COAP_TYPE_ACK, CONTENT_2_05, message->mid);
+                coap_init_message(response, COAP_TYPE_ACK, COAP_205_CONTENT, message->mid);
             }
             else
             {
                 /* Unreliable NON requests are answered with a NON as well. */
-                coap_init_message(response, COAP_TYPE_NON, CONTENT_2_05, contextP->nextMID++);
+                coap_init_message(response, COAP_TYPE_NON, COAP_205_CONTENT, contextP->nextMID++);
             }
 
             /* mirror token */
@@ -245,11 +245,11 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
             if (coap_error_code==NO_ERROR)
             {
                 /* Apply blockwise transfers. */
-                if ( IS_OPTION(message, COAP_OPTION_BLOCK1) && response->code<BAD_REQUEST_4_00 && !IS_OPTION(response, COAP_OPTION_BLOCK1) )
+                if ( IS_OPTION(message, COAP_OPTION_BLOCK1) && response->code<COAP_400_BAD_REQUEST && !IS_OPTION(response, COAP_OPTION_BLOCK1) )
                 {
                     LOG("Block1 NOT IMPLEMENTED\n");
 
-                    coap_error_code = NOT_IMPLEMENTED_5_01;
+                    coap_error_code = COAP_501_NOT_IMPLEMENTED;
                     coap_error_message = "NoBlock1Support";
                 }
                 else if ( IS_OPTION(message, COAP_OPTION_BLOCK2) )
@@ -262,7 +262,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
                         {
                             LOG("handle_incoming_data(): block_offset >= response->payload_len\n");
 
-                            response->code = BAD_OPTION_4_02;
+                            response->code = COAP_402_BAD_OPTION;
                             coap_set_payload(response, "BlockOutOfScope", 15); /* a const char str[] and sizeof(str) produces larger code size */
                         }
                         else
@@ -354,7 +354,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
         /* Set to sendable error code. */
         if (coap_error_code >= 192)
         {
-            coap_error_code = INTERNAL_SERVER_ERROR_5_00;
+            coap_error_code = COAP_500_INTERNAL_SERVER_ERROR;
         }
         /* Reuse input buffer for error message. */
         coap_init_message(message, COAP_TYPE_ACK, coap_error_code, message->mid);
@@ -368,7 +368,7 @@ coap_status_t message_send(lwm2m_context_t * contextP,
                            coap_packet_t * message,
                            void * sessionH)
 {
-    coap_status_t result = INTERNAL_SERVER_ERROR_5_00;
+    coap_status_t result = COAP_500_INTERNAL_SERVER_ERROR;
     uint8_t * pktBuffer;
     size_t pktBufferLen = 0;
     size_t allocLen;

--- a/core/registration.c
+++ b/core/registration.c
@@ -128,7 +128,7 @@ static void prv_handleRegistrationReply(lwm2m_transaction_t * transacP,
         {
             targetP->registration = tv_sec;
         }
-        if (packet != NULL && packet->code == CREATED_2_01)
+        if (packet != NULL && packet->code == COAP_201_CREATED)
         {
             targetP->status = STATE_REGISTERED;
             if (NULL != targetP->location)
@@ -217,7 +217,7 @@ static void prv_handleRegistrationUpdateReply(lwm2m_transaction_t * transacP,
         {
             targetP->registration = tv_sec;
         }
-        if (packet != NULL && packet->code == CHANGED_2_04)
+        if (packet != NULL && packet->code == COAP_204_CHANGED)
         {
             targetP->status = STATE_REGISTERED;
             LOG("    => REGISTERED\r\n");
@@ -956,7 +956,7 @@ coap_status_t registration_handleRequest(lwm2m_context_t * contextP,
 
             if (contextP->monitorCallback != NULL)
             {
-                contextP->monitorCallback(clientP->internalID, NULL, CREATED_2_01, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+                contextP->monitorCallback(clientP->internalID, NULL, COAP_201_CREATED, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
             }
             result = COAP_201_CREATED;
             break;
@@ -1060,7 +1060,7 @@ coap_status_t registration_handleRequest(lwm2m_context_t * contextP,
         if (clientP == NULL) return COAP_400_BAD_REQUEST;
         if (contextP->monitorCallback != NULL)
         {
-            contextP->monitorCallback(clientP->internalID, NULL, DELETED_2_02, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+            contextP->monitorCallback(clientP->internalID, NULL, COAP_202_DELETED, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
         }
         registration_freeClient(clientP);
         result = COAP_202_DELETED;
@@ -1135,7 +1135,7 @@ void registration_step(lwm2m_context_t * contextP,
             contextP->clientList = (lwm2m_client_t *)LWM2M_LIST_RM(contextP->clientList, clientP->internalID, NULL);
             if (contextP->monitorCallback != NULL)
             {
-                contextP->monitorCallback(clientP->internalID, NULL, DELETED_2_02, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+                contextP->monitorCallback(clientP->internalID, NULL, COAP_202_DELETED, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
             }
             registration_freeClient(clientP);
         }

--- a/core/registration.c
+++ b/core/registration.c
@@ -63,8 +63,10 @@
 
 #ifdef LWM2M_CLIENT_MODE
 
-static int prv_getRegistrationQuery(lwm2m_context_t * contextP, lwm2m_server_t * server,
-                                    char * buffer, size_t length)
+static int prv_getRegistrationQuery(lwm2m_context_t * contextP,
+                                    lwm2m_server_t * server,
+                                    char * buffer,
+                                    size_t length)
 {
     int index;
     int res;
@@ -228,9 +230,9 @@ static void prv_handleRegistrationUpdateReply(lwm2m_transaction_t * transacP,
     }
 }
 
-static int prv_update_registration(lwm2m_context_t * contextP,
-                                   lwm2m_server_t * server,
-                                   bool withObjects)
+static int prv_updateRegistration(lwm2m_context_t * contextP,
+                                  lwm2m_server_t * server,
+                                  bool withObjects)
 {
     lwm2m_transaction_t * transaction;
     uint8_t payload[512];
@@ -290,12 +292,12 @@ int lwm2m_update_registration(lwm2m_context_t * contextP,
             if (targetP->shortID == shortServerID)
             {
                 // found the server, trigger the update transaction
-                return prv_update_registration(contextP, targetP, withObjects);
+                return prv_updateRegistration(contextP, targetP, withObjects);
             }
         }
         else
         {
-            result = prv_update_registration(contextP, targetP, withObjects);
+            result = prv_updateRegistration(contextP, targetP, withObjects);
         }
         targetP = targetP->next;
     }
@@ -337,7 +339,7 @@ uint8_t registration_start(lwm2m_context_t * contextP)
  * Returns STATE_REGISTERED if no registration is pending and there is at least one server the client is registered to
  * Returns STATE_REG_FAILED if all registration failed.
  */
-lwm2m_status_t registration_get_status(lwm2m_context_t * contextP)
+lwm2m_status_t registration_getStatus(lwm2m_context_t * contextP)
 {
     lwm2m_server_t * targetP;
     lwm2m_status_t reg_status;
@@ -374,7 +376,7 @@ lwm2m_status_t registration_get_status(lwm2m_context_t * contextP)
 }
 
 static void prv_handleDeregistrationReply(lwm2m_transaction_t * transacP,
-                                        void * message)
+                                          void * message)
 {
     lwm2m_server_t * targetP;
 
@@ -811,7 +813,7 @@ static lwm2m_client_t * prv_getClientByName(lwm2m_context_t * contextP,
     return targetP;
 }
 
-void prv_freeClient(lwm2m_client_t * clientP)
+void registration_freeClient(lwm2m_client_t * clientP)
 {
     if (clientP->name != NULL) lwm2m_free(clientP->name);
     if (clientP->msisdn != NULL) lwm2m_free(clientP->msisdn);
@@ -846,7 +848,7 @@ static int prv_getLocationString(uint16_t id,
     return index + result;
 }
 
-coap_status_t handle_registration_request(lwm2m_context_t * contextP,
+coap_status_t registration_handleRequest(lwm2m_context_t * contextP,
                                           lwm2m_uri_t * uriP,
                                           void * fromSessionH,
                                           coap_packet_t * message,
@@ -943,12 +945,12 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
 
             if (prv_getLocationString(clientP->internalID, location) == 0)
             {
-                prv_freeClient(clientP);
+                registration_freeClient(clientP);
                 return COAP_500_INTERNAL_SERVER_ERROR;
             }
             if (coap_set_header_location_path(response, location) == 0)
             {
-                prv_freeClient(clientP);
+                registration_freeClient(clientP);
                 return COAP_500_INTERNAL_SERVER_ERROR;
             }
 
@@ -1060,7 +1062,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
         {
             contextP->monitorCallback(clientP->internalID, NULL, DELETED_2_02, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
         }
-        prv_freeClient(clientP);
+        registration_freeClient(clientP);
         result = COAP_202_DELETED;
     }
     break;
@@ -1108,7 +1110,7 @@ void registration_step(lwm2m_context_t * contextP,
             if (0 >= interval)
             {
                 LOG("Updating registration...\r\n");
-                prv_update_registration(contextP, targetP, false);
+                prv_updateRegistration(contextP, targetP, false);
             }
             else if (interval < *timeoutP)
             {
@@ -1135,7 +1137,7 @@ void registration_step(lwm2m_context_t * contextP,
             {
                 contextP->monitorCallback(clientP->internalID, NULL, DELETED_2_02, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
             }
-            prv_freeClient(clientP);
+            registration_freeClient(clientP);
         }
         else
         {

--- a/core/registration.c
+++ b/core/registration.c
@@ -1008,7 +1008,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
                                                COAP_202_DELETED,
                                                LWM2M_CONTENT_TEXT, NULL, 0,
                                                observationP->userData);
-                        observation_remove(clientP, observationP);
+                        observe_remove(clientP, observationP);
                     }
                     else
                     {
@@ -1021,7 +1021,7 @@ coap_status_t handle_registration_request(lwm2m_context_t * contextP,
                                                        COAP_202_DELETED,
                                                        LWM2M_CONTENT_TEXT, NULL, 0,
                                                        observationP->userData);
-                                observation_remove(clientP, observationP);
+                                observe_remove(clientP, observationP);
                             }
                         }
                     }

--- a/core/registration.c
+++ b/core/registration.c
@@ -686,7 +686,7 @@ static int prv_getId(uint8_t * data,
 
     limit = 0;
     while (limit < length && data[limit] != '/') limit++;
-    value = prv_get_number(data, limit);
+    value = uri_getNumber(data, limit);
     if (value < 0 || value >= LWM2M_MAX_ID) return 0;
     *objId = value;
 
@@ -698,7 +698,7 @@ static int prv_getId(uint8_t * data,
 
         if (length > 0)
         {
-            value = prv_get_number(data, length);
+            value = uri_getNumber(data, length);
             if (value >= 0 && value < LWM2M_MAX_ID)
             {
                 *instanceId = value;

--- a/core/registration.c
+++ b/core/registration.c
@@ -504,7 +504,7 @@ static int prv_getParameters(multi_option_t * query,
             if (*bindingP != BINDING_UNKNOWN) goto error;
             if (query->len == QUERY_BINDING_LEN) goto error;
 
-            *bindingP = lwm2m_stringToBinding(query->data + QUERY_BINDING_LEN, query->len - QUERY_BINDING_LEN);
+            *bindingP = utils_stringToBinding(query->data + QUERY_BINDING_LEN, query->len - QUERY_BINDING_LEN);
         }
         query = query->next;
     }

--- a/core/registration.c
+++ b/core/registration.c
@@ -157,7 +157,7 @@ static uint8_t prv_register(lwm2m_context_t * contextP,
     int payload_length;
     lwm2m_transaction_t * transaction;
 
-    payload_length = prv_getRegisterPayload(contextP, payload, sizeof(payload));
+    payload_length = object_getRegisterPayload(contextP, payload, sizeof(payload));
     if (payload_length == 0) return COAP_500_INTERNAL_SERVER_ERROR;
 
     query_length = prv_getRegistrationQuery(contextP, server, query, sizeof(query));
@@ -243,7 +243,7 @@ static int prv_update_registration(lwm2m_context_t * contextP,
 
     if (withObjects == true)
     {
-        payload_length = prv_getRegisterPayload(contextP, payload, sizeof(payload));
+        payload_length = object_getRegisterPayload(contextP, payload, sizeof(payload));
         if (payload_length == 0)
         {
             transaction_free(transaction);

--- a/core/tlv.c
+++ b/core/tlv.c
@@ -158,7 +158,7 @@ static int prv_boolToTLV(lwm2m_tlv_type_t type,
     return prv_intToTLV(type, value ? 1 : 0, id, buffer, buffer_len);
 }
 
-int lwm2m_decodeTLV(const uint8_t * buffer,
+int lwm2m_decode_TLV(const uint8_t * buffer,
                     size_t buffer_len,
                     lwm2m_tlv_type_t * oType,
                     uint16_t * oID,
@@ -234,7 +234,7 @@ int tlv_parse(uint8_t * buffer,
 
     *dataP = NULL;
 
-    while (0 != (result = lwm2m_decodeTLV((uint8_t*)buffer + index, bufferLen - index, &type, &id, &dataIndex, &dataLen)))
+    while (0 != (result = lwm2m_decode_TLV((uint8_t*)buffer + index, bufferLen - index, &type, &id, &dataIndex, &dataLen)))
     {
         lwm2m_data_t * newTlvP;
 

--- a/core/tlv.c
+++ b/core/tlv.c
@@ -144,7 +144,7 @@ static int prv_intToTLV(lwm2m_tlv_type_t type,
     if (type != LWM2M_TYPE_RESOURCE_INSTANCE && type != LWM2M_TYPE_RESOURCE)
         return 0;
 
-    utils_encodeInt(data, data_buffer, &length);
+    length = utils_encodeInt(data, data_buffer);
 
     return prv_opaqueToTLV(type, data_buffer, length, id, buffer, buffer_len);
 }

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -114,8 +114,8 @@ Contains code snippets which are:
 #define COAP_RESPONSE_TIMEOUT_TICKS         (CLOCK_SECOND * COAP_RESPONSE_TIMEOUT)
 #define COAP_RESPONSE_TIMEOUT_BACKOFF_MASK  ((CLOCK_SECOND * COAP_RESPONSE_TIMEOUT * (COAP_RESPONSE_RANDOM_FACTOR - 1)) + 1.5)
 
-static int prv_transaction_check_finished(lwm2m_transaction_t * transacP,
-        coap_packet_t * receivedMessage)
+static int prv_checkFinished(lwm2m_transaction_t * transacP,
+                             coap_packet_t * receivedMessage)
 {
     int len;
     const uint8_t* token;
@@ -258,7 +258,7 @@ void transaction_remove(lwm2m_context_t * contextP,
     transaction_free(transacP);
 }
 
-bool transaction_handle_response(lwm2m_context_t * contextP,
+bool transaction_handleResponse(lwm2m_context_t * contextP,
                                  void * fromSessionH,
                                  coap_packet_t * message,
                                  coap_packet_t * response)
@@ -315,7 +315,7 @@ bool transaction_handle_response(lwm2m_context_t * contextP,
                 }
             }
 
-            if (reset || prv_transaction_check_finished(transacP, message))
+            if (reset || prv_checkFinished(transacP, message))
             {
                 // HACK: If a message is sent from the monitor callback,
                 // it will arrive before the registration ACK.

--- a/core/uri.c
+++ b/core/uri.c
@@ -55,7 +55,7 @@
 #include <ctype.h>
 
 
-static int prv_parse_number(uint8_t * uriString,
+static int prv_parseNumber(uint8_t * uriString,
                             size_t uriLength,
                             size_t * headP)
 {
@@ -85,16 +85,16 @@ static int prv_parse_number(uint8_t * uriString,
 }
 
 
-int prv_get_number(uint8_t * uriString,
+int uri_getNumber(uint8_t * uriString,
                    size_t uriLength)
 {
     size_t index = 0;
 
-    return prv_parse_number(uriString, uriLength, &index);
+    return prv_parseNumber(uriString, uriLength, &index);
 }
 
 
-lwm2m_uri_t * lwm2m_decode_uri(char * altPath,
+lwm2m_uri_t * uri_decode(char * altPath,
                                multi_option_t *uriPath)
 {
     lwm2m_uri_t * uriP;
@@ -152,7 +152,7 @@ lwm2m_uri_t * lwm2m_decode_uri(char * altPath,
         }
     }
 
-    readNum = prv_get_number(uriPath->data, uriPath->len);
+    readNum = uri_getNumber(uriPath->data, uriPath->len);
     if (readNum < 0 || readNum > LWM2M_MAX_ID) goto error;
     uriP->objectId = (uint16_t)readNum;
     uriP->flag |= LWM2M_URI_FLAG_OBJECT_ID;
@@ -170,7 +170,7 @@ lwm2m_uri_t * lwm2m_decode_uri(char * altPath,
     // Read object instance
     if (uriPath->len != 0)
     {
-        readNum = prv_get_number(uriPath->data, uriPath->len);
+        readNum = uri_getNumber(uriPath->data, uriPath->len);
         if (readNum < 0 || readNum >= LWM2M_MAX_ID) goto error;
         uriP->instanceId = (uint16_t)readNum;
         uriP->flag |= LWM2M_URI_FLAG_INSTANCE_ID;
@@ -185,7 +185,7 @@ lwm2m_uri_t * lwm2m_decode_uri(char * altPath,
         // resource ID without an instance ID is not allowed
         if ((uriP->flag & LWM2M_URI_FLAG_INSTANCE_ID) == 0) goto error;
 
-        readNum = prv_get_number(uriPath->data, uriPath->len);
+        readNum = uri_getNumber(uriPath->data, uriPath->len);
         if (readNum < 0 || readNum > LWM2M_MAX_ID) goto error;
         uriP->resourceId = (uint16_t)readNum;
         uriP->flag |= LWM2M_URI_FLAG_RESOURCE_ID;
@@ -224,7 +224,7 @@ int lwm2m_stringToUri(const char * buffer,
     if (head == buffer_len) return 0;
 
     // Read object ID
-    readNum = prv_parse_number((uint8_t *)buffer, buffer_len, &head);
+    readNum = prv_parseNumber((uint8_t *)buffer, buffer_len, &head);
     if (readNum < 0 || readNum > LWM2M_MAX_ID) return 0;
     uriP->objectId = (uint16_t)readNum;
     uriP->flag |= LWM2M_URI_FLAG_OBJECT_ID;
@@ -232,7 +232,7 @@ int lwm2m_stringToUri(const char * buffer,
     if (buffer[head] == '/') head += 1;
     if (head >= buffer_len) return head;
 
-    readNum = prv_parse_number((uint8_t *)buffer, buffer_len, &head);
+    readNum = prv_parseNumber((uint8_t *)buffer, buffer_len, &head);
     if (readNum < 0 || readNum >= LWM2M_MAX_ID) return 0;
     uriP->instanceId = (uint16_t)readNum;
     uriP->flag |= LWM2M_URI_FLAG_INSTANCE_ID;
@@ -240,7 +240,7 @@ int lwm2m_stringToUri(const char * buffer,
     if (buffer[head] == '/') head += 1;
     if (head >= buffer_len) return head;
 
-    readNum = prv_parse_number((uint8_t *)buffer, buffer_len, &head);
+    readNum = prv_parseNumber((uint8_t *)buffer, buffer_len, &head);
     if (readNum < 0 || readNum >= LWM2M_MAX_ID) return 0;
     uriP->resourceId = (uint16_t)readNum;
     uriP->flag |= LWM2M_URI_FLAG_RESOURCE_ID;

--- a/core/uri.c
+++ b/core/uri.c
@@ -250,3 +250,49 @@ int lwm2m_stringToUri(const char * buffer,
     return head;
 }
 
+int uri_toString(lwm2m_uri_t * uriP,
+                 uint8_t * buffer,
+                 size_t bufferLen,
+                 lwm2m_tlv_type_t * depthP)
+{
+    size_t head;
+    int res;
+
+    buffer[0] = '/';
+
+    if (uriP == NULL) return -1;
+
+    head = 1;
+
+    res = utils_intToText(uriP->objectId, buffer + head, bufferLen - head);
+    if (res <= 0) return -1;
+    head += res;
+    if (head >= bufferLen - 1) return -1;
+    *depthP = LWM2M_TYPE_OBJECT_INSTANCE;
+
+    if (LWM2M_URI_IS_SET_INSTANCE(uriP))
+    {
+        buffer[head] = '/';
+        head++;
+        res = utils_intToText(uriP->instanceId, buffer + head, bufferLen - head);
+        if (res <= 0) return -1;
+        head += res;
+        if (head >= bufferLen - 1) return -1;
+        *depthP = LWM2M_TYPE_RESOURCE;
+        if (LWM2M_URI_IS_SET_RESOURCE(uriP))
+        {
+            buffer[head] = '/';
+            head++;
+            res = utils_intToText(uriP->resourceId, buffer + head, bufferLen - head);
+            if (res <= 0) return -1;
+            head += res;
+            if (head >= bufferLen - 1) return -1;
+            *depthP = LWM2M_TYPE_RESOURCE_INSTANCE;
+        }
+    }
+
+    buffer[head] = '/';
+    head++;
+
+    return head;
+}

--- a/core/utils.c
+++ b/core/utils.c
@@ -596,22 +596,23 @@ int utils_opaqueToFloat(const uint8_t * buffer,
 
 /**
 * Encode an integer value to a byte representation.
+* Returns the length of the result. For values < 0xff length is 1,
+* for values < 0xffff length is 2 and so on.
 * @param data        Input value
 * @param data_buffer Result in data_buffer is in big endian encoding
 *                    Negative values are represented in two's complement as of
 *                    OMA-TS-LightweightM2M-V1_0-20160308-D, Appendix C
-* @param lengthP     The length of the result. For values < 0xff length is 1,
-*                    for values < 0xffff length is 2 and so on.
 */
-void utils_encodeInt(int64_t data,
-                     uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE],
-                     size_t * lengthP)
+size_t utils_encodeInt(int64_t data,
+                       uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE])
 {
+    size_t length = 0;
+
     memset(data_buffer, 0, _PRV_64BIT_BUFFER_SIZE);
 
     if (data >= INT8_MIN && data <= INT8_MAX)
     {
-        *lengthP = 1;
+        length = 1;
         data_buffer[0] = data;
     }
     else if (data >= INT16_MIN && data <= INT16_MAX)
@@ -619,7 +620,7 @@ void utils_encodeInt(int64_t data,
         int16_t value;
 
         value = data;
-        *lengthP = 2;
+        length = 2;
         data_buffer[0] = (value >> 8) & 0xFF;
         data_buffer[1] = value & 0xFF;
     }
@@ -628,12 +629,14 @@ void utils_encodeInt(int64_t data,
         int32_t value;
 
         value = data;
-        *lengthP = 4;
-        utils_copyValue(data_buffer, &value, *lengthP);
+        length = 4;
+        utils_copyValue(data_buffer, &value, length);
     }
     else if (data >= INT64_MIN && data <= INT64_MAX)
     {
-        *lengthP = 8;
-        utils_copyValue(data_buffer, &data, *lengthP);
+        length = 8;
+        utils_copyValue(data_buffer, &data, length);
     }
+
+    return length;
 }

--- a/core/utils.c
+++ b/core/utils.c
@@ -504,3 +504,21 @@ int utils_intCopy(char * buffer,
 
     return len;
 }
+
+void utils_copyValue(void * dst,
+                     const void * src,
+                     size_t len)
+{
+#ifdef LWM2M_BIG_ENDIAN
+    memcpy(dst, src, len);
+#else
+#ifdef LWM2M_LITTLE_ENDIAN
+    int i;
+
+    for (i = 0; i < len; i++)
+    {
+        ((uint8_t *)dst)[i] = ((uint8_t *)src)[len - 1 - i];
+    }
+#endif
+#endif
+}

--- a/core/utils.c
+++ b/core/utils.c
@@ -53,7 +53,7 @@
 #include <float.h>
 
 
-int lwm2m_PlainTextToInt64(uint8_t * buffer,
+int utils_plainTextToInt64(uint8_t * buffer,
                            int length,
                            int64_t * dataP)
 {
@@ -98,7 +98,7 @@ int lwm2m_PlainTextToInt64(uint8_t * buffer,
     return 1;
 }
 
-int lwm2m_PlainTextToFloat64(uint8_t * buffer,
+int utils_plainTextToFloat64(uint8_t * buffer,
                              int length,
                              double * dataP)
 {
@@ -277,7 +277,7 @@ size_t utils_floatToText(double data,
     return intLength + decLength;
 }
 
-size_t lwm2m_int64ToPlainText(int64_t data,
+size_t utils_int64ToPlainText(int64_t data,
                               uint8_t ** bufferP)
 {
 #define _PRV_STR_LENGTH 32
@@ -296,7 +296,7 @@ size_t lwm2m_int64ToPlainText(int64_t data,
 }
 
 
-size_t lwm2m_float64ToPlainText(double data,
+size_t utils_float64ToPlainText(double data,
                                 uint8_t ** bufferP)
 {
     uint8_t string[_PRV_STR_LENGTH * 2];
@@ -314,13 +314,13 @@ size_t lwm2m_float64ToPlainText(double data,
 }
 
 
-size_t lwm2m_boolToPlainText(bool data,
+size_t utils_boolToPlainText(bool data,
                              uint8_t ** bufferP)
 {
-    return lwm2m_int64ToPlainText((int64_t)(data?1:0), bufferP);
+    return utils_int64ToPlainText((int64_t)(data?1:0), bufferP);
 }
 
-lwm2m_binding_t lwm2m_stringToBinding(uint8_t * buffer,
+lwm2m_binding_t utils_stringToBinding(uint8_t * buffer,
                                       size_t length)
 {
     if (length == 0) return BINDING_UNKNOWN;
@@ -377,7 +377,7 @@ lwm2m_binding_t lwm2m_stringToBinding(uint8_t * buffer,
     return BINDING_UNKNOWN;
 }
 
-lwm2m_media_type_t prv_convertMediaType(coap_content_type_t type)
+lwm2m_media_type_t utils_convertMediaType(coap_content_type_t type)
 {
     // Here we just check the content type is a valid value for LWM2M
     switch(type)
@@ -438,7 +438,7 @@ lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP,
 #endif
 }
 
-int prv_isAltPathValid(const char * altPath)
+int utils_isAltPathValid(const char * altPath)
 {
     int i;
 

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -563,7 +563,7 @@ static void prv_create_client(char * buffer,
     char * end = NULL;
     int result;
     int64_t value;
-    uint8_t temp_buffer[MAX_PACKET_SIZE];
+    uint8_t * temp_buffer = NULL;
     int temp_length = 0;
     lwm2m_media_type_t format = LWM2M_CONTENT_TEXT;
 
@@ -590,9 +590,20 @@ static void prv_create_client(char * buffer,
 
     if (uri.objectId == 1024)
     {
-        result = lwm2m_PlainTextToInt64((uint8_t *)buffer, end - buffer, &value);
-        temp_length = lwm2m_intToTLV(LWM2M_TYPE_RESOURCE, value, (uint16_t) 1, temp_buffer, MAX_PACKET_SIZE);
+        lwm2m_data_t * dataP;
+
+        dataP = lwm2m_data_new(1);
+        if (dataP == NULL)
+        {
+            fprintf(stdout, "Allocation error !");
+            return;
+        }
+        lwm2m_data_encode_int(value, dataP);
+        dataP->type = LWM2M_TYPE_RESOURCE;
+        dataP->id = 1;
+
         format = LWM2M_CONTENT_TLV;
+        temp_length = lwm2m_data_serialize(NULL, 1, dataP, &format, &temp_buffer);
     }
    /* End Client dependent part*/
 

--- a/examples/utils/commandline.c
+++ b/examples/utils/commandline.c
@@ -228,7 +228,7 @@ void output_tlv(FILE * stream,
     int length = 0;
     int result;
 
-    while (0 != (result = lwm2m_decodeTLV((uint8_t*)buffer + length, buffer_len - length, &type, &id, &dataIndex, &dataLen)))
+    while (0 != (result = lwm2m_decode_TLV((uint8_t*)buffer + length, buffer_len - length, &type, &id, &dataIndex, &dataLen)))
     {
         print_indent(stream, indent);
         fprintf(stream, "{\r\n");

--- a/examples/utils/commandline.c
+++ b/examples/utils/commandline.c
@@ -266,21 +266,25 @@ void output_tlv(FILE * stream,
         {
             int64_t intValue;
             double floatValue;
+            uint8_t tmp;
 
             print_indent(stream, indent+2);
             fprintf(stream, "data (%ld bytes):\r\n", dataLen);
             output_buffer(stream, (uint8_t*)buffer + length + dataIndex, dataLen, indent+2);
 
-            if (0 < lwm2m_opaqueToInt(buffer + length + dataIndex, dataLen, &intValue))
+            tmp = buffer[length + dataIndex + dataLen];
+            buffer[length + dataIndex + dataLen] = 0;
+            if (0 < sscanf(buffer + length + dataIndex, "%"PRId64, &intValue))
             {
                 print_indent(stream, indent+2);
                 fprintf(stream, "data as Integer: %" PRId64 "\r\n", intValue);
             }
-            if (0 < lwm2m_opaqueToFloat(buffer + length + dataIndex, dataLen, &floatValue))
+            if (0 < sscanf(buffer + length + dataIndex, "%g", &floatValue))
             {
                 print_indent(stream, indent+2);
                 fprintf(stream, "data as Float: %.16g\r\n", floatValue);
             }
+            buffer[length + dataIndex + dataLen] = tmp;
         }
         print_indent(stream, indent+1);
         fprintf(stream, "}\r\n");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,14 +4,14 @@ project (lwm2munittests)
   
 SET(LIBLWM2M_DIR ${PROJECT_SOURCE_DIR}/../core)
 
-add_definitions(-DLWM2M_CLIENT_MODE -DLWM2M_LITTLE_ENDIAN)
+add_definitions(-DLWM2M_CLIENT_MODE -DLWM2M_SUPPORT_JSON -DLWM2M_LITTLE_ENDIAN)
 
-include_directories (${LIBLWM2M_DIR} ${PROJECT_SOURCE_DIR}/../examples/utils)
+include_directories (${LIBLWM2M_DIR} ${PROJECT_SOURCE_DIR}/../examples/utils ${PROJECT_SOURCE_DIR}/../core)
 
 add_subdirectory(${LIBLWM2M_DIR} ${CMAKE_CURRENT_BINARY_DIR}/core)
 
 # Enable all warnings for this test build  
-add_definitions(-Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default -Wswitch-enum)  
+# add_definitions(-Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default -Wswitch-enum)  
 
 SET(SOURCES
     unittests.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories (${LIBLWM2M_DIR} ${PROJECT_SOURCE_DIR}/../examples/utils ${P
 add_subdirectory(${LIBLWM2M_DIR} ${CMAKE_CURRENT_BINARY_DIR}/core)
 
 # Enable all warnings for this test build  
-# add_definitions(-Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default -Wswitch-enum)  
+add_definitions(-Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default -Wswitch-enum)  
 
 SET(SOURCES
     unittests.c

--- a/tests/convert_numbers_test.c
+++ b/tests/convert_numbers_test.c
@@ -16,7 +16,7 @@
  *    
  *******************************************************************************/
 
-#include "liblwm2m.h"
+#include "internals.h"
 #include "tests.h"
 #include "CUnit/Basic.h"
 
@@ -41,7 +41,7 @@ static void test_lwm2m_PlainTextToInt64(void)
     {
         int64_t res;
 
-        if (lwm2m_PlainTextToInt64((unsigned char*)tests[i], strlen(tests[i]), &res) != 1)
+        if (utils_plainTextToInt64((unsigned char*)tests[i], strlen(tests[i]), &res) != 1)
             res = -1;
 
         CU_ASSERT_EQUAL(res, tests_expected_int[i]);
@@ -55,7 +55,7 @@ static void test_lwm2m_PlainTextToFloat64(void)
     {
         double res;
 
-        if (lwm2m_PlainTextToFloat64((unsigned char*)tests[i], strlen(tests[i]), &res) != 1)
+        if (utils_plainTextToFloat64((unsigned char*)tests[i], strlen(tests[i]), &res) != 1)
             res = -1;
 
         CU_ASSERT_DOUBLE_EQUAL(res, tests_expected_float[i], 0.0001);
@@ -70,7 +70,7 @@ static void test_lwm2m_int64ToPlainText(void)
         char * res = (char*)"";
         int len;
 
-        len = lwm2m_int64ToPlainText(ints[i], (uint8_t**)&res);
+        len = utils_int64ToPlainText(ints[i], (uint8_t**)&res);
 
         CU_ASSERT_FATAL(len);
         CU_ASSERT_NSTRING_EQUAL(res, ints_expected[i],len);
@@ -88,7 +88,7 @@ static void test_lwm2m_float64ToPlainText(void)
         char * res;
         int len;
 
-        len = lwm2m_float64ToPlainText(floats[i], (uint8_t**)&res);
+        len = utils_float64ToPlainText(floats[i], (uint8_t**)&res);
 
         CU_ASSERT_FATAL(len);
         CU_ASSERT_NSTRING_EQUAL(res, floats_expected[i],len);
@@ -100,10 +100,10 @@ static void test_lwm2m_float64ToPlainText(void)
 }
 
 static struct TestTable table[] = {
-        { "test of lwm2m_PlainTextToInt64()", test_lwm2m_PlainTextToInt64 },
-        { "test of lwm2m_PlainTextToFloat64()", test_lwm2m_PlainTextToFloat64 },
-        { "test of lwm2m_int64ToPlainText()", test_lwm2m_int64ToPlainText },
-        { "test of lwm2m_float64ToPlainText()", test_lwm2m_float64ToPlainText },
+        { "test of utils_plainTextToInt64()", test_lwm2m_PlainTextToInt64 },
+        { "test of utils_plainTextToFloat64()", test_lwm2m_PlainTextToFloat64 },
+        { "test of utils_int64ToPlainText()", test_lwm2m_int64ToPlainText },
+        { "test of utils_float64ToPlainText()", test_lwm2m_float64ToPlainText },
         { NULL, NULL },
 };
 

--- a/tests/tlv_json_lwm2m_data_test.c
+++ b/tests/tlv_json_lwm2m_data_test.c
@@ -38,7 +38,14 @@ static void test_data(const char * uriStr,
 {
     lwm2m_uri_t uri;
     uint8_t * buffer;
-    int length = lwm2m_data_serialize((uriStr != NULL)?&uri:NULL, size, tlvP, &format, &buffer);
+    int length;
+    
+    if (uriStr != NULL)
+    {
+        lwm2m_stringToUri(uriStr, strlen(uriStr), &uri);
+    }
+
+    length = lwm2m_data_serialize((uriStr != NULL) ? &uri : NULL, size, tlvP, &format, &buffer);
     if (length <= 0)
     {
         printf("Serialize lwm2m_data_t %s to %s failed.\n", id, format==LWM2M_CONTENT_JSON?"JSON":"TLV");
@@ -63,7 +70,14 @@ static void test_data_and_compare(const char * uriStr,
 {
     lwm2m_uri_t uri;
     uint8_t * buffer;
-    size_t length = lwm2m_data_serialize((uriStr != NULL)?&uri:NULL, size, tlvP, &format, &buffer);
+    int length;
+    
+    if (uriStr != NULL)
+    {
+        lwm2m_stringToUri(uriStr, strlen(uriStr), &uri);
+    }
+
+    length = lwm2m_data_serialize((uriStr != NULL) ? &uri : NULL, size, tlvP, &format, &buffer);
     if (length <= 0)
     {
         printf("Serialize lwm2m_data_t %s to TLV failed.\n", id);
@@ -146,19 +160,25 @@ static void test_raw(const char * uriStr,
 {
     lwm2m_data_t * tlvP;
     lwm2m_uri_t uri;
-    int size = lwm2m_data_parse((uriStr != NULL)?&uri:NULL, (uint8_t *)testBuf, testLen,
-                                format, &tlvP);
+    int size;
+    
+    if (uriStr != NULL)
+    {
+        lwm2m_stringToUri(uriStr, strlen(uriStr), &uri);
+    }
+
+    size = lwm2m_data_parse((uriStr != NULL) ? &uri : NULL, (uint8_t *)testBuf, testLen, format, &tlvP);
     CU_ASSERT_TRUE_FATAL(size>0);
 
     // Serialize to the same format and compare to the input buffer
     test_data_and_compare(uriStr, format, tlvP, size, id, (uint8_t*)testBuf, testLen);
 
-    // Serialize to the other format respectivly.
-    if (format == LWM2M_CONTENT_TLV) {
-        make_all_objects_string_types(tlvP, size);
-        test_data(uriStr, LWM2M_CONTENT_JSON, tlvP, size, id);
-    } else if (format == LWM2M_CONTENT_JSON)
+    // Serialize to the TLV format
+    // the reverse is not possible as TLV format loses the data type information
+    if (format == LWM2M_CONTENT_JSON)
+    {
         test_data(uriStr, LWM2M_CONTENT_TLV, tlvP, size, id);
+    }
 }
 
 static void test_raw_expected(const char * uriStr,

--- a/tests/uritests.c
+++ b/tests/uritests.c
@@ -17,7 +17,6 @@
 
 #include "tests.h"
 #include "CUnit/Basic.h"
-#include "liblwm2m.h"
 #include "internals.h"
 #include "memtest.h"
 
@@ -37,40 +36,40 @@ static void test_uri_decode(void)
     MEMORY_TRACE_BEFORE;
 
     /* "/rd" */
-    uri = lwm2m_decode_uri(NULL, &reg);
+    uri = uri_decode(NULL, &reg);
     CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
     CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_REGISTRATION);
     lwm2m_free(uri);
 
     /* "/rd/5a3f" */
     reg.next = &location;
-    uri = lwm2m_decode_uri(NULL, &reg);
+    uri = uri_decode(NULL, &reg);
     /* should not fail, error in uri_parse */
     /* CU_ASSERT_PTR_NOT_NULL(uri); */
     lwm2m_free(uri);
 
     /* "/rd/5312" */
     reg.next = &locationDecimal;
-    uri = lwm2m_decode_uri(NULL, &reg);
+    uri = uri_decode(NULL, &reg);
     CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
     CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_REGISTRATION | LWM2M_URI_FLAG_OBJECT_ID);
     CU_ASSERT_EQUAL(uri->objectId, 5312);
     lwm2m_free(uri);
 
     /* "/bs" */
-    uri = lwm2m_decode_uri(NULL, &boot);
+    uri = uri_decode(NULL, &boot);
     CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
     CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_BOOTSTRAP);
     lwm2m_free(uri);
 
     /* "/bs/5a3f" */
     boot.next = &location;
-    uri = lwm2m_decode_uri(NULL, &boot);
+    uri = uri_decode(NULL, &boot);
     CU_ASSERT_PTR_NULL(uri);
     lwm2m_free(uri);
 
     /* "/9050/11/0" */
-    uri = lwm2m_decode_uri(NULL, &oID);
+    uri = uri_decode(NULL, &oID);
     CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
     CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID | LWM2M_URI_FLAG_RESOURCE_ID);
     CU_ASSERT_EQUAL(uri->objectId, 9050);
@@ -79,7 +78,7 @@ static void test_uri_decode(void)
     lwm2m_free(uri);
 
     /* "/11/0" */
-    uri = lwm2m_decode_uri(NULL, &iID);
+    uri = uri_decode(NULL, &iID);
     CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
     CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID);
     CU_ASSERT_EQUAL(uri->objectId, 11);
@@ -87,7 +86,7 @@ static void test_uri_decode(void)
     lwm2m_free(uri);
 
     /* "/0" */
-    uri = lwm2m_decode_uri(NULL, &rID);
+    uri = uri_decode(NULL, &rID);
     CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
     CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID);
     CU_ASSERT_EQUAL(uri->objectId, 0);
@@ -95,13 +94,13 @@ static void test_uri_decode(void)
 
     /* "/9050/11/0/555" */
     rID.next = &extraID;
-    uri = lwm2m_decode_uri(NULL, &oID);
+    uri = uri_decode(NULL, &oID);
     CU_ASSERT_PTR_NULL(uri);
     lwm2m_free(uri);
 
     /* "/0/5a3f" */
     rID.next = &location;
-    uri = lwm2m_decode_uri(NULL, &rID);
+    uri = uri_decode(NULL, &rID);
     CU_ASSERT_PTR_NULL(uri);
     lwm2m_free(uri);
 


### PR DESCRIPTION
Move unused APIs from liblwm2m.h to internals.h
Make more functions statics
Normalize names:
- APIs are named ```lwm2m_[snake_case]``` (eg. ```lwm2m_add_object()```)
- internal functions are named ```[file]_[hungarianNotation]``` (eg. ```observe_handleRequest()```)
- static functions are named ```prv_[hungarianNotation]``` (eg. ```prv_getHeaderLength()```)