### PR TITLE
lwm2m_data_t rework

### DIFF
--- a/core/data.c
+++ b/core/data.c
@@ -58,10 +58,9 @@ static int prv_textSerialize(lwm2m_data_t * dataP,
         return (int)utils_boolToPlainText(value, bufferP);
     }
 
-    case LWM2M_TYPE_OPAQUE:
-        // TODO: base64 encoding
     case LWM2M_TYPE_OBJECT_LINK:
         // TODO: implement
+    case LWM2M_TYPE_OPAQUE:
     case LWM2M_TYPE_UNDEFINED:
     default:
         return 0;
@@ -328,6 +327,11 @@ int lwm2m_data_serialize(lwm2m_uri_t * uriP,
             *formatP = LWM2M_CONTENT_TLV;
 #endif
         }
+    }
+    if (*formatP == LWM2M_CONTENT_TEXT
+     && dataP->dataType == LWM2M_TYPE_OPAQUE)
+    {
+        *formatP = LWM2M_CONTENT_OPAQUE;
     }
 
     switch (*formatP)

--- a/core/data.c
+++ b/core/data.c
@@ -96,7 +96,7 @@ void lwm2m_data_free(int size,
         case LWM2M_TYPE_MULTIPLE_RESOURCE:
         case LWM2M_TYPE_OBJECT_INSTANCE:
         case LWM2M_TYPE_OBJECT:
-            lwm2m_data_free(dataP[i].value.asChildren.num, dataP[i].value.asChildren.array);
+            lwm2m_data_free(dataP[i].value.asChildren.count, dataP[i].value.asChildren.array);
             break;
 
         case LWM2M_TYPE_STRING:
@@ -352,7 +352,7 @@ void lwm2m_data_include(lwm2m_data_t * subDataP,
     default:
         return;
     }
-    dataP->value.asChildren.num = count;
+    dataP->value.asChildren.count = count;
     dataP->value.asChildren.array = subDataP;
 }
 

--- a/core/data.c
+++ b/core/data.c
@@ -146,7 +146,7 @@ void lwm2m_data_encode_string(const char * string,
     }
 }
 
-void lwm2m_data_encode_opaque(int8_t * buffer,
+void lwm2m_data_encode_opaque(uint8_t * buffer,
                               size_t length,
                               lwm2m_data_t * dataP)
 {

--- a/core/data.c
+++ b/core/data.c
@@ -356,6 +356,14 @@ void lwm2m_data_include(lwm2m_data_t * subDataP,
     dataP->value.asChildren.array = subDataP;
 }
 
+void lwm2m_data_encode_instances(lwm2m_data_t * subDataP,
+                                 size_t count,
+                                 lwm2m_data_t * dataP)
+{
+    lwm2m_data_include(subDataP, count, dataP);
+    dataP->type = LWM2M_TYPE_MULTIPLE_RESOURCE;
+}
+
 int lwm2m_data_parse(lwm2m_uri_t * uriP,
                      uint8_t * buffer,
                      size_t bufferLen,

--- a/core/discover.c
+++ b/core/discover.c
@@ -173,7 +173,7 @@ static int prv_serializeLinkData(lwm2m_context_t * contextP,
             memcpy(buffer + head, LINK_ITEM_DIM_START, LINK_ITEM_DIM_START_SIZE);
             head += LINK_ITEM_DIM_START_SIZE;
 
-            res = utils_intToText(tlvP->value.asChildren.num, buffer + head, bufferLen - head);
+            res = utils_intToText(tlvP->value.asChildren.count, buffer + head, bufferLen - head);
             if (res <= 0) return -1;
             head += res;
 
@@ -235,7 +235,7 @@ static int prv_serializeLinkData(lwm2m_context_t * contextP,
         if (res == 0) head = 0;    // rewind
         else head += res - 1;
 
-        for (index = 0; index < tlvP->value.asChildren.num; index++)
+        for (index = 0; index < tlvP->value.asChildren.count; index++)
         {
             res = prv_serializeLinkData(contextP, tlvP->value.asChildren.array + index, &uri, uriStr, uriLen, buffer + head, bufferLen - head);
             if (res < 0) return -1;

--- a/core/internals.h
+++ b/core/internals.h
@@ -143,6 +143,7 @@
 #define ATTR_DIMENSION_LEN       4
 
 #define URI_MAX_STRING_LEN    18      // /65535/65535/65535
+#define _PRV_64BIT_BUFFER_SIZE 8
 
 #define LINK_ITEM_START             "<"
 #define LINK_ITEM_START_SIZE        1
@@ -159,9 +160,6 @@
 
 #define ATTR_FLAG_NUMERIC (uint8_t)(LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP)
 
-#define LWM2M_TLV_HEADER_MAX_LENGTH 6
-#define _PRV_64BIT_BUFFER_SIZE 8
-
 #define LWM2M_URI_FLAG_DM           (uint8_t)0x00
 #define LWM2M_URI_FLAG_DELETE_ALL   (uint8_t)0x10
 #define LWM2M_URI_FLAG_REGISTRATION (uint8_t)0x20
@@ -177,6 +175,14 @@ typedef struct
     void * userData;
 } dm_data_t;
 
+typedef enum
+{
+    URI_DEPTH_OBJECT,
+    URI_DEPTH_OBJECT_INSTANCE,
+    URI_DEPTH_RESOURCE,
+    URI_DEPTH_RESOURCE_INSTANCE
+} uri_depth_t;
+
 #ifdef LWM2M_BOOTSTRAP_SERVER_MODE
 typedef struct
 {
@@ -190,7 +196,7 @@ typedef struct
 // defined in uri.c
 lwm2m_uri_t * uri_decode(char * altPath, multi_option_t *uriPath);
 int uri_getNumber(uint8_t * uriString, size_t uriLength);
-int uri_toString(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, lwm2m_tlv_type_t * depthP);
+int uri_toString(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, uri_depth_t * depthP);
 
 // defined in objects.c
 coap_status_t object_readData(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);
@@ -250,12 +256,12 @@ lwm2m_status_t bootstrap_getStatus(lwm2m_context_t * contextP);
 
 // defined in tlv.c
 int tlv_parse(uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
-int tlv_serialize(int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
+size_t tlv_serialize(bool isResourceInstance, int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
 
 // defined in json.c
 #ifdef LWM2M_SUPPORT_JSON
 int json_parse(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
-int json_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * tlvP, uint8_t ** bufferP);
+size_t json_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * tlvP, uint8_t ** bufferP);
 #endif
 
 // defined in discover.c

--- a/core/internals.h
+++ b/core/internals.h
@@ -278,6 +278,9 @@ void utils_copyValue(void * dst, const void * src, size_t len);
 int utils_opaqueToInt(const uint8_t * buffer, size_t buffer_len, int64_t * dataP);
 int utils_opaqueToFloat(const uint8_t * buffer, size_t buffer_len, double * dataP);
 size_t utils_encodeInt(int64_t data, uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE]);
+size_t utils_base64ToOpaque(uint8_t * dataP, size_t dataLen, uint8_t ** bufferP);
+size_t utils_opaqueToBase64(uint8_t * dataP, size_t dataLen, uint8_t ** bufferP);
+size_t utils_base64Encode(uint8_t * dataP, size_t dataLen, uint8_t * bufferP, size_t bufferLen);
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * utils_findServer(lwm2m_context_t * contextP, void * fromSessionH);
 lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP, void * fromSessionH);

--- a/core/json.c
+++ b/core/json.c
@@ -1105,19 +1105,17 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
     break;
 
     case LWM2M_TYPE_OPAQUE:
-        // TODO: base64 encoding
         if (bufferLen < JSON_ITEM_STRING_BEGIN_SIZE) return -1;
         memcpy(buffer, JSON_ITEM_STRING_BEGIN, JSON_ITEM_STRING_BEGIN_SIZE);
         head = JSON_ITEM_STRING_BEGIN_SIZE;
 
-        if (bufferLen - head < tlvP->length) return -1;
-        memcpy(buffer + head, tlvP->value, tlvP->length);
-        head += tlvP->length;
+        res = utils_base64Encode(tlvP->value, tlvP->length, buffer, bufferLen - head);
+        if (res == 0) return -1;
+        head += res;
 
         if (bufferLen - head < JSON_ITEM_STRING_END_SIZE) return -1;
         memcpy(buffer + head, JSON_ITEM_STRING_END, JSON_ITEM_STRING_END_SIZE);
         head += JSON_ITEM_STRING_END_SIZE;
-
         break;
 
     case LWM2M_TYPE_OBJECT_LINK:

--- a/core/json.c
+++ b/core/json.c
@@ -526,6 +526,34 @@ static uri_depth_t prv_decreaseLevel(uri_depth_t level)
     }
 }
 
+static uri_depth_t prv_typeToLevel(lwm2m_data_type_t type)
+{
+    switch (type)
+    {
+    case LWM2M_TYPE_OBJECT:
+        return URI_DEPTH_OBJECT;
+
+    case LWM2M_TYPE_OBJECT_INSTANCE:
+        return URI_DEPTH_OBJECT_INSTANCE;
+
+    case LWM2M_TYPE_MULTIPLE_RESOURCE:
+        return URI_DEPTH_RESOURCE;
+
+
+    case LWM2M_TYPE_STRING:
+    case LWM2M_TYPE_INTEGER:
+    case LWM2M_TYPE_FLOAT:
+    case LWM2M_TYPE_BOOLEAN:
+    case LWM2M_TYPE_OPAQUE:
+    case LWM2M_TYPE_OBJECT_LINK:
+        return URI_DEPTH_RESOURCE;
+
+    case LWM2M_TYPE_UNDEFINED:
+    default:
+        return URI_DEPTH_RESOURCE;
+    }
+}
+
 static lwm2m_data_t * prv_extendData(lwm2m_data_t * parentP)
 {
     lwm2m_data_t * newP;
@@ -1220,7 +1248,7 @@ size_t json_serialize(lwm2m_uri_t * uriP,
         // check that data is consistent
         for (index = 0 ; index < size ; index++)
         {
-            if (tlvP[index].type != rootLevel)
+            if (prv_typeToLevel(tlvP[index].type) != rootLevel)
             {
                 if (rootLevel != URI_DEPTH_RESOURCE
                  || tlvP[index].type != LWM2M_TYPE_MULTIPLE_RESOURCE)

--- a/core/json.c
+++ b/core/json.c
@@ -479,7 +479,7 @@ static bool prv_convertValue(_record_t * recordP,
 
         // TODO: Copy string instead of pointing to it
     case _TYPE_STRING:
-        targetP->flags = LWM2M_TLV_FLAG_STATIC_DATA | LWM2M_TLV_FLAG_TEXT_FORMAT;
+        targetP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
         targetP->dataType = LWM2M_TYPE_STRING;      // or opaque ?
         targetP->length = recordP->valueLen;
         targetP->value = recordP->value;

--- a/core/json.c
+++ b/core/json.c
@@ -477,12 +477,9 @@ static bool prv_convertValue(_record_t * recordP,
     }
     break;
 
-        // TODO: Copy string instead of pointing to it
     case _TYPE_STRING:
-        targetP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        targetP->dataType = LWM2M_TYPE_STRING;      // or opaque ?
-        targetP->length = recordP->valueLen;
-        targetP->value = recordP->value;
+        lwm2m_data_encode_opaque(recordP->value, recordP->valueLen, targetP);
+        targetP->type = LWM2M_TYPE_STRING;
         break;
 
     case _TYPE_UNSET:
@@ -502,7 +499,7 @@ static lwm2m_data_t * prv_findDataItem(lwm2m_data_t * listP,
     i = 0;
     while (i < count)
     {
-        if (listP[i].length != 0 && listP[i].id == id)
+        if (listP[i].type == LWM2M_TYPE_UNDEFINED && listP[i].id == id)
         {
             return listP + i;
         }
@@ -512,20 +509,20 @@ static lwm2m_data_t * prv_findDataItem(lwm2m_data_t * listP,
     return NULL;
 }
 
-static lwm2m_tlv_type_t prv_decreaseLevel(lwm2m_tlv_type_t level)
+static uri_depth_t prv_decreaseLevel(uri_depth_t level)
 {
     switch(level)
     {
-    case LWM2M_TYPE_OBJECT:
-        return LWM2M_TYPE_OBJECT_INSTANCE;
-    case LWM2M_TYPE_OBJECT_INSTANCE:
-        return LWM2M_TYPE_RESOURCE;
-    case LWM2M_TYPE_RESOURCE:
-        return LWM2M_TYPE_RESOURCE_INSTANCE;
-    case LWM2M_TYPE_RESOURCE_INSTANCE:
-        return LWM2M_TYPE_RESOURCE_INSTANCE;
+    case URI_DEPTH_OBJECT:
+        return URI_DEPTH_OBJECT_INSTANCE;
+    case URI_DEPTH_OBJECT_INSTANCE:
+        return URI_DEPTH_RESOURCE;
+    case URI_DEPTH_RESOURCE:
+        return URI_DEPTH_RESOURCE_INSTANCE;
+    case URI_DEPTH_RESOURCE_INSTANCE:
+        return URI_DEPTH_RESOURCE_INSTANCE;
     default:
-        return LWM2M_TYPE_RESOURCE;
+        return URI_DEPTH_RESOURCE;
     }
 }
 
@@ -533,17 +530,17 @@ static lwm2m_data_t * prv_extendData(lwm2m_data_t * parentP)
 {
     lwm2m_data_t * newP;
 
-    newP = lwm2m_data_new(parentP->length + 1);
+    newP = lwm2m_data_new(parentP->value.asChildren.num + 1);
     if (newP == NULL) return NULL;
-    if (parentP->value != NULL)
+    if (parentP->value.asChildren.array != NULL)
     {
-        memcpy(newP, parentP->value, parentP->length * sizeof(lwm2m_data_t));
-        lwm2m_free(parentP->value);     // do not use lwm2m_data_free() to keep pointed values
+        memcpy(newP, parentP->value.asChildren.array, parentP->value.asChildren.num * sizeof(lwm2m_data_t));
+        lwm2m_free(parentP->value.asChildren.array);     // do not use lwm2m_data_free() to keep pointed values
     }
-    parentP->value = (uint8_t *)newP;
-    parentP->length += 1;
+    parentP->value.asChildren.array = newP;
+    parentP->value.asChildren.num += 1;
 
-    return newP + parentP->length - 1;
+    return newP + parentP->value.asChildren.num - 1;
 }
 
 static int prv_convertRecord(lwm2m_uri_t * uriP,
@@ -555,14 +552,14 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
     int freeIndex;
     lwm2m_data_t * rootP;
     int size;
-    lwm2m_tlv_type_t rootLevel;
+    uri_depth_t rootLevel;
 
     if (uriP == NULL)
     {
         size = count;
         *dataP = lwm2m_data_new(count);
         if (NULL == *dataP) return -1;
-        rootLevel = LWM2M_TYPE_OBJECT;
+        rootLevel = URI_DEPTH_OBJECT;
         rootP = *dataP;
     }
     else
@@ -572,33 +569,34 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
 
         *dataP = lwm2m_data_new(1);
         if (NULL == *dataP) return -1;
-        ((lwm2m_data_t *)*dataP)->type = LWM2M_TYPE_OBJECT;
-        ((lwm2m_data_t *)*dataP)->id = uriP->objectId;
+        (*dataP)->type = LWM2M_TYPE_OBJECT;
+        (*dataP)->id = uriP->objectId;
+        rootLevel = URI_DEPTH_OBJECT_INSTANCE;
         parentP = *dataP;
         if (LWM2M_URI_IS_SET_INSTANCE(uriP))
         {
-            parentP->length = 1;
-            parentP->value = (uint8_t *)lwm2m_data_new(1);
-            if (NULL == parentP->value) goto error;
-            parentP = (lwm2m_data_t *)parentP->value;
+            parentP->value.asChildren.num = 1;
+            parentP->value.asChildren.array = lwm2m_data_new(1);
+            if (NULL == parentP->value.asChildren.array) goto error;
+            parentP = parentP->value.asChildren.array;
             parentP->type = LWM2M_TYPE_OBJECT_INSTANCE;
             parentP->id = uriP->instanceId;
-            rootLevel = LWM2M_TYPE_RESOURCE;
+            rootLevel = URI_DEPTH_RESOURCE;
             if (LWM2M_URI_IS_SET_RESOURCE(uriP))
             {
-                parentP->length = 1;
-                parentP->value = (uint8_t *)lwm2m_data_new(1);
-                if (NULL == parentP->value) goto error;
-                parentP = (lwm2m_data_t *)parentP->value;
-                parentP->type = LWM2M_TYPE_RESOURCE;
+                parentP->value.asChildren.num = 1;
+                parentP->value.asChildren.array = lwm2m_data_new(1);
+                if (NULL == parentP->value.asChildren.array) goto error;
+                parentP = parentP->value.asChildren.array;
+                parentP->type = LWM2M_TYPE_UNDEFINED;
                 parentP->id = uriP->resourceId;
-                rootLevel = LWM2M_TYPE_RESOURCE_INSTANCE;
+                rootLevel = URI_DEPTH_RESOURCE_INSTANCE;
             }
         }
-        parentP->length = count;
-        parentP->value = (uint8_t *)lwm2m_data_new(count);
-        if (NULL == parentP->value) goto error;
-        rootP = (lwm2m_data_t *)parentP->value;
+        parentP->value.asChildren.num = count;
+        parentP->value.asChildren.array = lwm2m_data_new(count);
+        if (NULL == parentP->value.asChildren.array) goto error;
+        rootP = parentP->value.asChildren.array;
     }
 
     freeIndex = 0;
@@ -612,16 +610,16 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
         // resSegmentIndex is set to the resource segment position
         switch(rootLevel)
         {
-        case LWM2M_TYPE_OBJECT:
+        case URI_DEPTH_OBJECT:
             resSegmentIndex = 2;
             break;
-        case LWM2M_TYPE_OBJECT_INSTANCE:
+        case URI_DEPTH_OBJECT_INSTANCE:
             resSegmentIndex = 1;
             break;
-        case LWM2M_TYPE_RESOURCE:
+        case URI_DEPTH_RESOURCE:
             resSegmentIndex = 0;
             break;
-        case LWM2M_TYPE_RESOURCE_INSTANCE:
+        case URI_DEPTH_RESOURCE_INSTANCE:
             resSegmentIndex = -1;
             break;
         default:
@@ -647,13 +645,13 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
         if (recordArray[index].ids[1] != LWM2M_MAX_ID)
         {
             lwm2m_data_t * parentP;
-            lwm2m_tlv_type_t level;
+            uri_depth_t level;
 
             parentP = targetP;
             level = prv_decreaseLevel(rootLevel);
             for (i = 1 ; i <= resSegmentIndex ; i++)
             {
-                targetP = prv_findDataItem((lwm2m_data_t *)parentP->value, parentP->length, recordArray[index].ids[i]);
+                targetP = prv_findDataItem(parentP->value.asChildren.array, parentP->value.asChildren.num, recordArray[index].ids[i]);
                 if (targetP == NULL)
                 {
                     targetP = prv_extendData(parentP);
@@ -670,9 +668,8 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
                 targetP = prv_extendData(targetP);
                 if (targetP == NULL) goto error;
                 targetP->id = recordArray[index].ids[resSegmentIndex + 1];
-                targetP->type = LWM2M_TYPE_RESOURCE_INSTANCE;
+                targetP->type = LWM2M_TYPE_UNDEFINED;
             }
-
         }
 
         if (true != prv_convertValue(recordArray + index, targetP)) goto error;
@@ -698,7 +695,7 @@ static int prv_dataStrip(int size,
     realSize = 0;
     for (i = 0 ; i < size ; i++)
     {
-        if (dataP[i].length != 0)
+        if (dataP[i].type != LWM2M_TYPE_UNDEFINED)
         {
             realSize++;
         }
@@ -710,16 +707,17 @@ static int prv_dataStrip(int size,
     j = 0;
     for (i = 0 ; i < size ; i++)
     {
-        if (dataP[i].length != 0)
+        if (dataP[i].type != LWM2M_TYPE_UNDEFINED)
         {
             memcpy((*resultP) + j, dataP + i, sizeof(lwm2m_data_t));
 
-            if (dataP[i].type != LWM2M_TYPE_RESOURCE
-             && dataP[i].type != LWM2M_TYPE_RESOURCE_INSTANCE)
+            if (dataP[i].type == LWM2M_TYPE_OBJECT
+             || dataP[i].type == LWM2M_TYPE_OBJECT_INSTANCE
+             || dataP[i].type == LWM2M_TYPE_MULTIPLE_RESOURCE)
             {
                 int childLen;
 
-                childLen = prv_dataStrip(dataP[i].length, (lwm2m_data_t *)dataP[i].value, (lwm2m_data_t **)&((*resultP)[j].value));
+                childLen = prv_dataStrip(dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, &((*resultP)[j].value.asChildren.array));
                 if (childLen <= 0)
                 {
                     // skip this one
@@ -727,12 +725,12 @@ static int prv_dataStrip(int size,
                 }
                 else
                 {
-                    (*resultP)[j].length = childLen;
+                    (*resultP)[j].value.asChildren.num = childLen;
                 }
             }
             else
             {
-                dataP[i].value = NULL;
+                dataP[i].value.asBuffer.buffer = NULL;
             }
 
             j++;
@@ -931,8 +929,8 @@ int json_parse(lwm2m_uri_t * uriP,
             if (parsedP->type != LWM2M_TYPE_OBJECT || parsedP->id != uriP->objectId) goto error;
             if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
             {
-                size = parsedP->length;
-                resultP = (lwm2m_data_t *)(parsedP->value);
+                size = parsedP->value.asChildren.num;
+                resultP = parsedP->value.asChildren.array;
             }
             else
             {
@@ -940,15 +938,15 @@ int json_parse(lwm2m_uri_t * uriP,
 
                 resultP = NULL;
                 // be permissive and allow full object JSON when requesting for a single instance
-                for (i = 0 ; i < parsedP->length && resultP == NULL; i++)
+                for (i = 0 ; i < parsedP->value.asChildren.num && resultP == NULL; i++)
                 {
                     lwm2m_data_t * targetP;
 
-                    targetP = (lwm2m_data_t *)(parsedP->value) + i;
+                    targetP = parsedP->value.asChildren.array + i;
                     if (targetP->id == uriP->instanceId)
                     {
-                        resultP = ((lwm2m_data_t *)(targetP->value));
-                        size = targetP->length;
+                        resultP = targetP->value.asChildren.array;
+                        size = targetP->value.asChildren.num;
                     }
                 }
                 if (resultP == NULL) goto error;
@@ -966,8 +964,8 @@ int json_parse(lwm2m_uri_t * uriP,
                         {
                             if (targetP->type == LWM2M_TYPE_MULTIPLE_RESOURCE)
                             {
-                                resP = (lwm2m_data_t *)(targetP->value);
-                                size = targetP->length;
+                                resP = targetP->value.asChildren.array;
+                                size = targetP->value.asChildren.num;
                             }
                             else
                             {
@@ -1025,16 +1023,16 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
     int res;
     int head;
 
-    switch (tlvP->dataType)
+    switch (tlvP->type)
     {
     case LWM2M_TYPE_STRING:
         if (bufferLen < JSON_ITEM_STRING_BEGIN_SIZE) return -1;
         memcpy(buffer, JSON_ITEM_STRING_BEGIN, JSON_ITEM_STRING_BEGIN_SIZE);
         head = JSON_ITEM_STRING_BEGIN_SIZE;
 
-        if (bufferLen - head < tlvP->length) return -1;
-        memcpy(buffer + head, tlvP->value, tlvP->length);
-        head += tlvP->length;
+        if (bufferLen - head < tlvP->value.asBuffer.length) return -1;
+        memcpy(buffer + head, tlvP->value.asBuffer.buffer, tlvP->value.asBuffer.length);
+        head += tlvP->value.asBuffer.length;
 
         if (bufferLen - head < JSON_ITEM_STRING_END_SIZE) return -1;
         memcpy(buffer + head, JSON_ITEM_STRING_END, JSON_ITEM_STRING_END_SIZE);
@@ -1043,7 +1041,6 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
         break;
 
     case LWM2M_TYPE_INTEGER:
-    case LWM2M_TYPE_TIME:
     {
         int64_t value;
 
@@ -1109,7 +1106,7 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
         memcpy(buffer, JSON_ITEM_STRING_BEGIN, JSON_ITEM_STRING_BEGIN_SIZE);
         head = JSON_ITEM_STRING_BEGIN_SIZE;
 
-        res = utils_base64Encode(tlvP->value, tlvP->length, buffer, bufferLen - head);
+        res = utils_base64Encode(tlvP->value.asBuffer.buffer, tlvP->value.asBuffer.length, buffer, bufferLen - head);
         if (res == 0) return -1;
         head += res;
 
@@ -1142,28 +1139,6 @@ int prv_serializeData(lwm2m_data_t * tlvP,
 
     switch (tlvP->type)
     {
-    case LWM2M_TYPE_RESOURCE_INSTANCE:
-    case LWM2M_TYPE_RESOURCE:
-        if (bufferLen < JSON_RES_ITEM_URI_SIZE) return -1;
-        memcpy(buffer, JSON_RES_ITEM_URI, JSON_RES_ITEM_URI_SIZE);
-        head = JSON_RES_ITEM_URI_SIZE;
-
-        if (parentUriLen > 0)
-        {
-            if (bufferLen - head < parentUriLen) return -1;
-            memcpy(buffer + head, parentUriStr, parentUriLen);
-            head += parentUriLen;
-        }
-
-        res = utils_intToText(tlvP->id, buffer + head, bufferLen - head);
-        if (res <= 0) return -1;
-        head += res;
-
-        res = prv_serializeValue(tlvP, buffer + head, bufferLen - head);
-        if (res < 0) return -1;
-        head += res;
-        break;
-
     case LWM2M_TYPE_OBJECT:
     case LWM2M_TYPE_OBJECT_INSTANCE:
     case LWM2M_TYPE_MULTIPLE_RESOURCE:
@@ -1189,9 +1164,9 @@ int prv_serializeData(lwm2m_data_t * tlvP,
         uriLen++;
 
         head = 0;
-        for (index = 0 ; index < tlvP->length ; index++)
+        for (index = 0 ; index < tlvP->value.asChildren.num; index++)
         {
-            res = prv_serializeData(((lwm2m_data_t *)tlvP->value) + index, uriStr, uriLen, buffer + head, bufferLen - head);
+            res = prv_serializeData(tlvP->value.asChildren.array + index, uriStr, uriLen, buffer + head, bufferLen - head);
             if (res < 0) return -1;
             head += res;
         }
@@ -1199,29 +1174,46 @@ int prv_serializeData(lwm2m_data_t * tlvP,
     break;
 
     default:
-        return -1;
+        if (bufferLen < JSON_RES_ITEM_URI_SIZE) return -1;
+        memcpy(buffer, JSON_RES_ITEM_URI, JSON_RES_ITEM_URI_SIZE);
+        head = JSON_RES_ITEM_URI_SIZE;
+
+        if (parentUriLen > 0)
+        {
+            if (bufferLen - head < parentUriLen) return -1;
+            memcpy(buffer + head, parentUriStr, parentUriLen);
+            head += parentUriLen;
+        }
+
+        res = utils_intToText(tlvP->id, buffer + head, bufferLen - head);
+        if (res <= 0) return -1;
+        head += res;
+
+        res = prv_serializeValue(tlvP, buffer + head, bufferLen - head);
+        if (res < 0) return -1;
+        head += res;
+        break;
     }
 
     return head;
 }
 
-int json_serialize(lwm2m_uri_t * uriP,
-                   int size,
-                   lwm2m_data_t * tlvP,
-                   uint8_t ** bufferP)
+size_t json_serialize(lwm2m_uri_t * uriP,
+                      int size,
+                      lwm2m_data_t * tlvP,
+                      uint8_t ** bufferP)
 {
     int index;
     size_t head;
     uint8_t bufferJSON[PRV_JSON_BUFFER_SIZE];
     char baseUriStr[URI_MAX_STRING_LEN];
     size_t baseUriLen;
-    lwm2m_tlv_type_t rootLevel;
+    uri_depth_t rootLevel;
 
-    if (size == 0) return 0;
-    if (tlvP == NULL) return -1;
+    if (size == 0 || tlvP == NULL) return 0;
 
     baseUriLen = uri_toString(uriP, baseUriStr, URI_MAX_STRING_LEN, &rootLevel);
-    if (baseUriLen < 0) return -1;
+    if (baseUriLen < 0) return 0;
 
     if (baseUriLen > 0)
     {
@@ -1230,27 +1222,27 @@ int json_serialize(lwm2m_uri_t * uriP,
         {
             if (tlvP[index].type != rootLevel)
             {
-                if (rootLevel != LWM2M_TYPE_RESOURCE
+                if (rootLevel != URI_DEPTH_RESOURCE
                  || tlvP[index].type != LWM2M_TYPE_MULTIPLE_RESOURCE)
                 {
-                    return -1;
+                    return 0;
                 }
             }
         }
     }
 
     while (size == 1
-    && tlvP->type != LWM2M_TYPE_RESOURCE
-    && tlvP->type != LWM2M_TYPE_RESOURCE_INSTANCE)
+        && tlvP->type != URI_DEPTH_RESOURCE
+        && tlvP->type != URI_DEPTH_RESOURCE_INSTANCE)
     {
         int res;
 
         res = utils_intToText(tlvP->id, baseUriStr + baseUriLen, URI_MAX_STRING_LEN - baseUriLen);
-        if (res <= 0) return -1;
+        if (res <= 0) return 0;
         baseUriLen += res;
-        if (baseUriLen >= URI_MAX_STRING_LEN -1) return -1;
-        size = tlvP->length;
-        tlvP = (lwm2m_data_t *)(tlvP->value);
+        if (baseUriLen >= URI_MAX_STRING_LEN -1) return 0;
+        size = tlvP->value.asChildren.num;
+        tlvP = tlvP->value.asChildren.array;
         baseUriStr[baseUriLen] = '/';
         baseUriLen++;
     }
@@ -1275,11 +1267,11 @@ int json_serialize(lwm2m_uri_t * uriP,
         int res;
 
         res = prv_serializeData(tlvP + index, NULL, 0, bufferJSON + head, PRV_JSON_BUFFER_SIZE - head);
-        if (res < 0) return -1;
+        if (res < 0) return 0;
         head += res;
     }
 
-    if (head + JSON_FOOTER_SIZE - 1 > PRV_JSON_BUFFER_SIZE) return -1;
+    if (head + JSON_FOOTER_SIZE - 1 > PRV_JSON_BUFFER_SIZE) return 0;
 
     memcpy(bufferJSON + head - 1, JSON_FOOTER, JSON_FOOTER_SIZE);
     head = head - 1 + JSON_FOOTER_SIZE;
@@ -1288,7 +1280,7 @@ int json_serialize(lwm2m_uri_t * uriP,
     if (*bufferP == NULL) return 0;
     memcpy(*bufferP, bufferJSON, head);
 
-    return (int)head;
+    return head;
 }
 
 #endif

--- a/core/json.c
+++ b/core/json.c
@@ -558,17 +558,17 @@ static lwm2m_data_t * prv_extendData(lwm2m_data_t * parentP)
 {
     lwm2m_data_t * newP;
 
-    newP = lwm2m_data_new(parentP->value.asChildren.num + 1);
+    newP = lwm2m_data_new(parentP->value.asChildren.count + 1);
     if (newP == NULL) return NULL;
     if (parentP->value.asChildren.array != NULL)
     {
-        memcpy(newP, parentP->value.asChildren.array, parentP->value.asChildren.num * sizeof(lwm2m_data_t));
+        memcpy(newP, parentP->value.asChildren.array, parentP->value.asChildren.count * sizeof(lwm2m_data_t));
         lwm2m_free(parentP->value.asChildren.array);     // do not use lwm2m_data_free() to keep pointed values
     }
     parentP->value.asChildren.array = newP;
-    parentP->value.asChildren.num += 1;
+    parentP->value.asChildren.count += 1;
 
-    return newP + parentP->value.asChildren.num - 1;
+    return newP + parentP->value.asChildren.count - 1;
 }
 
 static int prv_convertRecord(lwm2m_uri_t * uriP,
@@ -603,7 +603,7 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
         parentP = *dataP;
         if (LWM2M_URI_IS_SET_INSTANCE(uriP))
         {
-            parentP->value.asChildren.num = 1;
+            parentP->value.asChildren.count = 1;
             parentP->value.asChildren.array = lwm2m_data_new(1);
             if (NULL == parentP->value.asChildren.array) goto error;
             parentP = parentP->value.asChildren.array;
@@ -612,7 +612,7 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
             rootLevel = URI_DEPTH_RESOURCE;
             if (LWM2M_URI_IS_SET_RESOURCE(uriP))
             {
-                parentP->value.asChildren.num = 1;
+                parentP->value.asChildren.count = 1;
                 parentP->value.asChildren.array = lwm2m_data_new(1);
                 if (NULL == parentP->value.asChildren.array) goto error;
                 parentP = parentP->value.asChildren.array;
@@ -621,7 +621,7 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
                 rootLevel = URI_DEPTH_RESOURCE_INSTANCE;
             }
         }
-        parentP->value.asChildren.num = count;
+        parentP->value.asChildren.count = count;
         parentP->value.asChildren.array = lwm2m_data_new(count);
         if (NULL == parentP->value.asChildren.array) goto error;
         rootP = parentP->value.asChildren.array;
@@ -679,7 +679,7 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
             level = prv_decreaseLevel(rootLevel);
             for (i = 1 ; i <= resSegmentIndex ; i++)
             {
-                targetP = prv_findDataItem(parentP->value.asChildren.array, parentP->value.asChildren.num, recordArray[index].ids[i]);
+                targetP = prv_findDataItem(parentP->value.asChildren.array, parentP->value.asChildren.count, recordArray[index].ids[i]);
                 if (targetP == NULL)
                 {
                     targetP = prv_extendData(parentP);
@@ -745,7 +745,7 @@ static int prv_dataStrip(int size,
             {
                 int childLen;
 
-                childLen = prv_dataStrip(dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, &((*resultP)[j].value.asChildren.array));
+                childLen = prv_dataStrip(dataP[i].value.asChildren.count, dataP[i].value.asChildren.array, &((*resultP)[j].value.asChildren.array));
                 if (childLen <= 0)
                 {
                     // skip this one
@@ -753,7 +753,7 @@ static int prv_dataStrip(int size,
                 }
                 else
                 {
-                    (*resultP)[j].value.asChildren.num = childLen;
+                    (*resultP)[j].value.asChildren.count = childLen;
                 }
             }
             else
@@ -957,7 +957,7 @@ int json_parse(lwm2m_uri_t * uriP,
             if (parsedP->type != LWM2M_TYPE_OBJECT || parsedP->id != uriP->objectId) goto error;
             if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
             {
-                size = parsedP->value.asChildren.num;
+                size = parsedP->value.asChildren.count;
                 resultP = parsedP->value.asChildren.array;
             }
             else
@@ -966,7 +966,7 @@ int json_parse(lwm2m_uri_t * uriP,
 
                 resultP = NULL;
                 // be permissive and allow full object JSON when requesting for a single instance
-                for (i = 0 ; i < parsedP->value.asChildren.num && resultP == NULL; i++)
+                for (i = 0 ; i < parsedP->value.asChildren.count && resultP == NULL; i++)
                 {
                     lwm2m_data_t * targetP;
 
@@ -974,7 +974,7 @@ int json_parse(lwm2m_uri_t * uriP,
                     if (targetP->id == uriP->instanceId)
                     {
                         resultP = targetP->value.asChildren.array;
-                        size = targetP->value.asChildren.num;
+                        size = targetP->value.asChildren.count;
                     }
                 }
                 if (resultP == NULL) goto error;
@@ -993,7 +993,7 @@ int json_parse(lwm2m_uri_t * uriP,
                             if (targetP->type == LWM2M_TYPE_MULTIPLE_RESOURCE)
                             {
                                 resP = targetP->value.asChildren.array;
-                                size = targetP->value.asChildren.num;
+                                size = targetP->value.asChildren.count;
                             }
                             else
                             {
@@ -1192,7 +1192,7 @@ int prv_serializeData(lwm2m_data_t * tlvP,
         uriLen++;
 
         head = 0;
-        for (index = 0 ; index < tlvP->value.asChildren.num; index++)
+        for (index = 0 ; index < tlvP->value.asChildren.count; index++)
         {
             res = prv_serializeData(tlvP->value.asChildren.array + index, uriStr, uriLen, buffer + head, bufferLen - head);
             if (res < 0) return -1;
@@ -1281,7 +1281,7 @@ static size_t prv_findAndCheckData(lwm2m_uri_t * uriP,
             {
                 if (tlvP[index].id == uriP->objectId)
                 {
-                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.num, tlvP[index].value.asChildren.array, targetP);
+                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.count, tlvP[index].value.asChildren.array, targetP);
                 }
             }
             break;
@@ -1302,7 +1302,7 @@ static size_t prv_findAndCheckData(lwm2m_uri_t * uriP,
             {
                 if (tlvP[index].id == uriP->objectId)
                 {
-                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.num, tlvP[index].value.asChildren.array, targetP);
+                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.count, tlvP[index].value.asChildren.array, targetP);
                 }
             }
             break;
@@ -1311,7 +1311,7 @@ static size_t prv_findAndCheckData(lwm2m_uri_t * uriP,
             {
                 if (tlvP[index].id == uriP->instanceId)
                 {
-                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.num, tlvP[index].value.asChildren.array, targetP);
+                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.count, tlvP[index].value.asChildren.array, targetP);
                 }
             }
             break;
@@ -1330,7 +1330,7 @@ static size_t prv_findAndCheckData(lwm2m_uri_t * uriP,
             {
                 if (tlvP[index].id == uriP->objectId)
                 {
-                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.num, tlvP[index].value.asChildren.array, targetP);
+                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.count, tlvP[index].value.asChildren.array, targetP);
                 }
             }
             break;
@@ -1339,7 +1339,7 @@ static size_t prv_findAndCheckData(lwm2m_uri_t * uriP,
             {
                 if (tlvP[index].id == uriP->instanceId)
                 {
-                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.num, tlvP[index].value.asChildren.array, targetP);
+                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.count, tlvP[index].value.asChildren.array, targetP);
                 }
             }
             break;
@@ -1348,7 +1348,7 @@ static size_t prv_findAndCheckData(lwm2m_uri_t * uriP,
             {
                 if (tlvP[index].id == uriP->resourceId)
                 {
-                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.num, tlvP[index].value.asChildren.array, targetP);
+                    return prv_findAndCheckData(uriP, level, tlvP[index].value.asChildren.count, tlvP[index].value.asChildren.array, targetP);
                 }
             }
             break;
@@ -1399,7 +1399,7 @@ size_t json_serialize(lwm2m_uri_t * uriP,
         if (res <= 0) return 0;
         baseUriLen += res;
         if (baseUriLen >= URI_MAX_STRING_LEN -1) return 0;
-        num = targetP->value.asChildren.num;
+        num = targetP->value.asChildren.count;
         targetP = targetP->value.asChildren.array;
         baseUriStr[baseUriLen] = '/';
         baseUriLen++;

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -264,11 +264,8 @@ int lwm2m_stringToUri(const char * buffer, size_t buffer_len, lwm2m_uri_t * uriP
  * Bitmask for the lwm2m_data_t::flag
  * LWM2M_TLV_FLAG_STATIC_DATA specifies that lwm2m_data_t::value
  * points to static memory and must no be freeed by the caller.
- * LWM2M_TLV_FLAG_TEXT_FORMAT specifies that lwm2m_data_t::value
- * is expressed or requested in plain text format.
  */
 #define LWM2M_TLV_FLAG_STATIC_DATA   0x01
-#define LWM2M_TLV_FLAG_TEXT_FORMAT   0x02
 
 /*
  * Bits 7 and 6 of assigned values for LWM2M_TYPE_RESOURCE,
@@ -289,6 +286,7 @@ typedef enum
 typedef enum
 {
     LWM2M_TYPE_UNDEFINED = 0,
+    LWM2M_TYPE_AS_TEXT,
     LWM2M_TYPE_STRING,
     LWM2M_TYPE_INTEGER,
     LWM2M_TYPE_FLOAT,

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -324,7 +324,7 @@ void lwm2m_data_free(int size, lwm2m_data_t * dataP);
 
 void lwm2m_data_encode_string(const char * string, lwm2m_data_t * dataP);
 void lwm2m_data_encode_nstring(const char * string, size_t length, lwm2m_data_t * dataP);
-void lwm2m_data_encode_opaque(int8_t * buffer, size_t length, lwm2m_data_t * dataP);
+void lwm2m_data_encode_opaque(uint8_t * buffer, size_t length, lwm2m_data_t * dataP);
 void lwm2m_data_encode_int(int64_t value, lwm2m_data_t * dataP);
 int lwm2m_data_decode_int(const lwm2m_data_t * dataP, int64_t * valueP);
 void lwm2m_data_encode_float(double value, lwm2m_data_t * dataP);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -331,6 +331,7 @@ void lwm2m_data_encode_float(double value, lwm2m_data_t * dataP);
 int lwm2m_data_decode_float(const lwm2m_data_t * dataP, double * valueP);
 void lwm2m_data_encode_bool(bool value, lwm2m_data_t * dataP);
 int lwm2m_data_decode_bool(const lwm2m_data_t * dataP, bool * valueP);
+void lwm2m_data_encode_instances(lwm2m_data_t * subDataP, size_t count, lwm2m_data_t * dataP);
 void lwm2m_data_include(lwm2m_data_t * subDataP, size_t count, lwm2m_data_t * dataP);
 
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -258,53 +258,55 @@ int lwm2m_stringToUri(const char * buffer, size_t buffer_len, lwm2m_uri_t * uriP
 
 /*
  * The lwm2m_data_t is used to store LWM2M resource values in a hierarchical way.
- */
-
-/*
- * Bitmask for the lwm2m_data_t::flag
- * LWM2M_TLV_FLAG_STATIC_DATA specifies that lwm2m_data_t::value
- * points to static memory and must no be freeed by the caller.
- */
-#define LWM2M_TLV_FLAG_STATIC_DATA   0x01
-
-/*
- * Bits 7 and 6 of assigned values for LWM2M_TYPE_RESOURCE,
- * LWM2M_TYPE_MULTIPLE_RESOURCE, LWM2M_TYPE_RESOURCE_INSTANCE
- * and LWM2M_TYPE_OBJECT_INSTANCE must match the ones defined
- * in the TLV format from LWM2M TS §6.3.3
+ * Depending on the type the value is different:
+ * - LWM2M_TYPE_OBJECT, LWM2M_TYPE_OBJECT_INSTANCE, LWM2M_TYPE_MULTIPLE_RESOURCE: value.asChildren
+ * - LWM2M_TYPE_STRING, LWM2M_TYPE_OPAQUE: value.asBuffer
+ * - LWM2M_TYPE_INTEGER, LWM2M_TYPE_TIME: value.asInteger
+ * - LWM2M_TYPE_FLOAT: value.asFloat
+ * - LWM2M_TYPE_BOOLEAN: value.asBoolean
  *
+ * LWM2M_TYPE_STRING is also used when the data is in text format.
  */
-typedef enum
-{
-    LWM2M_TYPE_RESOURCE = 0xC0,
-    LWM2M_TYPE_MULTIPLE_RESOURCE = 0x80,
-    LWM2M_TYPE_RESOURCE_INSTANCE = 0x40,
-    LWM2M_TYPE_OBJECT_INSTANCE = 0x00,
-    LWM2M_TYPE_OBJECT = 0x10
-} lwm2m_tlv_type_t;
 
 typedef enum
 {
     LWM2M_TYPE_UNDEFINED = 0,
-    LWM2M_TYPE_AS_TEXT,
+    LWM2M_TYPE_OBJECT,
+    LWM2M_TYPE_OBJECT_INSTANCE,
+    LWM2M_TYPE_MULTIPLE_RESOURCE,
+
     LWM2M_TYPE_STRING,
+    LWM2M_TYPE_OPAQUE,
     LWM2M_TYPE_INTEGER,
     LWM2M_TYPE_FLOAT,
     LWM2M_TYPE_BOOLEAN,
-    LWM2M_TYPE_OPAQUE,
-    LWM2M_TYPE_TIME,
+
     LWM2M_TYPE_OBJECT_LINK
 } lwm2m_data_type_t;
 
-typedef struct
+typedef struct _lwm2m_data_t lwm2m_data_t;
+
+struct _lwm2m_data_t
 {
-    uint8_t     flags;
-    lwm2m_tlv_type_t  type;
-    lwm2m_data_type_t dataType;
+    lwm2m_data_type_t type;
     uint16_t    id;
-    size_t      length;
-    uint8_t *   value;
-} lwm2m_data_t;
+    union
+    {
+        bool        asBoolean;
+        int64_t     asInteger;
+        double      asFloat;
+        struct
+        {
+            size_t    length;
+            uint8_t * buffer;
+        } asBuffer;
+        struct
+        {
+            size_t         num;
+            lwm2m_data_t * array;
+        } asChildren;
+    } value;
+};
 
 typedef enum
 {
@@ -317,9 +319,12 @@ typedef enum
 
 lwm2m_data_t * lwm2m_data_new(int size);
 int lwm2m_data_parse(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, lwm2m_media_type_t format, lwm2m_data_t ** dataP);
-int lwm2m_data_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * dataP, lwm2m_media_type_t * formatP, uint8_t ** bufferP);
+size_t lwm2m_data_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * dataP, lwm2m_media_type_t * formatP, uint8_t ** bufferP);
 void lwm2m_data_free(int size, lwm2m_data_t * dataP);
 
+void lwm2m_data_encode_string(const char * string, lwm2m_data_t * dataP);
+void lwm2m_data_encode_nstring(const char * string, size_t length, lwm2m_data_t * dataP);
+void lwm2m_data_encode_opaque(int8_t * buffer, size_t length, lwm2m_data_t * dataP);
 void lwm2m_data_encode_int(int64_t value, lwm2m_data_t * dataP);
 int lwm2m_data_decode_int(const lwm2m_data_t * dataP, int64_t * valueP);
 void lwm2m_data_encode_float(double value, lwm2m_data_t * dataP);
@@ -335,7 +340,11 @@ void lwm2m_data_include(lwm2m_data_t * subDataP, size_t count, lwm2m_data_t * da
  * Returned value: number of bytes parsed
  * buffer: buffer to parse
  * buffer_len: length in bytes of buffer
- * oType: (OUT) type of the parsed TLV record
+ * oType: (OUT) type of the parsed TLV record. can be:
+ *          - LWM2M_TYPE_OBJECT
+ *          - LWM2M_TYPE_OBJECT_INSTANCE
+ *          - LWM2M_TYPE_MULTIPLE_RESOURCE
+ *          - LWM2M_TYPE_OPAQUE
  * oID: (OUT) ID of the parsed TLV record
  * oDataIndex: (OUT) index of the data of the parsed TLV record in the buffer
  * oDataLen: (OUT) length of the data of the parsed TLV record
@@ -343,7 +352,7 @@ void lwm2m_data_include(lwm2m_data_t * subDataP, size_t count, lwm2m_data_t * da
 
 #define LWM2M_TLV_HEADER_MAX_LENGTH 6
 
-int lwm2m_decode_TLV(const uint8_t * buffer, size_t buffer_len, lwm2m_tlv_type_t * oType, uint16_t * oID, size_t * oDataIndex, size_t * oDataLen);
+int lwm2m_decode_TLV(const uint8_t * buffer, size_t buffer_len, lwm2m_data_type_t * oType, uint16_t * oID, size_t * oDataIndex, size_t * oDataLen);
 
 
 /*

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -302,7 +302,7 @@ struct _lwm2m_data_t
         } asBuffer;
         struct
         {
-            size_t         num;
+            size_t         count;
             lwm2m_data_t * array;
         } asChildren;
     } value;

--- a/core/objects.c
+++ b/core/objects.c
@@ -192,7 +192,7 @@ coap_status_t object_readData(lwm2m_context_t * contextP,
         i = 0;
         while (instanceP != NULL && result == COAP_205_CONTENT)
         {
-            result = targetP->readFunc(instanceP->id, (int*)&((*dataP)[i].value.asChildren.num), &((*dataP)[i].value.asChildren.array), targetP);
+            result = targetP->readFunc(instanceP->id, (int*)&((*dataP)[i].value.asChildren.count), &((*dataP)[i].value.asChildren.array), targetP);
             (*dataP)[i].type = LWM2M_TYPE_OBJECT_INSTANCE;
             (*dataP)[i].id = instanceP->id;
             i++;
@@ -403,7 +403,7 @@ coap_status_t object_discover(lwm2m_context_t * contextP,
         i = 0;
         while (instanceP != NULL && result == COAP_205_CONTENT)
         {
-            result = targetP->discoverFunc(instanceP->id, (int*)&(dataP[i].value.asChildren.num), &(dataP[i].value.asChildren.array), targetP);
+            result = targetP->discoverFunc(instanceP->id, (int*)&(dataP[i].value.asChildren.count), &(dataP[i].value.asChildren.array), targetP);
             dataP[i].type = LWM2M_TYPE_OBJECT_INSTANCE;
             dataP[i].id = instanceP->id;
             i++;
@@ -757,7 +757,7 @@ coap_status_t object_createInstance(lwm2m_context_t * contextP,
         return COAP_405_METHOD_NOT_ALLOWED;
     }
 
-    result = targetP->createFunc(lwm2m_list_newId(targetP->instanceList), dataP->value.asChildren.num, dataP->value.asChildren.array, targetP);
+    result = targetP->createFunc(lwm2m_list_newId(targetP->instanceList), dataP->value.asChildren.count, dataP->value.asChildren.array, targetP);
 }
 
 coap_status_t object_writeInstance(lwm2m_context_t * contextP,
@@ -775,7 +775,7 @@ coap_status_t object_writeInstance(lwm2m_context_t * contextP,
         return COAP_405_METHOD_NOT_ALLOWED;
     }
 
-    result = targetP->writeFunc(dataP->id, dataP->value.asChildren.num, dataP->value.asChildren.array, targetP);
+    result = targetP->writeFunc(dataP->id, dataP->value.asChildren.count, dataP->value.asChildren.array, targetP);
 }
 
 #endif

--- a/core/observe.c
+++ b/core/observe.c
@@ -184,7 +184,7 @@ coap_status_t observe_handleRequest(lwm2m_context_t * contextP,
 
         if (LWM2M_URI_IS_SET_RESOURCE(uriP))
         {
-            switch (dataP->dataType)
+            switch (dataP->type)
             {
             case LWM2M_TYPE_INTEGER:
                 if (1 != lwm2m_data_decode_int(dataP, &(watcherP->lastValue.asInteger))) return COAP_500_INTERNAL_SERVER_ERROR;
@@ -437,7 +437,7 @@ void observe_step(lwm2m_context_t * contextP,
         if (LWM2M_URI_IS_SET_RESOURCE(&targetP->uri))
         {
             if (COAP_205_CONTENT != object_readData(contextP, &targetP->uri, &size, &dataP)) continue;
-            switch (dataP->dataType)
+            switch (dataP->type)
             {
             case LWM2M_TYPE_INTEGER:
                 if (1 != lwm2m_data_decode_int(dataP, &integerValue)) continue;
@@ -474,7 +474,7 @@ void observe_step(lwm2m_context_t * contextP,
                         if ((watcherP->parameters->toSet & LWM2M_ATTR_FLAG_LESS_THAN) != 0)
                         {
                             // Did we cross the lower treshold ?
-                            switch (dataP->dataType)
+                            switch (dataP->type)
                             {
                             case LWM2M_TYPE_INTEGER:
                                 if ((integerValue <= watcherP->parameters->lessThan
@@ -501,7 +501,7 @@ void observe_step(lwm2m_context_t * contextP,
                         if ((watcherP->parameters->toSet & LWM2M_ATTR_FLAG_GREATER_THAN) != 0)
                         {
                             // Did we cross the upper treshold ?
-                            switch (dataP->dataType)
+                            switch (dataP->type)
                             {
                             case LWM2M_TYPE_INTEGER:
                                 if ((integerValue <= watcherP->parameters->greaterThan
@@ -527,7 +527,7 @@ void observe_step(lwm2m_context_t * contextP,
                         }
                         if ((watcherP->parameters->toSet & LWM2M_ATTR_FLAG_STEP) != 0)
                         {
-                            switch (dataP->dataType)
+                            switch (dataP->type)
                             {
                             case LWM2M_TYPE_INTEGER:
                             {
@@ -620,7 +620,7 @@ void observe_step(lwm2m_context_t * contextP,
                 // Store this value
                 if (notify == true && storeValue == true)
                 {
-                    switch (dataP->dataType)
+                    switch (dataP->type)
                     {
                     case LWM2M_TYPE_INTEGER:
                         watcherP->lastValue.asInteger = integerValue;

--- a/core/tlv.c
+++ b/core/tlv.c
@@ -335,9 +335,7 @@ int tlv_parse(uint8_t * buffer,
         }
         else
         {
-            (*dataP)[size].type = LWM2M_TYPE_OPAQUE;
-            (*dataP)[size].value.asBuffer.length = dataLen;
-            (*dataP)[size].value.asBuffer.buffer = buffer + index + dataIndex;
+            lwm2m_data_encode_opaque(buffer + index + dataIndex, dataLen, (*dataP) + size);
         }
         size++;
         index += result;

--- a/core/tlv.c
+++ b/core/tlv.c
@@ -31,6 +31,65 @@
 #endif
 
 #define _PRV_TLV_TYPE_MASK 0xC0
+#define _PRV_TLV_HEADER_MAX_LENGTH 6
+
+#define _PRV_TLV_TYPE_UNKNOWN           (uint8_t)0xFF
+#define _PRV_TLV_TYPE_OBJECT            (uint8_t)0x10
+#define _PRV_TLV_TYPE_OBJECT_INSTANCE   (uint8_t)0x00
+#define _PRV_TLV_TYPE_RESOURCE          (uint8_t)0xC0
+#define _PRV_TLV_TYPE_MULTIPLE_RESOURCE (uint8_t)0x80
+#define _PRV_TLV_TYPE_RESOURCE_INSTANCE (uint8_t)0x40
+
+
+static uint8_t prv_getHeaderType(lwm2m_data_type_t type)
+{
+    switch (type)
+    {
+    case LWM2M_TYPE_OBJECT:
+        return _PRV_TLV_TYPE_OBJECT;
+
+    case LWM2M_TYPE_OBJECT_INSTANCE:
+        return _PRV_TLV_TYPE_OBJECT_INSTANCE;
+
+    case LWM2M_TYPE_MULTIPLE_RESOURCE:
+        return _PRV_TLV_TYPE_MULTIPLE_RESOURCE;
+
+
+    case LWM2M_TYPE_STRING:
+    case LWM2M_TYPE_INTEGER:
+    case LWM2M_TYPE_FLOAT:
+    case LWM2M_TYPE_BOOLEAN:
+    case LWM2M_TYPE_OPAQUE:
+    case LWM2M_TYPE_OBJECT_LINK:
+        return _PRV_TLV_TYPE_RESOURCE;
+
+    case LWM2M_TYPE_UNDEFINED:
+    default:
+        return _PRV_TLV_TYPE_UNKNOWN;
+    }
+}
+
+static lwm2m_data_type_t prv_getDataType(uint8_t type)
+{
+    switch (type)
+    {
+    case _PRV_TLV_TYPE_OBJECT:
+        return LWM2M_TYPE_OBJECT;
+
+    case _PRV_TLV_TYPE_OBJECT_INSTANCE:
+        return LWM2M_TYPE_OBJECT_INSTANCE;
+
+    case _PRV_TLV_TYPE_MULTIPLE_RESOURCE:
+        return LWM2M_TYPE_MULTIPLE_RESOURCE;
+
+    case _PRV_TLV_TYPE_RESOURCE:
+    case _PRV_TLV_TYPE_RESOURCE_INSTANCE:
+        return LWM2M_TYPE_OPAQUE;
+
+    default:
+        return LWM2M_TYPE_UNDEFINED;
+    }
+}
 
 static int prv_getHeaderLength(uint16_t id,
                                size_t dataLen)
@@ -61,17 +120,27 @@ static int prv_getHeaderLength(uint16_t id,
 }
 
 static int prv_createHeader(uint8_t * header,
-                            lwm2m_tlv_type_t type,
+                            bool isInstance,
+                            lwm2m_data_type_t type,
                             uint16_t id,
                             size_t data_len)
 {
     int header_len;
     int offset;
+    uint8_t hdrType;
 
     header_len = prv_getHeaderLength(id, data_len);
+    if (isInstance == true)
+    {
+        hdrType = _PRV_TLV_TYPE_RESOURCE_INSTANCE;
+    }
+    else
+    {
+        hdrType = prv_getHeaderType(type);
+    }
 
     header[0] = 0;
-    header[0] |= type&_PRV_TLV_TYPE_MASK;
+    header[0] |= hdrType&_PRV_TLV_TYPE_MASK;
 
     if (id > 0xFF)
     {
@@ -111,17 +180,17 @@ static int prv_createHeader(uint8_t * header,
     return header_len;
 }
 
-static int prv_opaqueToTLV(lwm2m_tlv_type_t type,
+static int prv_opaqueToTLV(bool isInstance,
                            uint8_t* dataP,
                            size_t data_len,
                            uint16_t id,
                            uint8_t * buffer,
                            size_t buffer_len)
 {
-    uint8_t header[LWM2M_TLV_HEADER_MAX_LENGTH];
+    uint8_t header[_PRV_TLV_HEADER_MAX_LENGTH];
     size_t header_len;
 
-    header_len = prv_createHeader(header, type, id, data_len);
+    header_len = prv_createHeader(header, isInstance, LWM2M_TYPE_OPAQUE, id, data_len);
 
     if (buffer_len < data_len + header_len) return 0;
 
@@ -132,7 +201,7 @@ static int prv_opaqueToTLV(lwm2m_tlv_type_t type,
     return header_len + data_len;
 }
 
-static int prv_intToTLV(lwm2m_tlv_type_t type,
+static int prv_intToTLV(bool isInstance,
                         int64_t data,
                         uint16_t id,
                         uint8_t * buffer,
@@ -141,26 +210,23 @@ static int prv_intToTLV(lwm2m_tlv_type_t type,
     uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE];
     size_t length = 0;
 
-    if (type != LWM2M_TYPE_RESOURCE_INSTANCE && type != LWM2M_TYPE_RESOURCE)
-        return 0;
-
     length = utils_encodeInt(data, data_buffer);
 
-    return prv_opaqueToTLV(type, data_buffer, length, id, buffer, buffer_len);
+    return prv_opaqueToTLV(isInstance, data_buffer, length, id, buffer, buffer_len);
 }
 
-static int prv_boolToTLV(lwm2m_tlv_type_t type,
+static int prv_boolToTLV(bool isInstance,
                          bool value,
                          uint16_t id,
                          uint8_t * buffer,
                          size_t buffer_len)
 {
-    return prv_intToTLV(type, value ? 1 : 0, id, buffer, buffer_len);
+    return prv_intToTLV(isInstance, value ? 1 : 0, id, buffer, buffer_len);
 }
 
 int lwm2m_decode_TLV(const uint8_t * buffer,
                     size_t buffer_len,
-                    lwm2m_tlv_type_t * oType,
+                    lwm2m_data_type_t * oType,
                     uint16_t * oID,
                     size_t * oDataIndex,
                     size_t * oDataLen)
@@ -170,7 +236,7 @@ int lwm2m_decode_TLV(const uint8_t * buffer,
 
     *oDataIndex = 2;
 
-    *oType = buffer[0]&_PRV_TLV_TYPE_MASK;
+    *oType = prv_getDataType(buffer[0]&_PRV_TLV_TYPE_MASK);
 
     if ((buffer[0]&0x20) == 0x20)
     {
@@ -224,7 +290,7 @@ int tlv_parse(uint8_t * buffer,
               size_t bufferLen,
               lwm2m_data_t ** dataP)
 {
-    lwm2m_tlv_type_t type;
+    lwm2m_data_type_t type;
     uint16_t id;
     size_t dataIndex;
     size_t dataLen;
@@ -258,10 +324,10 @@ int tlv_parse(uint8_t * buffer,
         (*dataP)[size].id = id;
         if (type == LWM2M_TYPE_OBJECT_INSTANCE || type == LWM2M_TYPE_MULTIPLE_RESOURCE)
         {
-            (*dataP)[size].length = tlv_parse(buffer + index + dataIndex,
-                                                    dataLen,
-                                                    (lwm2m_data_t **)&((*dataP)[size].value));
-            if ((*dataP)[size].length == 0)
+            (*dataP)[size].value.asChildren.num = tlv_parse(buffer + index + dataIndex,
+                                                          dataLen,
+                                                          &((*dataP)[size].value.asChildren.array));
+            if ((*dataP)[size].value.asChildren.num == 0)
             {
                 lwm2m_data_free(size + 1, *dataP);
                 return 0;
@@ -269,9 +335,9 @@ int tlv_parse(uint8_t * buffer,
         }
         else
         {
-            (*dataP)[size].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-            (*dataP)[size].length = dataLen;
-            (*dataP)[size].value = (uint8_t*)buffer + index + dataIndex;
+            (*dataP)[size].type = LWM2M_TYPE_OPAQUE;
+            (*dataP)[size].value.asBuffer.length = dataLen;
+            (*dataP)[size].value.asBuffer.buffer = buffer + index + dataIndex;
         }
         size++;
         index += result;
@@ -281,8 +347,8 @@ int tlv_parse(uint8_t * buffer,
 }
 
 
-static int prv_getLength(int size,
-                         lwm2m_data_t * dataP)
+static size_t prv_getLength(int size,
+                            lwm2m_data_t * dataP)
 {
     int length;
     int i;
@@ -298,7 +364,7 @@ static int prv_getLength(int size,
             {
                 int subLength;
 
-                subLength = prv_getLength(dataP[i].length, (lwm2m_data_t *)(dataP[i].value));
+                subLength = prv_getLength(dataP[i].value.asChildren.num, dataP[i].value.asChildren.array);
                 if (subLength == -1)
                 {
                     length = -1;
@@ -309,25 +375,60 @@ static int prv_getLength(int size,
                 }
             }
             break;
-        case LWM2M_TYPE_RESOURCE_INSTANCE:
-        case LWM2M_TYPE_RESOURCE:
-            length += prv_getHeaderLength(dataP[i].id, dataP[i].length) + dataP[i].length;
+
+        case LWM2M_TYPE_STRING:
+        case LWM2M_TYPE_OPAQUE:
+            length += prv_getHeaderLength(dataP[i].id, dataP[i].value.asBuffer.length) + dataP[i].value.asBuffer.length;
             break;
+
+        case LWM2M_TYPE_INTEGER:
+            {
+                size_t data_len;
+                uint8_t unused_buffer[_PRV_64BIT_BUFFER_SIZE];
+
+                data_len = utils_encodeInt(dataP[i].value.asInteger, unused_buffer);
+                length += prv_getHeaderLength(dataP[i].id, data_len) + data_len;
+            }
+            break;
+
+        case LWM2M_TYPE_FLOAT:
+            // TODO: support floats in TLV.
+            length = -1;
+            break;
+
+        case LWM2M_TYPE_BOOLEAN:
+            // Booleans are always encoded on one byte
+            length += prv_getHeaderLength(dataP[i].id, 1) + 1;
+            break;
+
+        case LWM2M_TYPE_OBJECT_LINK:
+            // Object Link are always encoded on four bytes
+            length += prv_getHeaderLength(dataP[i].id, 4) + 4;
+            break;
+
         default:
             length = -1;
             break;
         }
     }
 
-    return length;
+    if (length < 0)
+    {
+        return 0;
+    }
+    else
+    {
+        return (size_t)length;
+    }
 }
 
 
-int tlv_serialize(int size,
-                  lwm2m_data_t * dataP,
-                  uint8_t ** bufferP)
+size_t tlv_serialize(bool isResourceInstance, 
+                     int size,
+                     lwm2m_data_t * dataP,
+                     uint8_t ** bufferP)
 {
-    int length;
+    size_t length;
     int index;
     int i;
 
@@ -342,23 +443,27 @@ int tlv_serialize(int size,
     for (i = 0 ; i < size && length != 0 ; i++)
     {
         int headerLen;
+        bool isInstance;
 
+        isInstance = isResourceInstance;
         switch (dataP[i].type)
         {
-        case LWM2M_TYPE_OBJECT_INSTANCE:
         case LWM2M_TYPE_MULTIPLE_RESOURCE:
+            isInstance = true;
+            // fall throught
+        case LWM2M_TYPE_OBJECT_INSTANCE:
             {
                 uint8_t * tmpBuffer;
-                int tmpLength;
+                size_t tmpLength;
 
-                tmpLength = tlv_serialize(dataP[i].length, (lwm2m_data_t *)dataP[i].value, &tmpBuffer);
+                tmpLength = tlv_serialize(isInstance, dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, &tmpBuffer);
                 if (tmpLength == 0)
                 {
                     length = 0;
                 }
                 else
                 {
-                    headerLen = prv_createHeader((uint8_t*)(*bufferP) + index, dataP[i].type, dataP[i].id, tmpLength);
+                    headerLen = prv_createHeader(*bufferP + index, false, dataP[i].type, dataP[i].id, tmpLength);
                     index += headerLen;
                     memcpy(*bufferP + index, tmpBuffer, tmpLength);
                     index += tmpLength;
@@ -367,10 +472,30 @@ int tlv_serialize(int size,
             }
             break;
 
-        case LWM2M_TYPE_RESOURCE_INSTANCE:
-        case LWM2M_TYPE_RESOURCE:
+        case LWM2M_TYPE_STRING:
+        case LWM2M_TYPE_OPAQUE:
+            headerLen = prv_createHeader(*bufferP + index, isInstance, dataP[i].type, dataP[i].id, dataP[i].value.asBuffer.length);
+            if (headerLen == 0)
             {
-                headerLen = prv_createHeader((uint8_t*)(*bufferP) + index, dataP[i].type, dataP[i].id, dataP[i].length);
+                length = 0;
+            }
+            else
+            {
+                index += headerLen;
+                memcpy(*bufferP + index, dataP[i].value.asBuffer.buffer, dataP[i].value.asBuffer.length);
+                index += dataP[i].value.asBuffer.length;
+            }
+            break;
+
+        case LWM2M_TYPE_OBJECT_LINK:
+            // Object Link is a four-bytes integer
+        case LWM2M_TYPE_INTEGER:
+            {
+                size_t data_len;
+                uint8_t data_buffer[_PRV_64BIT_BUFFER_SIZE];
+
+                data_len = utils_encodeInt(dataP[i].value.asInteger, data_buffer);
+                headerLen = prv_createHeader(*bufferP + index, isInstance, dataP[i].type, dataP[i].id, data_len);
                 if (headerLen == 0)
                 {
                     length = 0;
@@ -378,9 +503,28 @@ int tlv_serialize(int size,
                 else
                 {
                     index += headerLen;
-                    memcpy(*bufferP + index, dataP[i].value, dataP[i].length);
-                    index += dataP[i].length;
+                    memcpy(*bufferP + index, data_buffer, data_len);
+                    index += data_len;
                 }
+            }
+            break;
+
+        case LWM2M_TYPE_FLOAT:
+            // TODO: support floats in TLV.
+            length = 0;
+            break;
+
+        case LWM2M_TYPE_BOOLEAN:
+            headerLen = prv_createHeader(*bufferP + index, isInstance, dataP[i].type, dataP[i].id, 1);
+            if (headerLen == 0)
+            {
+                length = 0;
+            }
+            else
+            {
+                index += headerLen;
+                *bufferP[index] = dataP[i].value.asBoolean ? 1 : 0;
+                index += 1;
             }
             break;
 

--- a/core/tlv.c
+++ b/core/tlv.c
@@ -324,10 +324,10 @@ int tlv_parse(uint8_t * buffer,
         (*dataP)[size].id = id;
         if (type == LWM2M_TYPE_OBJECT_INSTANCE || type == LWM2M_TYPE_MULTIPLE_RESOURCE)
         {
-            (*dataP)[size].value.asChildren.num = tlv_parse(buffer + index + dataIndex,
+            (*dataP)[size].value.asChildren.count = tlv_parse(buffer + index + dataIndex,
                                                           dataLen,
                                                           &((*dataP)[size].value.asChildren.array));
-            if ((*dataP)[size].value.asChildren.num == 0)
+            if ((*dataP)[size].value.asChildren.count == 0)
             {
                 lwm2m_data_free(size + 1, *dataP);
                 return 0;
@@ -362,7 +362,7 @@ static size_t prv_getLength(int size,
             {
                 int subLength;
 
-                subLength = prv_getLength(dataP[i].value.asChildren.num, dataP[i].value.asChildren.array);
+                subLength = prv_getLength(dataP[i].value.asChildren.count, dataP[i].value.asChildren.array);
                 if (subLength == -1)
                 {
                     length = -1;
@@ -454,7 +454,7 @@ size_t tlv_serialize(bool isResourceInstance,
                 uint8_t * tmpBuffer;
                 size_t tmpLength;
 
-                tmpLength = tlv_serialize(isInstance, dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, &tmpBuffer);
+                tmpLength = tlv_serialize(isInstance, dataP[i].value.asChildren.count, dataP[i].value.asChildren.array, &tmpBuffer);
                 if (tmpLength == 0)
                 {
                     length = 0;

--- a/core/uri.c
+++ b/core/uri.c
@@ -260,7 +260,11 @@ int uri_toString(lwm2m_uri_t * uriP,
 
     buffer[0] = '/';
 
-    if (uriP == NULL) return -1;
+    if (uriP == NULL)
+    {
+        if (depthP) *depthP = URI_DEPTH_OBJECT;
+        return 1;
+    }
 
     head = 1;
 

--- a/core/uri.c
+++ b/core/uri.c
@@ -253,7 +253,7 @@ int lwm2m_stringToUri(const char * buffer,
 int uri_toString(lwm2m_uri_t * uriP,
                  uint8_t * buffer,
                  size_t bufferLen,
-                 lwm2m_tlv_type_t * depthP)
+                 uri_depth_t * depthP)
 {
     size_t head;
     int res;
@@ -268,7 +268,7 @@ int uri_toString(lwm2m_uri_t * uriP,
     if (res <= 0) return -1;
     head += res;
     if (head >= bufferLen - 1) return -1;
-    *depthP = LWM2M_TYPE_OBJECT_INSTANCE;
+    if (depthP) *depthP = URI_DEPTH_OBJECT_INSTANCE;
 
     if (LWM2M_URI_IS_SET_INSTANCE(uriP))
     {
@@ -278,7 +278,7 @@ int uri_toString(lwm2m_uri_t * uriP,
         if (res <= 0) return -1;
         head += res;
         if (head >= bufferLen - 1) return -1;
-        *depthP = LWM2M_TYPE_RESOURCE;
+        if (depthP) *depthP = URI_DEPTH_RESOURCE;
         if (LWM2M_URI_IS_SET_RESOURCE(uriP))
         {
             buffer[head] = '/';
@@ -287,7 +287,7 @@ int uri_toString(lwm2m_uri_t * uriP,
             if (res <= 0) return -1;
             head += res;
             if (head >= bufferLen - 1) return -1;
-            *depthP = LWM2M_TYPE_RESOURCE_INSTANCE;
+            if (depthP) *depthP = URI_DEPTH_RESOURCE_INSTANCE;
         }
     }
 

--- a/examples/bootstrap_server/bootstrap_info.c
+++ b/examples/bootstrap_server/bootstrap_info.c
@@ -387,52 +387,33 @@ static int prv_add_server(bs_info_t * infoP,
     if (tlvP == NULL) goto error;
 
     // LWM2M Server URI
-    tlvP[0].type = LWM2M_TYPE_RESOURCE;
     tlvP[0].id = LWM2M_SECURITY_URI_ID;
-    tlvP[0].dataType = LWM2M_TYPE_STRING;
-    tlvP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-    tlvP[0].value = (uint8_t *)dataP->uri;
-    tlvP[0].length = strlen(dataP->uri);
+    lwm2m_data_encode_string(dataP->uri, tlvP);
 
     // Bootstrap Server
-    tlvP[1].type = LWM2M_TYPE_RESOURCE;
     tlvP[1].id = LWM2M_SECURITY_BOOTSTRAP_ID;
     lwm2m_data_encode_bool(dataP->isBootstrap, tlvP + 1);
 
     // Short Server ID
-    tlvP[2].type = LWM2M_TYPE_RESOURCE;
     tlvP[2].id = LWM2M_SECURITY_SHORT_SERVER_ID;
     lwm2m_data_encode_int(dataP->id, tlvP + 2);
 
     // Security Mode
-    tlvP[3].type = LWM2M_TYPE_RESOURCE;
     tlvP[3].id = LWM2M_SECURITY_SECURITY_ID;
     lwm2m_data_encode_int(dataP->securityMode, tlvP + 3);
 
     if (size > 4)
     {
-        tlvP[4].type = LWM2M_TYPE_RESOURCE;
         tlvP[4].id = LWM2M_SECURITY_PUBLIC_KEY_ID;
-        tlvP[4].dataType = LWM2M_TYPE_OPAQUE;
-        tlvP[4].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP[4].value = dataP->publicKey;
-        tlvP[4].length = dataP->publicKeyLen;
+        lwm2m_data_encode_opaque(dataP->publicKey, dataP->publicKeyLen, tlvP + 4);
 
-        tlvP[5].type = LWM2M_TYPE_RESOURCE;
         tlvP[5].id = LWM2M_SECURITY_SECRET_KEY_ID;
-        tlvP[5].dataType = LWM2M_TYPE_OPAQUE;
-        tlvP[5].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP[5].value = dataP->secretKey;
-        tlvP[5].length = dataP->secretKeyLen;
+        lwm2m_data_encode_opaque(dataP->secretKey, dataP->secretKeyLen, tlvP + 5);
 
         if (size == 7)
         {
-            tlvP[6].type = LWM2M_TYPE_RESOURCE;
             tlvP[6].id = LWM2M_SECURITY_SERVER_PUBLIC_KEY_ID;
-            tlvP[6].dataType = LWM2M_TYPE_OPAQUE;
-            tlvP[6].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-            tlvP[6].value = dataP->serverKey;
-            tlvP[6].length = dataP->serverKeyLen;
+            lwm2m_data_encode_opaque(dataP->serverKey, dataP->serverKeyLen, tlvP + 5);
         }
     }
 
@@ -448,27 +429,20 @@ static int prv_add_server(bs_info_t * infoP,
         if (tlvP == NULL) goto error;
 
         // Short Server ID
-        tlvP[0].type = LWM2M_TYPE_RESOURCE;
         tlvP[0].id = LWM2M_SERVER_SHORT_ID_ID;
         lwm2m_data_encode_int(dataP->id, tlvP);
 
         // Lifetime
-        tlvP[1].type = LWM2M_TYPE_RESOURCE;
         tlvP[1].id = LWM2M_SERVER_LIFETIME_ID;
         lwm2m_data_encode_int(dataP->lifetime, tlvP + 1);
 
         // Notification Storing
-        tlvP[2].type = LWM2M_TYPE_RESOURCE;
         tlvP[2].id = LWM2M_SERVER_STORING_ID;
         lwm2m_data_encode_bool(false, tlvP + 2);
 
         // Binding
-        tlvP[3].type = LWM2M_TYPE_RESOURCE;
         tlvP[3].id = LWM2M_SERVER_BINDING_ID;
-        tlvP[3].dataType = LWM2M_TYPE_STRING;
-        tlvP[3].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        tlvP[3].value = "U";
-        tlvP[3].length = 1;
+        lwm2m_data_encode_string("U", tlvP + 3);
 
         serverP->serverLen = lwm2m_data_serialize(NULL, size, tlvP, &format, &(serverP->serverData));
         if (serverP->serverLen <= 0) goto error;

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -155,10 +155,8 @@ void handle_value_changed(lwm2m_context_t * lwm2mH,
                 fprintf(stderr, "Internal allocation failure !\n");
                 return;
             }
-            dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA | LWM2M_TLV_FLAG_TEXT_FORMAT;
             dataP->id = uri->resourceId;
-            dataP->length = valueLength;
-            dataP->value = (uint8_t*) value;
+            lwm2m_data_encode_nstring(value, valueLength, dataP);
 
             result = object->writeFunc(uri->instanceId, 1, dataP, object);
             if (COAP_405_METHOD_NOT_ALLOWED == result)

--- a/examples/client/object_access_control.c
+++ b/examples/client/object_access_control.c
@@ -264,7 +264,7 @@ static uint8_t prv_write_resources(uint16_t instanceId, int numData,
                 int ri;
                 lwm2m_data_t* subTlvArray = tlvArray[i].value.asChildren.array;
 
-                if (tlvArray[i].value.asChildren.num == 0)
+                if (tlvArray[i].value.asChildren.count == 0)
                 {
                     result = COAP_204_CHANGED;
                 }
@@ -274,7 +274,7 @@ static uint8_t prv_write_resources(uint16_t instanceId, int numData,
                 }
                 else
                 {
-                    for (ri=0; tlvArray[i].value.asChildren.num; ri++)
+                    for (ri=0; tlvArray[i].value.asChildren.count; ri++)
                     {
                         if (1 != lwm2m_data_decode_int(&subTlvArray[ri], &value))
                         {

--- a/examples/client/object_access_control.c
+++ b/examples/client/object_access_control.c
@@ -95,7 +95,7 @@ static uint8_t prv_set_tlv(lwm2m_data_t* dataP, acc_ctrl_oi_t* accCtrlOiP)
                 subTlvP[ri].id = (uint16_t)ri;
                 lwm2m_data_encode_int(accCtrlRiP->accCtrlValue, &subTlvP[ri]);
             }
-            lwm2m_data_include(subTlvP, 2, dataP);
+            lwm2m_data_encode_instances(subTlvP, 2, dataP);
             return COAP_205_CONTENT;
         }
     }   break;

--- a/examples/client/object_access_control.c
+++ b/examples/client/object_access_control.c
@@ -67,15 +67,11 @@ static uint8_t prv_set_tlv(lwm2m_data_t* dataP, acc_ctrl_oi_t* accCtrlOiP)
     switch (dataP->id) {
     case RES_M_OBJECT_ID:
         lwm2m_data_encode_int(accCtrlOiP->objectId, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT
-                                   : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     case RES_M_OBJECT_INSTANCE_ID:
         lwm2m_data_encode_int(accCtrlOiP->objectInstId, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT
-                                   : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     case RES_O_ACL:
     {
@@ -96,13 +92,8 @@ static uint8_t prv_set_tlv(lwm2m_data_t* dataP, acc_ctrl_oi_t* accCtrlOiP)
                  accCtrlRiP!= NULL;
                  accCtrlRiP = accCtrlRiP->next, ri++)
             {
+                subTlvP[ri].id = (uint16_t)ri;
                 lwm2m_data_encode_int(accCtrlRiP->accCtrlValue, &subTlvP[ri]);
-                subTlvP[ri].type = LWM2M_TYPE_RESOURCE_INSTANCE;
-                if (subTlvP[ri].length == 0)
-                {
-                    lwm2m_free(subTlvP);
-                    return COAP_500_INTERNAL_SERVER_ERROR ;
-                }
             }
             lwm2m_data_include(subTlvP, 2, dataP);
             return COAP_205_CONTENT;
@@ -110,9 +101,7 @@ static uint8_t prv_set_tlv(lwm2m_data_t* dataP, acc_ctrl_oi_t* accCtrlOiP)
     }   break;
     case RES_M_ACCESS_CONTROL_OWNER:
         lwm2m_data_encode_int(accCtrlOiP->accCtrlOwner, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT
-                                   : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     default:
         return COAP_404_NOT_FOUND ;
@@ -273,9 +262,9 @@ static uint8_t prv_write_resources(uint16_t instanceId, int numData,
                 accCtrlOiP->accCtrlValList = NULL;
 
                 int ri;
-                lwm2m_data_t* subTlvArray = (lwm2m_data_t*)tlvArray[i].value;
+                lwm2m_data_t* subTlvArray = tlvArray[i].value.asChildren.array;
 
-                if (tlvArray[i].length==0)
+                if (tlvArray[i].value.asChildren.num == 0)
                 {
                     result = COAP_204_CHANGED;
                 }
@@ -285,7 +274,7 @@ static uint8_t prv_write_resources(uint16_t instanceId, int numData,
                 }
                 else
                 {
-                    for (ri=0; tlvArray[i].length; ri++)
+                    for (ri=0; tlvArray[i].value.asChildren.num; ri++)
                     {
                         if (1 != lwm2m_data_decode_int(&subTlvArray[ri], &value))
                         {

--- a/examples/client/object_connectivity_moni.c
+++ b/examples/client/object_connectivity_moni.c
@@ -101,7 +101,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
         subTlvP = lwm2m_data_new(riCnt);
         subTlvP[0].id    = 0;
         lwm2m_data_encode_int(VALUE_AVL_NETWORK_BEARER_1, subTlvP);
-        lwm2m_data_include(subTlvP, riCnt, dataP);
+        lwm2m_data_encode_instances(subTlvP, riCnt, dataP);
         return COAP_205_CONTENT ;
     }
 
@@ -122,7 +122,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
             subTlvP[ri].id = ri;
             lwm2m_data_encode_string(connDataP->ipAddresses[ri], subTlvP + ri);
         }
-        lwm2m_data_include(subTlvP, riCnt, dataP);
+        lwm2m_data_encode_instances(subTlvP, riCnt, dataP);
         return COAP_205_CONTENT ;
     }
         break;
@@ -136,7 +136,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
             subTlvP[ri].id = ri;
             lwm2m_data_encode_string(connDataP->routerIpAddresses[ri], subTlvP + ri);
         }
-        lwm2m_data_include(subTlvP, riCnt, dataP);
+        lwm2m_data_encode_instances(subTlvP, riCnt, dataP);
         return COAP_205_CONTENT ;
     }
         break;
@@ -152,7 +152,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
         subTlvP = lwm2m_data_new(riCnt);
         subTlvP[0].id     = 0;
         lwm2m_data_encode_string(VALUE_APN_1, subTlvP);
-        lwm2m_data_include(subTlvP, riCnt, dataP);
+        lwm2m_data_encode_instances(subTlvP, riCnt, dataP);
         return COAP_205_CONTENT;
     }
         break;

--- a/examples/client/object_connectivity_moni.c
+++ b/examples/client/object_connectivity_moni.c
@@ -92,63 +92,35 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
     {
     case RES_M_NETWORK_BEARER:
         lwm2m_data_encode_int(VALUE_NETWORK_BEARER_GSM, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        if (0 != dataP->length) return COAP_205_CONTENT ;
-        else return COAP_500_INTERNAL_SERVER_ERROR ;
-        break;
+        return COAP_205_CONTENT;
 
     case RES_M_AVL_NETWORK_BEARER:
     {
         int riCnt = 1;   // reduced to 1 instance to fit in one block size
         lwm2m_data_t * subTlvP;
         subTlvP = lwm2m_data_new(riCnt);
-        subTlvP[0].flags = 0;
         subTlvP[0].id    = 0;
-        subTlvP[0].type  = LWM2M_TYPE_RESOURCE_INSTANCE;
         lwm2m_data_encode_int(VALUE_AVL_NETWORK_BEARER_1, subTlvP);
-        if (0 == subTlvP[0].length)
-        {
-            lwm2m_data_free(riCnt, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR ;
-        }
         lwm2m_data_include(subTlvP, riCnt, dataP);
         return COAP_205_CONTENT ;
     }
-        break;
 
     case RES_M_RADIO_SIGNAL_STRENGTH: //s-int
         lwm2m_data_encode_int(connDataP->signalStrength, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        if (0 != dataP->length)
-            return COAP_205_CONTENT ;
-        else
-            return COAP_500_INTERNAL_SERVER_ERROR ;
-        break;
+        return COAP_205_CONTENT;
 
     case RES_O_LINK_QUALITY: //s-int
         lwm2m_data_encode_int(connDataP->linkQuality, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        if (0 != dataP->length) return COAP_205_CONTENT ;
-        else return COAP_500_INTERNAL_SERVER_ERROR ;
-        break;
+        return COAP_205_CONTENT ;
 
     case RES_M_IP_ADDRESSES:
     {
         int ri, riCnt = 1;   // reduced to 1 instance to fit in one block size
         lwm2m_data_t* subTlvP = lwm2m_data_new(riCnt);
-        for (ri=0; ri<riCnt; ri++)
+        for (ri = 0; ri < riCnt; ri++)
         {
-            subTlvP[ri].flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-            subTlvP[ri].id     = 0;
-            subTlvP[ri].type   = LWM2M_TYPE_RESOURCE_INSTANCE;
-            subTlvP[ri].dataType = LWM2M_TYPE_STRING;
-            subTlvP[ri].value  = (uint8_t*) connDataP->ipAddresses[ri];
-            subTlvP[ri].length = strlen(connDataP->ipAddresses[ri]);
-            if (subTlvP[ri].length == 0)
-            {
-                lwm2m_data_free(riCnt, subTlvP);
-                return COAP_500_INTERNAL_SERVER_ERROR ;
-            }
+            subTlvP[ri].id = ri;
+            lwm2m_data_encode_string(connDataP->ipAddresses[ri], subTlvP + ri);
         }
         lwm2m_data_include(subTlvP, riCnt, dataP);
         return COAP_205_CONTENT ;
@@ -161,17 +133,8 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
         lwm2m_data_t* subTlvP = lwm2m_data_new(riCnt);
         for (ri=0; ri<riCnt; ri++)
         {
-            subTlvP[ri].flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-            subTlvP[ri].id     = 0;
-            subTlvP[ri].type   = LWM2M_TYPE_RESOURCE_INSTANCE;
-            subTlvP[ri].dataType = LWM2M_TYPE_STRING;
-            subTlvP[ri].value  = (uint8_t*) connDataP->routerIpAddresses[ri];
-            subTlvP[ri].length = strlen(connDataP->routerIpAddresses[ri]);
-            if (subTlvP[ri].length == 0)
-            {
-                lwm2m_data_free(riCnt, subTlvP);
-                return COAP_500_INTERNAL_SERVER_ERROR ;
-            }
+            subTlvP[ri].id = ri;
+            lwm2m_data_encode_string(connDataP->routerIpAddresses[ri], subTlvP + ri);
         }
         lwm2m_data_include(subTlvP, riCnt, dataP);
         return COAP_205_CONTENT ;
@@ -180,29 +143,15 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
     case RES_O_LINK_UTILIZATION:
         lwm2m_data_encode_int(connDataP->linkUtilization, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        if (0 != dataP->length)
-            return COAP_205_CONTENT ;
-        else
-            return COAP_500_INTERNAL_SERVER_ERROR ;
-        break;
+        return COAP_205_CONTENT;
 
     case RES_O_APN:
     {
         int riCnt = 1;   // reduced to 1 instance to fit in one block size
         lwm2m_data_t * subTlvP;
         subTlvP = lwm2m_data_new(riCnt);
-        subTlvP[0].flags  = LWM2M_TLV_FLAG_STATIC_DATA;
         subTlvP[0].id     = 0;
-        subTlvP[0].type   = LWM2M_TYPE_RESOURCE_INSTANCE;
-        subTlvP[0].dataType = LWM2M_TYPE_STRING;
-        subTlvP[0].value  = (uint8_t*) VALUE_APN_1;
-        subTlvP[0].length = strlen(VALUE_APN_1);
-        if (0 == subTlvP[0].length)
-        {
-            lwm2m_data_free(riCnt, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR ;
-        }
+        lwm2m_data_encode_string(VALUE_APN_1, subTlvP);
         lwm2m_data_include(subTlvP, riCnt, dataP);
         return COAP_205_CONTENT;
     }
@@ -210,24 +159,15 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
     case RES_O_CELL_ID:
         lwm2m_data_encode_int(connDataP->cellId, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        if (0 != dataP->length) return COAP_205_CONTENT ;
-        else return COAP_500_INTERNAL_SERVER_ERROR ;
-        break;
+        return COAP_205_CONTENT ;
 
     case RES_O_SMNC:
         lwm2m_data_encode_int(VALUE_SMNC, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        if (0 != dataP->length) return COAP_205_CONTENT ;
-        else return COAP_500_INTERNAL_SERVER_ERROR ;
-        break;
+        return COAP_205_CONTENT ;
 
     case RES_O_SMCC:
         lwm2m_data_encode_int(VALUE_SMCC, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        if (0 != dataP->length) return COAP_205_CONTENT ;
-        else return COAP_500_INTERNAL_SERVER_ERROR ;
-        break;
+        return COAP_205_CONTENT ;
 
     default:
         return COAP_404_NOT_FOUND ;
@@ -395,29 +335,29 @@ uint8_t connectivity_moni_change(lwm2m_data_t * dataArray,
         break;
 
     case RES_M_IP_ADDRESSES:
-        if (sizeof(data->ipAddresses[0]) <= dataArray->length)
+        if (sizeof(data->ipAddresses[0]) <= dataArray->value.asBuffer.length)
         {
             result = COAP_400_BAD_REQUEST;
         }
         else
         {
             memset(data->ipAddresses[0], 0, sizeof(data->ipAddresses[0]));
-            memcpy(data->ipAddresses[0], dataArray->value, dataArray->length);
-            data->ipAddresses[0][dataArray->length] = 0;
+            memcpy(data->ipAddresses[0], dataArray->value.asBuffer.buffer, dataArray->value.asBuffer.length);
+            data->ipAddresses[0][dataArray->value.asBuffer.length] = 0;
             result = COAP_204_CHANGED;
         }
         break;
 
     case RES_O_ROUTER_IP_ADDRESS:
-        if (sizeof(data->routerIpAddresses[0]) <= dataArray->length)
+        if (sizeof(data->routerIpAddresses[0]) <= dataArray->value.asBuffer.length)
         {
             result = COAP_400_BAD_REQUEST;
         }
         else
         {
             memset(data->routerIpAddresses[0], 0, sizeof(data->routerIpAddresses[0]));
-            memcpy(data->routerIpAddresses[0], dataArray->value, dataArray->length);
-            data->routerIpAddresses[0][dataArray->length] = 0;
+            memcpy(data->routerIpAddresses[0], dataArray->value.asBuffer.buffer, dataArray->value.asBuffer.length);
+            data->routerIpAddresses[0][dataArray->value.asBuffer.length] = 0;
             result = COAP_204_CHANGED;
         }
         break;

--- a/examples/client/object_connectivity_stat.c
+++ b/examples/client/object_connectivity_stat.c
@@ -63,33 +63,27 @@ static uint8_t prv_set_tlv(lwm2m_data_t * dataP, conn_s_data_t * connStDataP)
     switch (dataP->id) {
     case RES_O_SMS_TX_COUNTER:
         lwm2m_data_encode_int(connStDataP->smsTxCounter, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     case RES_O_SMS_RX_COUNTER:
         lwm2m_data_encode_int(connStDataP->smsRxCounter, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     case RES_O_TX_DATA:
         lwm2m_data_encode_int(connStDataP->txDataByte/1024, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     case RES_O_RX_DATA:
         lwm2m_data_encode_int(connStDataP->rxDataByte/1024, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     case RES_O_MAX_MESSAGE_SIZE:
         lwm2m_data_encode_int(connStDataP->maxMessageSize, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     case RES_O_AVERAGE_MESSAGE_SIZE:
         lwm2m_data_encode_int(connStDataP->avrMessageSize, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        return (0 != dataP->length) ? COAP_205_CONTENT : COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
         break;
     default:
         return COAP_404_NOT_FOUND ;

--- a/examples/client/object_device.c
+++ b/examples/client/object_device.c
@@ -200,7 +200,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
         subTlvP[1].id = 1;
         lwm2m_data_encode_int(PRV_POWER_SOURCE_2, subTlvP + 1);
 
-        lwm2m_data_include(subTlvP, 2, dataP);
+        lwm2m_data_encode_instances(subTlvP, 2, dataP);
 
         return COAP_205_CONTENT;
     }
@@ -216,7 +216,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
         subTlvP[1].id = 1;
         lwm2m_data_encode_int(PRV_POWER_VOLTAGE_2, subTlvP + 1);
 
-        lwm2m_data_include(subTlvP, 2, dataP);
+        lwm2m_data_encode_instances(subTlvP, 2, dataP);
 
         return COAP_205_CONTENT;
     }
@@ -232,7 +232,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
         subTlvP[1].id = 1;
         lwm2m_data_encode_int(PRV_POWER_CURRENT_2, &subTlvP[1]);
  
-        lwm2m_data_include(subTlvP, 2, dataP);
+        lwm2m_data_encode_instances(subTlvP, 2, dataP);
 
         return COAP_205_CONTENT;
     }
@@ -254,7 +254,7 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
         subTlvP[0].id = 0;
         lwm2m_data_encode_int(devDataP->error, subTlvP);
 
-        lwm2m_data_include(subTlvP, 1, dataP);
+        lwm2m_data_encode_instances(subTlvP, 1, dataP);
 
         return COAP_205_CONTENT;
     }        

--- a/examples/client/object_device.c
+++ b/examples/client/object_device.c
@@ -168,35 +168,19 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
     switch (dataP->id)
     {
     case RES_O_MANUFACTURER:
-        dataP->value  = (uint8_t*)PRV_MANUFACTURER;
-        dataP->length = strlen(PRV_MANUFACTURER);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_MANUFACTURER, dataP);
         return COAP_205_CONTENT;
 
     case RES_O_MODEL_NUMBER:
-        dataP->value  = (uint8_t*)PRV_MODEL_NUMBER;
-        dataP->length = strlen(PRV_MODEL_NUMBER);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_MODEL_NUMBER, dataP);
         return COAP_205_CONTENT;
 
     case RES_O_SERIAL_NUMBER:
-        dataP->value  = (uint8_t*)PRV_SERIAL_NUMBER;
-        dataP->length = strlen(PRV_SERIAL_NUMBER);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_SERIAL_NUMBER, dataP);
         return COAP_205_CONTENT;
 
     case RES_O_FIRMWARE_VERSION:
-        dataP->value  = (uint8_t*)PRV_FIRMWARE_VERSION;
-        dataP->length = strlen(PRV_FIRMWARE_VERSION);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_FIRMWARE_VERSION, dataP);
         return COAP_205_CONTENT;
 
     case RES_M_REBOOT:
@@ -211,25 +195,10 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
         subTlvP = lwm2m_data_new(2);
 
-        subTlvP[0].flags = 0;
         subTlvP[0].id = 0;
-        subTlvP[0].type = LWM2M_TYPE_RESOURCE_INSTANCE;
         lwm2m_data_encode_int(PRV_POWER_SOURCE_1, subTlvP);
-        if (0 == subTlvP[0].length)
-        {
-            lwm2m_data_free(2, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR;
-        }
-
-        subTlvP[1].flags = 0;
         subTlvP[1].id = 1;
-        subTlvP[1].type = LWM2M_TYPE_RESOURCE_INSTANCE;
         lwm2m_data_encode_int(PRV_POWER_SOURCE_2, subTlvP + 1);
-        if (0 == subTlvP[1].length)
-        {
-            lwm2m_data_free(2, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR;
-        }
 
         lwm2m_data_include(subTlvP, 2, dataP);
 
@@ -242,25 +211,10 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
         subTlvP = lwm2m_data_new(2);
 
-        subTlvP[0].flags = 0;
         subTlvP[0].id = 0;
-        subTlvP[0].type = LWM2M_TYPE_RESOURCE_INSTANCE;
         lwm2m_data_encode_int(PRV_POWER_VOLTAGE_1, subTlvP);
-        if (0 == subTlvP[0].length)
-        {
-            lwm2m_data_free(2, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR;
-        }
-
-        subTlvP[1].flags = 0;
         subTlvP[1].id = 1;
-        subTlvP[1].type = LWM2M_TYPE_RESOURCE_INSTANCE;
         lwm2m_data_encode_int(PRV_POWER_VOLTAGE_2, subTlvP + 1);
-        if (0 == subTlvP[1].length)
-        {
-            lwm2m_data_free(2, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR;
-        }
 
         lwm2m_data_include(subTlvP, 2, dataP);
 
@@ -273,26 +227,11 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
         subTlvP = lwm2m_data_new(2);
 
-        subTlvP[0].flags = 0;
         subTlvP[0].id = 0;
-        subTlvP[0].type = LWM2M_TYPE_RESOURCE_INSTANCE;
         lwm2m_data_encode_int(PRV_POWER_CURRENT_1, &subTlvP[0]);
-        if (0 == subTlvP[0].length)
-        {
-            lwm2m_data_free(2, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR;
-        }
-
-        subTlvP[1].flags = 0;
         subTlvP[1].id = 1;
-        subTlvP[1].type = LWM2M_TYPE_RESOURCE_INSTANCE;
         lwm2m_data_encode_int(PRV_POWER_CURRENT_2, &subTlvP[1]);
-        if (0 == subTlvP[1].length)
-        {
-            lwm2m_data_free(2, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR;
-        }
-
+ 
         lwm2m_data_include(subTlvP, 2, dataP);
 
         return COAP_205_CONTENT;
@@ -300,17 +239,11 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
     case RES_O_BATTERY_LEVEL:
         lwm2m_data_encode_int(devDataP->battery_level, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case RES_O_MEMORY_FREE:
         lwm2m_data_encode_int(devDataP->free_memory, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case RES_M_ERROR_CODE:
     {
@@ -318,15 +251,8 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
         subTlvP = lwm2m_data_new(1);
 
-        subTlvP[0].flags = 0;
         subTlvP[0].id = 0;
-        subTlvP[0].type = LWM2M_TYPE_RESOURCE_INSTANCE;
         lwm2m_data_encode_int(devDataP->error, subTlvP);
-        if (0 == subTlvP[0].length)
-        {
-            lwm2m_data_free(2, subTlvP);
-            return COAP_500_INTERNAL_SERVER_ERROR;
-        }
 
         lwm2m_data_include(subTlvP, 1, dataP);
 
@@ -337,34 +263,18 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
 
     case RES_O_CURRENT_TIME:
         lwm2m_data_encode_int(time(NULL) + devDataP->time, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_TIME;
-
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case RES_O_UTC_OFFSET:
-        dataP->value  = (uint8_t*)devDataP->time_offset;
-        dataP->length = strlen(devDataP->time_offset);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(devDataP->time_offset, dataP);
         return COAP_205_CONTENT;
 
     case RES_O_TIMEZONE:
-        dataP->value  = (uint8_t*)PRV_TIME_ZONE;
-        dataP->length = strlen(PRV_TIME_ZONE);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_TIME_ZONE, dataP);
         return COAP_205_CONTENT;
       
     case RES_M_BINDING_MODES:
-        dataP->value  = (uint8_t*)PRV_BINDING_MODE;
-        dataP->length = strlen(PRV_BINDING_MODE);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_BINDING_MODE, dataP);
         return COAP_205_CONTENT;
 
     default:
@@ -475,7 +385,6 @@ static uint8_t prv_device_discover(uint16_t instanceId,
         for (i = 0; i < nbRes; i++)
         {
             (*dataArrayP)[i].id = resList[i];
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
         }
     }
     else
@@ -544,10 +453,10 @@ static uint8_t prv_device_write(uint16_t instanceId,
             break;
 
         case RES_O_UTC_OFFSET:
-            if (1 == prv_check_time_offset((char*)dataArray[i].value, dataArray[i].length))
+            if (1 == prv_check_time_offset((char*)dataArray[i].value.asBuffer.buffer, dataArray[i].value.asBuffer.length))
             {
-                strncpy(((device_data_t*)(objectP->userData))->time_offset, (char*)dataArray[i].value, dataArray[i].length);
-                ((device_data_t*)(objectP->userData))->time_offset[dataArray[i].length] = 0;
+                strncpy(((device_data_t*)(objectP->userData))->time_offset, (char*)dataArray[i].value.asBuffer.buffer, dataArray[i].value.asBuffer.length);
+                ((device_data_t*)(objectP->userData))->time_offset[dataArray[i].value.asBuffer.length] = 0;
                 result = COAP_204_CHANGED;
             }
             else

--- a/examples/client/object_firmware.c
+++ b/examples/client/object_firmware.c
@@ -100,29 +100,17 @@ static uint8_t prv_firmware_read(uint16_t instanceId,
         case RES_M_STATE:
             // firmware update state (int)
             lwm2m_data_encode_int(data->state, *dataArrayP + i);
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
-
-            if (0 != (*dataArrayP)[i].length) result = COAP_205_CONTENT;
-            else result = COAP_500_INTERNAL_SERVER_ERROR;
-
+            result = COAP_205_CONTENT;
             break;
 
         case RES_O_UPDATE_SUPPORTED_OBJECTS:
             lwm2m_data_encode_bool(data->supported, *dataArrayP + i);
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
-
-            if (0 != (*dataArrayP)[i].length) result = COAP_205_CONTENT;
-            else result = COAP_500_INTERNAL_SERVER_ERROR;
-
+            result = COAP_205_CONTENT;
             break;
 
         case RES_M_UPDATE_RESULT:
             lwm2m_data_encode_int(data->result, *dataArrayP + i);
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
-
-            if (0 != (*dataArrayP)[i].length) result = COAP_205_CONTENT;
-            else result = COAP_500_INTERNAL_SERVER_ERROR;
-
+            result = COAP_205_CONTENT;
             break;
 
         default:

--- a/examples/client/object_location.c
+++ b/examples/client/object_location.c
@@ -89,44 +89,22 @@ static uint8_t prv_res2tlv(lwm2m_data_t* dataP,
     switch (dataP->id)     // location resourceId
     {
     case RES_M_LATITUDE:
-        dataP->value  = (uint8_t*)locDataP->latitude;
-        dataP->length = strlen(locDataP->latitude);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type   = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(locDataP->latitude, dataP);
         break;
     case RES_M_LONGITUDE:
-        dataP->value  = (uint8_t*)locDataP->longitude;
-        dataP->length = strlen(locDataP->latitude);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type   = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(locDataP->longitude, dataP);
         break;
     case RES_O_ALTITUDE:
-        dataP->value  = (uint8_t*)locDataP->altitude;
-        dataP->length = strlen(locDataP->altitude);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type   = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(locDataP->altitude, dataP);
         break;
     case RES_O_UNCERTAINTY:
-        dataP->value  = (uint8_t*)locDataP->uncertainty;
-        dataP->length = strlen(locDataP->uncertainty);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type   = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(locDataP->uncertainty, dataP);
         break;
     case RES_O_VELOCITY:
-        dataP->value  = locDataP->velocity;
-        dataP->length = VELOCITY_OCTETS;
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type   = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_OPAQUE;
+        lwm2m_data_encode_string(locDataP->velocity, dataP);
         break;
     case RES_M_TIMESTAMP:
         lwm2m_data_encode_int(locDataP->timestamp, dataP);
-        dataP->type   = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_TIME;
         break;
     default:
         ret = COAP_404_NOT_FOUND;

--- a/examples/client/object_server.c
+++ b/examples/client/object_server.c
@@ -56,49 +56,37 @@ typedef struct _server_instance_
 static uint8_t prv_get_value(lwm2m_data_t * dataP,
                              server_instance_t * targetP)
 {
-    // There are no multiple instance resources
-    dataP->type = LWM2M_TYPE_RESOURCE;
-
     switch (dataP->id)
     {
     case LWM2M_SERVER_SHORT_ID_ID:
         lwm2m_data_encode_int(targetP->shortServerId, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_LIFETIME_ID:
         lwm2m_data_encode_int(targetP->lifetime, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_MIN_PERIOD_ID:
         lwm2m_data_encode_int(targetP->defaultMinPeriod, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_MAX_PERIOD_ID:
         lwm2m_data_encode_int(targetP->defaultMaxPeriod, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_DISABLE_ID:
         return COAP_405_METHOD_NOT_ALLOWED;
 
     case LWM2M_SERVER_TIMEOUT_ID:
         lwm2m_data_encode_int(targetP->disableTimeout, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_STORING_ID:
         lwm2m_data_encode_bool(targetP->storing, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_BINDING_ID:
-        dataP->value = (uint8_t*)targetP->binding;
-        dataP->length = strlen(targetP->binding);
-        dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(targetP->binding, dataP);
         return COAP_205_CONTENT;
 
     case LWM2M_SERVER_UPDATE_ID:
@@ -186,7 +174,6 @@ static uint8_t prv_server_discover(uint16_t instanceId,
         for (i = 0; i < nbRes; i++)
         {
             (*dataArrayP)[i].id = resList[i];
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
         }
     }
     else
@@ -312,15 +299,16 @@ static uint8_t prv_server_write(uint16_t instanceId,
         break;
 
         case LWM2M_SERVER_BINDING_ID:
-            if ((dataArray[i].length > 0 && dataArray[i].length <= 3)
-             && (strncmp((char*)dataArray[i].value, "U",   dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "UQ",  dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "S",   dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "SQ",  dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "US",  dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "UQS", dataArray[i].length) == 0))
+            if (dataArray[i].type == LWM2M_TYPE_STRING
+             && dataArray[i].value.asBuffer.length > 0 && dataArray[i].value.asBuffer.length <= 3
+             && (strncmp((char*)dataArray[i].value.asBuffer.buffer, "U", dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "UQ", dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "S", dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "SQ", dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "US", dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "UQS", dataArray[i].value.asBuffer.length) == 0))
             {
-                strncpy(targetP->binding, (char*)dataArray[i].value, dataArray[i].length);
+                strncpy(targetP->binding, (char*)dataArray[i].value.asBuffer.buffer, dataArray[i].value.asBuffer.length);
                 result = COAP_204_CHANGED;
             }
             else

--- a/examples/client/test_object.c
+++ b/examples/client/test_object.c
@@ -155,19 +155,16 @@ static uint8_t prv_read(uint16_t instanceId,
         switch ((*dataArrayP)[i].id)
         {
         case 1:
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
             lwm2m_data_encode_int(targetP->test, *dataArrayP + i);
             break;
         case 2:
             return COAP_405_METHOD_NOT_ALLOWED;
         case 3:
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
             lwm2m_data_encode_float(targetP->dec, *dataArrayP + i);
             break;
         default:
             return COAP_404_NOT_FOUND;
         }
-        if ((*dataArrayP)[i].length == 0) return COAP_500_INTERNAL_SERVER_ERROR;
     }
 
     return COAP_205_CONTENT;
@@ -187,11 +184,8 @@ static uint8_t prv_discover(uint16_t instanceId,
         if (*dataArrayP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
         *numDataP = 3;
         (*dataArrayP)[0].id = 1;
-        (*dataArrayP)[0].type = LWM2M_TYPE_RESOURCE;
         (*dataArrayP)[1].id = 2;
-        (*dataArrayP)[1].type = LWM2M_TYPE_RESOURCE;
         (*dataArrayP)[2].id = 3;
-        (*dataArrayP)[2].type = LWM2M_TYPE_RESOURCE;
     }
     else
     {

--- a/examples/lightclient/object_device.c
+++ b/examples/lightclient/object_device.c
@@ -101,31 +101,20 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP)
     switch (dataP->id)
     {
     case RES_O_MANUFACTURER:
-        dataP->value  = (uint8_t*)PRV_MANUFACTURER;
-        dataP->length = strlen(PRV_MANUFACTURER);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_MANUFACTURER, dataP);
         return COAP_205_CONTENT;
 
     case RES_O_MODEL_NUMBER:
-        dataP->value  = (uint8_t*)PRV_MODEL_NUMBER;
-        dataP->length = strlen(PRV_MODEL_NUMBER);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_MODEL_NUMBER, dataP);
         return COAP_205_CONTENT;
 
     case RES_M_REBOOT:
         return COAP_405_METHOD_NOT_ALLOWED;
       
     case RES_M_BINDING_MODES:
-        dataP->value  = (uint8_t*)PRV_BINDING_MODE;
-        dataP->length = strlen(PRV_BINDING_MODE);
-        dataP->flags  = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->type     = LWM2M_TYPE_RESOURCE;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(PRV_BINDING_MODE, dataP);
         return COAP_205_CONTENT;
+
 
     default:
         return COAP_404_NOT_FOUND;
@@ -208,7 +197,6 @@ static uint8_t prv_device_discover(uint16_t instanceId,
         for (i = 0 ; i < nbRes ; i++)
         {
             (*dataArrayP)[i].id = resList[i];
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
         }
     }
     else

--- a/examples/lightclient/object_security.c
+++ b/examples/lightclient/object_security.c
@@ -60,87 +60,79 @@ typedef struct _security_instance_
 static uint8_t prv_get_value(lwm2m_data_t * dataP,
                              security_instance_t * targetP)
 {
-    // There are no multiple instance ressources
-    dataP->type = LWM2M_TYPE_RESOURCE;
 
     switch (dataP->id)
     {
     case LWM2M_SECURITY_URI_ID:
-        dataP->value = (uint8_t*)targetP->uri;
-        dataP->length = strlen(targetP->uri);
-        dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(targetP->uri, dataP);
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_BOOTSTRAP_ID:
         lwm2m_data_encode_bool(targetP->isBootstrap, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SECURITY_ID:
         lwm2m_data_encode_int(LWM2M_SECURITY_MODE_NONE, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_PUBLIC_KEY_ID:
         // Here we return an opaque of 1 byte containing 0
-        dataP->value = (uint8_t*)"";
-        dataP->length = 1;
-        dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->dataType = LWM2M_TYPE_OPAQUE;
+        {
+            uint8_t value = 0;
+
+            lwm2m_data_encode_opaque(&value, 1, dataP);
+        }
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SERVER_PUBLIC_KEY_ID:
         // Here we return an opaque of 1 byte containing 0
-        dataP->value = (uint8_t*)"";
-        dataP->length = 1;
-        dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->dataType = LWM2M_TYPE_OPAQUE;
+        {
+            uint8_t value = 0;
+
+            lwm2m_data_encode_opaque(&value, 1, dataP);
+        }
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SECRET_KEY_ID:
         // Here we return an opaque of 1 byte containing 0
-        dataP->value = (uint8_t*)"";
-        dataP->length = 1;
-        dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->dataType = LWM2M_TYPE_OPAQUE;
+        {
+            uint8_t value = 0;
+
+            lwm2m_data_encode_opaque(&value, 1, dataP);
+        }
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SMS_SECURITY_ID:
         lwm2m_data_encode_int(LWM2M_SECURITY_MODE_NONE, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SMS_KEY_PARAM_ID:
         // Here we return an opaque of 6 bytes containing a buggy value
-        dataP->value = (uint8_t*)"12345";
-        dataP->length = 6;
-        dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->dataType = LWM2M_TYPE_OPAQUE;
+        {
+            char * value = "12345";
+            lwm2m_data_encode_opaque((uint8_t *)value, 6, dataP);
+        }
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SMS_SECRET_KEY_ID:
         // Here we return an opaque of 32 bytes containing a buggy value
-        dataP->value = (uint8_t*)"1234567890abcdefghijklmnopqrstu";
-        dataP->length = 32;
-        dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->dataType = LWM2M_TYPE_OPAQUE;
+        {
+            char * value = "1234567890abcdefghijklmnopqrstu";
+            lwm2m_data_encode_opaque((uint8_t *)value, 32, dataP);
+        }
         return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SMS_SERVER_NUMBER_ID:
         lwm2m_data_encode_int(0, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_SHORT_SERVER_ID:
         lwm2m_data_encode_int(targetP->shortID, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SECURITY_HOLD_OFF_ID:
         lwm2m_data_encode_int(targetP->clientHoldOffTime, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     default:
         return COAP_404_NOT_FOUND;

--- a/examples/lightclient/object_server.c
+++ b/examples/lightclient/object_server.c
@@ -53,34 +53,25 @@ typedef struct _server_instance_
 static uint8_t prv_get_value(lwm2m_data_t * dataP,
                              server_instance_t * targetP)
 {
-    // There are no multiple instance resources
-    dataP->type = LWM2M_TYPE_RESOURCE;
-
     switch (dataP->id)
     {
     case LWM2M_SERVER_SHORT_ID_ID:
         lwm2m_data_encode_int(targetP->shortServerId, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_LIFETIME_ID:
         lwm2m_data_encode_int(targetP->lifetime, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_DISABLE_ID:
         return COAP_405_METHOD_NOT_ALLOWED;
 
     case LWM2M_SERVER_STORING_ID:
         lwm2m_data_encode_bool(targetP->storing, dataP);
-        if (0 != dataP->length) return COAP_205_CONTENT;
-        else return COAP_500_INTERNAL_SERVER_ERROR;
+        return COAP_205_CONTENT;
 
     case LWM2M_SERVER_BINDING_ID:
-        dataP->value = (uint8_t*)targetP->binding;
-        dataP->length = strlen(targetP->binding);
-        dataP->flags = LWM2M_TLV_FLAG_STATIC_DATA;
-        dataP->dataType = LWM2M_TYPE_STRING;
+        lwm2m_data_encode_string(targetP->binding, dataP);
         return COAP_205_CONTENT;
 
     case LWM2M_SERVER_UPDATE_ID:
@@ -165,7 +156,6 @@ static uint8_t prv_server_discover(uint16_t instanceId,
         for (i = 0 ; i < nbRes ; i++)
         {
             (*dataArrayP)[i].id = resList[i];
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
         }
     }
     else
@@ -282,15 +272,16 @@ static uint8_t prv_server_write(uint16_t instanceId,
         break;
 
         case LWM2M_SERVER_BINDING_ID:
-            if ((dataArray[i].length > 0 && dataArray[i].length <= 3)
-             && (strncmp((char*)dataArray[i].value, "U",   dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "UQ",  dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "S",   dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "SQ",  dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "US",  dataArray[i].length) == 0
-              || strncmp((char*)dataArray[i].value, "UQS", dataArray[i].length) == 0))
+            if (dataArray[i].type == LWM2M_TYPE_STRING
+             && dataArray[i].value.asBuffer.length > 0 && dataArray[i].value.asBuffer.length <= 3
+             && (strncmp((char*)dataArray[i].value.asBuffer.buffer, "U",   dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "UQ",  dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "S",   dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "SQ",  dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "US",  dataArray[i].value.asBuffer.length) == 0
+              || strncmp((char*)dataArray[i].value.asBuffer.buffer, "UQS", dataArray[i].value.asBuffer.length) == 0))
             {
-                strncpy(targetP->binding, (char*)dataArray[i].value, dataArray[i].length);
+                strncpy(targetP->binding, (char*)dataArray[i].value.asBuffer.buffer, dataArray[i].value.asBuffer.length);
                 result = COAP_204_CHANGED;
             }
             else

--- a/examples/lightclient/test_object.c
+++ b/examples/lightclient/test_object.c
@@ -156,23 +156,19 @@ static uint8_t prv_read(uint16_t instanceId,
         switch ((*dataArrayP)[i].id)
         {
         case 1:
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
             lwm2m_data_encode_int(targetP->test, *dataArrayP + i);
             break;
         case 2:
             return COAP_405_METHOD_NOT_ALLOWED;
         case 3:
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
             lwm2m_data_encode_float(targetP->dec, *dataArrayP + i);
             break;
         case 4:
-            (*dataArrayP)[i].type = LWM2M_TYPE_RESOURCE;
             lwm2m_data_encode_int(targetP->sig, *dataArrayP + i);
             break;
         default:
             return COAP_404_NOT_FOUND;
         }
-        if ((*dataArrayP)[i].length == 0) return COAP_500_INTERNAL_SERVER_ERROR;
     }
 
     return COAP_205_CONTENT;
@@ -192,13 +188,9 @@ static uint8_t prv_discover(uint16_t instanceId,
         if (*dataArrayP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
         *numDataP = 4;
         (*dataArrayP)[0].id = 1;
-        (*dataArrayP)[0].type = LWM2M_TYPE_RESOURCE;
         (*dataArrayP)[1].id = 2;
-        (*dataArrayP)[1].type = LWM2M_TYPE_RESOURCE;
         (*dataArrayP)[2].id = 3;
-        (*dataArrayP)[2].type = LWM2M_TYPE_RESOURCE;
         (*dataArrayP)[3].id = 4;
-        (*dataArrayP)[3].type = LWM2M_TYPE_RESOURCE;
     }
     else
     {

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -599,7 +599,6 @@ static void prv_create_client(char * buffer,
             return;
         }
         lwm2m_data_encode_int(value, dataP);
-        dataP->type = LWM2M_TYPE_RESOURCE;
         dataP->id = 1;
 
         format = LWM2M_CONTENT_TLV;

--- a/examples/utils/commandline.c
+++ b/examples/utils/commandline.c
@@ -393,14 +393,6 @@ void dump_tlv(FILE * stream,
         if (dataP[i].flags & LWM2M_TLV_FLAG_STATIC_DATA)
         {
             fprintf(stream, "STATIC_DATA");
-            if (dataP[i].flags & LWM2M_TLV_FLAG_TEXT_FORMAT)
-            {
-                fprintf(stream, " | TEXT_FORMAT");
-            }
-        }
-        else if (dataP[i].flags & LWM2M_TLV_FLAG_TEXT_FORMAT)
-        {
-            fprintf(stream, "TEXT_FORMAT");
         }
         fprintf(stream, "\r\n");
 
@@ -416,60 +408,69 @@ void dump_tlv(FILE * stream,
         else
         {
             print_indent(stream, indent+1);
-            fprintf(stream, "data type: ");
-            switch (dataP[i].dataType)
+            if (dataP[i].dataType == LWM2M_TYPE_AS_TEXT)
             {
-            case LWM2M_TYPE_INTEGER:
-                fprintf(stream, "Integer");
-                if ((dataP[i].flags & LWM2M_TLV_FLAG_TEXT_FORMAT) == 0)
-                {
-                    int64_t value;
-                    if (1 == lwm2m_data_decode_int(dataP + i, &value))
-                    {
-                        fprintf(stream, " (%" PRId64 ")", value);
-                    }
-                }
-                break;
-            case LWM2M_TYPE_STRING:
-                fprintf(stream, "String");
-                break;
-            case LWM2M_TYPE_FLOAT:
-                fprintf(stream, "Float");
-                if ((dataP[i].flags & LWM2M_TLV_FLAG_TEXT_FORMAT) == 0)
-                {
-                    double value;
-                    if (1 == lwm2m_data_decode_float(dataP + i, &value))
-                    {
-                        fprintf(stream, " (%f)", value);
-                    }
-                }
-                break;
-            case LWM2M_TYPE_BOOLEAN:
-                fprintf(stream, "Boolean");
-                if ((dataP[i].flags & LWM2M_TLV_FLAG_TEXT_FORMAT) == 0)
-                {
-                    bool value;
-                    if (1 == lwm2m_data_decode_bool(dataP + i, &value))
-                    {
-                        fprintf(stream, " (%s)", value?"true":"false");
-                    }
-                }
-                break;
-            case LWM2M_TYPE_TIME:
-                fprintf(stream, "Time");
-                break;
-            case LWM2M_TYPE_OBJECT_LINK:
-                fprintf(stream, "Object Link");
-                break;
-            case LWM2M_TYPE_OPAQUE:
-                fprintf(stream, "Opaque");
-                break;
-            case LWM2M_TYPE_UNDEFINED:
-                fprintf(stream, "Undefined");
-                break;
+                fprintf(stream, "in text format:\r\n");
+                print_indent(stream, indent + 1);
+                fprintf(stream, "%.*s\r\n", dataP[i].length, dataP[i].value);
             }
-            fprintf(stream, "\r\n");
-            output_buffer(stream, dataP[i].value, dataP[i].length, indent+1);
+            else
+            {
+                fprintf(stream, "data type: ");
+                switch (dataP[i].dataType)
+                {
+                case LWM2M_TYPE_INTEGER:
+                    fprintf(stream, "Integer");
+                    {
+                        int64_t value;
+                        if (1 == lwm2m_data_decode_int(dataP + i, &value))
+                        {
+                            fprintf(stream, " (%" PRId64 ")", value);
+                        }
+                    }
+                    break;
+                case LWM2M_TYPE_STRING:
+                    fprintf(stream, "String");
+                    break;
+                case LWM2M_TYPE_FLOAT:
+                    fprintf(stream, "Float");
+                    {
+                        double value;
+                        if (1 == lwm2m_data_decode_float(dataP + i, &value))
+                        {
+                            fprintf(stream, " (%f)", value);
+                        }
+                    }
+                    break;
+                case LWM2M_TYPE_BOOLEAN:
+                    fprintf(stream, "Boolean");
+                    {
+                        bool value;
+                        if (1 == lwm2m_data_decode_bool(dataP + i, &value))
+                        {
+                            fprintf(stream, " (%s)", value ? "true" : "false");
+                        }
+                    }
+                    break;
+                case LWM2M_TYPE_TIME:
+                    fprintf(stream, "Time");
+                    break;
+                case LWM2M_TYPE_OBJECT_LINK:
+                    fprintf(stream, "Object Link");
+                    break;
+                case LWM2M_TYPE_OPAQUE:
+                    fprintf(stream, "Opaque");
+                    break;
+                case LWM2M_TYPE_UNDEFINED:
+                    fprintf(stream, "Undefined");
+                    break;
+                case LWM2M_TYPE_AS_TEXT:
+                    fprintf(stream, "Undefined");
+                    break;
+                }
+                fprintf(stream, "\r\n");
+                output_buffer(stream, dataP[i].value, dataP[i].length, indent + 1);
+            }
         }
         print_indent(stream, indent);
         fprintf(stream, "}\r\n");

--- a/examples/utils/commandline.c
+++ b/examples/utils/commandline.c
@@ -221,7 +221,7 @@ void output_tlv(FILE * stream,
                 size_t buffer_len,
                 int indent)
 {
-    lwm2m_tlv_type_t type;
+    lwm2m_data_type_t type;
     uint16_t id;
     size_t dataIndex;
     size_t dataLen;
@@ -241,14 +241,11 @@ void output_tlv(FILE * stream,
         case LWM2M_TYPE_OBJECT_INSTANCE:
             fprintf(stream, "Object Instance");
             break;
-        case LWM2M_TYPE_RESOURCE_INSTANCE:
-            fprintf(stream, "Resource Instance");
-            break;
         case LWM2M_TYPE_MULTIPLE_RESOURCE:
             fprintf(stream, "Multiple Instances");
             break;
-        case LWM2M_TYPE_RESOURCE:
-            fprintf(stream, "Resource");
+        case LWM2M_TYPE_OPAQUE:
+            fprintf(stream, "Resource Value");
             break;
         default:
             printf("unknown (%d)", (int)type);
@@ -370,107 +367,51 @@ void dump_tlv(FILE * stream,
         {
         case LWM2M_TYPE_OBJECT:
             fprintf(stream, "LWM2M_TYPE_OBJECT\r\n");
+            dump_tlv(stream, dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, indent + 1);
             break;
         case LWM2M_TYPE_OBJECT_INSTANCE:
             fprintf(stream, "LWM2M_TYPE_OBJECT_INSTANCE\r\n");
-            break;
-        case LWM2M_TYPE_RESOURCE_INSTANCE:
-            fprintf(stream, "LWM2M_TYPE_RESOURCE_INSTANCE\r\n");
+            dump_tlv(stream, dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, indent + 1);
             break;
         case LWM2M_TYPE_MULTIPLE_RESOURCE:
             fprintf(stream, "LWM2M_TYPE_MULTIPLE_RESOURCE\r\n");
+            dump_tlv(stream, dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, indent + 1);
             break;
-        case LWM2M_TYPE_RESOURCE:
-            fprintf(stream, "LWM2M_TYPE_RESOURCE\r\n");
+        case LWM2M_TYPE_UNDEFINED:
+            fprintf(stream, "LWM2M_TYPE_UNDEFINED\r\n");
+            break;
+        case LWM2M_TYPE_STRING:
+            fprintf(stream, "LWM2M_TYPE_STRING\r\n");
+            print_indent(stream, indent + 1);
+            fprintf(stream, "\"%.*s\"\r\n", dataP[i].value.asBuffer.length, dataP[i].value.asBuffer.buffer);
+            break;
+        case LWM2M_TYPE_OPAQUE:
+            fprintf(stream, "LWM2M_TYPE_OPAQUE\r\n");
+            output_buffer(stream, dataP[i].value.asBuffer.buffer, dataP[i].value.asBuffer.length, indent + 1);
+            break;
+        case LWM2M_TYPE_INTEGER:
+            fprintf(stream, "LWM2M_TYPE_INTEGER: ");
+            print_indent(stream, indent + 1);
+            fprintf(stream, "%" PRId64, dataP[i].value.asInteger);
+            fprintf(stream, "\r\n");
+            break;
+        case LWM2M_TYPE_FLOAT:
+            fprintf(stream, "LWM2M_TYPE_FLOAT: ");
+            print_indent(stream, indent + 1);
+            fprintf(stream, "%f", dataP[i].value.asInteger);
+            fprintf(stream, "\r\n");
+            break;
+        case LWM2M_TYPE_BOOLEAN:
+            fprintf(stream, "LWM2M_TYPE_BOOLEAN: ");
+            fprintf(stream, "%s", dataP[i].value.asBoolean ? "true" : "false");
+            fprintf(stream, "\r\n");
+            break;
+        case LWM2M_TYPE_OBJECT_LINK:
+            fprintf(stream, "LWM2M_TYPE_OBJECT_LINK\r\n");
             break;
         default:
             fprintf(stream, "unknown (%d)\r\n", (int)dataP[i].type);
             break;
-        }
-
-        print_indent(stream, indent+1);
-        fprintf(stream, "flags: ");
-        if (dataP[i].flags & LWM2M_TLV_FLAG_STATIC_DATA)
-        {
-            fprintf(stream, "STATIC_DATA");
-        }
-        fprintf(stream, "\r\n");
-
-        print_indent(stream, indent+1);
-        fprintf(stream, "data length: %d\r\n", (int) dataP[i].length);
-
-        if (dataP[i].type == LWM2M_TYPE_OBJECT_INSTANCE
-         || dataP[i].type == LWM2M_TYPE_OBJECT
-         || dataP[i].type == LWM2M_TYPE_MULTIPLE_RESOURCE)
-        {
-            dump_tlv(stream, dataP[i].length, (lwm2m_data_t *)(dataP[i].value), indent+1);
-        }
-        else
-        {
-            print_indent(stream, indent+1);
-            if (dataP[i].dataType == LWM2M_TYPE_AS_TEXT)
-            {
-                fprintf(stream, "in text format:\r\n");
-                print_indent(stream, indent + 1);
-                fprintf(stream, "%.*s\r\n", dataP[i].length, dataP[i].value);
-            }
-            else
-            {
-                fprintf(stream, "data type: ");
-                switch (dataP[i].dataType)
-                {
-                case LWM2M_TYPE_INTEGER:
-                    fprintf(stream, "Integer");
-                    {
-                        int64_t value;
-                        if (1 == lwm2m_data_decode_int(dataP + i, &value))
-                        {
-                            fprintf(stream, " (%" PRId64 ")", value);
-                        }
-                    }
-                    break;
-                case LWM2M_TYPE_STRING:
-                    fprintf(stream, "String");
-                    break;
-                case LWM2M_TYPE_FLOAT:
-                    fprintf(stream, "Float");
-                    {
-                        double value;
-                        if (1 == lwm2m_data_decode_float(dataP + i, &value))
-                        {
-                            fprintf(stream, " (%f)", value);
-                        }
-                    }
-                    break;
-                case LWM2M_TYPE_BOOLEAN:
-                    fprintf(stream, "Boolean");
-                    {
-                        bool value;
-                        if (1 == lwm2m_data_decode_bool(dataP + i, &value))
-                        {
-                            fprintf(stream, " (%s)", value ? "true" : "false");
-                        }
-                    }
-                    break;
-                case LWM2M_TYPE_TIME:
-                    fprintf(stream, "Time");
-                    break;
-                case LWM2M_TYPE_OBJECT_LINK:
-                    fprintf(stream, "Object Link");
-                    break;
-                case LWM2M_TYPE_OPAQUE:
-                    fprintf(stream, "Opaque");
-                    break;
-                case LWM2M_TYPE_UNDEFINED:
-                    fprintf(stream, "Undefined");
-                    break;
-                case LWM2M_TYPE_AS_TEXT:
-                    fprintf(stream, "Undefined");
-                    break;
-                }
-                fprintf(stream, "\r\n");
-                output_buffer(stream, dataP[i].value, dataP[i].length, indent + 1);
-            }
         }
         print_indent(stream, indent);
         fprintf(stream, "}\r\n");

--- a/examples/utils/commandline.c
+++ b/examples/utils/commandline.c
@@ -367,15 +367,15 @@ void dump_tlv(FILE * stream,
         {
         case LWM2M_TYPE_OBJECT:
             fprintf(stream, "LWM2M_TYPE_OBJECT\r\n");
-            dump_tlv(stream, dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, indent + 1);
+            dump_tlv(stream, dataP[i].value.asChildren.count, dataP[i].value.asChildren.array, indent + 1);
             break;
         case LWM2M_TYPE_OBJECT_INSTANCE:
             fprintf(stream, "LWM2M_TYPE_OBJECT_INSTANCE\r\n");
-            dump_tlv(stream, dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, indent + 1);
+            dump_tlv(stream, dataP[i].value.asChildren.count, dataP[i].value.asChildren.array, indent + 1);
             break;
         case LWM2M_TYPE_MULTIPLE_RESOURCE:
             fprintf(stream, "LWM2M_TYPE_MULTIPLE_RESOURCE\r\n");
-            dump_tlv(stream, dataP[i].value.asChildren.num, dataP[i].value.asChildren.array, indent + 1);
+            dump_tlv(stream, dataP[i].value.asChildren.count, dataP[i].value.asChildren.array, indent + 1);
             break;
         case LWM2M_TYPE_UNDEFINED:
             fprintf(stream, "LWM2M_TYPE_UNDEFINED\r\n");

--- a/tests/tlv_json_lwm2m_data_test.c
+++ b/tests/tlv_json_lwm2m_data_test.c
@@ -70,7 +70,7 @@ static void test_data_and_compare(const char * uriStr,
 {
     lwm2m_uri_t uri;
     uint8_t * buffer;
-    int length;
+    size_t length;
     
     if (uriStr != NULL)
     {
@@ -134,13 +134,19 @@ static void test_data_and_compare(const char * uriStr,
 // data types, therefore hardcode all objects to be strings.
 static void make_all_objects_string_types(lwm2m_data_t * tlvP, int size)
 {
-    for (int i=0;i<size;++i) {
-        if (tlvP[i].dataType != LWM2M_TYPE_UNDEFINED)
-            continue;
-        tlvP[i].dataType = LWM2M_TYPE_STRING;
-        if (tlvP[i].type==LWM2M_TYPE_MULTIPLE_RESOURCE)
-            for (int j=0;j<tlvP[i].length;++j)
-                ((lwm2m_data_t *)tlvP[i].value)[j].dataType = LWM2M_TYPE_STRING;
+    for (int i=0 ; i<size ; ++i)
+    {
+        if (tlvP[i].type == LWM2M_TYPE_OPAQUE)
+        {
+            tlvP[i].type = LWM2M_TYPE_STRING;
+        }
+        else if (tlvP[i].type == LWM2M_TYPE_MULTIPLE_RESOURCE)
+        {
+            for (int j = 0; j < tlvP[i].value.asChildren.num; ++j)
+            {
+                tlvP[i].value.asChildren.array[j].type = LWM2M_TYPE_STRING;
+            }
+        }
     }
 }
 
@@ -363,25 +369,14 @@ static void test_9(void)
 }
 static void test_10(void)
 {
-    lwm2m_data_t data1[] = {                                                                \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 0, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 1, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 2, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 3, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 4, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 5, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 6, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 7, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 8, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 9, 0, NULL},    \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 10, 0, NULL},   \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 11, 0, NULL},   \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 12, 0, NULL},   \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 13, 0, NULL},   \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 14, 0, NULL},   \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 15, 0, NULL},   \
-                             {0, LWM2M_TYPE_RESOURCE, LWM2M_TYPE_UNDEFINED, 16, 0, NULL},   \
-                           };
+    lwm2m_data_t * data1 = lwm2m_data_new(17);
+    int i;
+
+    for (i = 0; i < 17; i++)
+    {
+        data1[i].id = i;
+    }
+
     lwm2m_data_encode_int(12, data1);
     lwm2m_data_encode_int(-12, data1 + 1);
     lwm2m_data_encode_int(255, data1 + 2);

--- a/tests/tlv_json_lwm2m_data_test.c
+++ b/tests/tlv_json_lwm2m_data_test.c
@@ -142,7 +142,7 @@ static void make_all_objects_string_types(lwm2m_data_t * tlvP, int size)
         }
         else if (tlvP[i].type == LWM2M_TYPE_MULTIPLE_RESOURCE)
         {
-            for (int j = 0; j < tlvP[i].value.asChildren.num; ++j)
+            for (int j = 0; j < tlvP[i].value.asChildren.count; ++j)
             {
                 tlvP[i].value.asChildren.array[j].type = LWM2M_TYPE_STRING;
             }

--- a/tests/tlvtests.c
+++ b/tests/tlvtests.c
@@ -143,7 +143,7 @@ static void test_tlv_parse()
     CU_ASSERT_PTR_NOT_NULL_FATAL(dataP);
     CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OBJECT_INSTANCE);
     CU_ASSERT_EQUAL(dataP->id, 0x203);
-    CU_ASSERT_EQUAL(dataP->value.asChildren.num, 2);
+    CU_ASSERT_EQUAL(dataP->value.asChildren.count, 2);
     CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value.asChildren.array);
     tlvSubP = dataP->value.asChildren.array;
 
@@ -163,13 +163,13 @@ static void test_tlv_parse()
     CU_ASSERT_PTR_NOT_NULL_FATAL(dataP);
     CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OBJECT_INSTANCE);
     CU_ASSERT_EQUAL(dataP->id, 11);
-    CU_ASSERT_EQUAL(dataP->value.asChildren.num, 1);
+    CU_ASSERT_EQUAL(dataP->value.asChildren.count, 1);
     CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value.asChildren.array);
     tlvSubP = dataP->value.asChildren.array;
 
     CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_MULTIPLE_RESOURCE);
     CU_ASSERT_EQUAL(tlvSubP[0].id, 77);
-    CU_ASSERT_EQUAL(tlvSubP[0].value.asChildren.num, 2);
+    CU_ASSERT_EQUAL(tlvSubP[0].value.asChildren.count, 2);
     CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[0].value.asChildren.array);
     tlvSubP = tlvSubP[0].value.asChildren.array;
 
@@ -212,7 +212,7 @@ static void test_tlv_serialize()
 
     tlvSubP[1].type = LWM2M_TYPE_MULTIPLE_RESOURCE;
     tlvSubP[1].id = 77;
-    tlvSubP[1].value.asChildren.num = 1;
+    tlvSubP[1].value.asChildren.count = 1;
     tlvSubP[1].value.asChildren.array = lwm2m_data_new(1);
     CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[1].value.asChildren.array);
     tlvRscInstP = tlvSubP[1].value.asChildren.array;
@@ -228,7 +228,7 @@ static void test_tlv_serialize()
     dataP->id = 3;
     lwm2m_data_include(tlvSubP, 2, dataP);
     CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OBJECT_INSTANCE);
-    CU_ASSERT_EQUAL(dataP->value.asChildren.num, 2);
+    CU_ASSERT_EQUAL(dataP->value.asChildren.count, 2);
     CU_ASSERT_EQUAL(dataP->value.asChildren.array, tlvSubP);
 
     lwm2m_media_type_t media_type = LWM2M_CONTENT_TLV;

--- a/tests/tlvtests.c
+++ b/tests/tlvtests.c
@@ -20,12 +20,6 @@
 #include "internals.h"
 #include "memtest.h"
 
-static void fill(uint8_t *data, int size) {
-    int index;
-    for (index = 0; index < size; ++index) {
-        data[index] = index;
-    }
-}
 
 static void test_tlv_new(void)
 {
@@ -50,7 +44,7 @@ static void test_decodeTLV()
     uint8_t data1[] = {0xC3, 55, 1, 2, 3};
     uint8_t data2[] = {0x28, 2, 3, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
     uint8_t data3[0x194] = {0x90, 33, 1, 0x90 };
-    lwm2m_tlv_type_t type;
+    lwm2m_data_type_t type;
     uint16_t id = 0;
     size_t   index = 0;
     size_t   length = 0;
@@ -62,7 +56,7 @@ static void test_decodeTLV()
 
     result = lwm2m_decode_TLV(data1, sizeof(data1), &type, &id, &index, &length);
     CU_ASSERT_EQUAL(result, 5);
-    CU_ASSERT_EQUAL(type, LWM2M_TYPE_RESOURCE);
+    CU_ASSERT_EQUAL(type, LWM2M_TYPE_OPAQUE);
     CU_ASSERT_EQUAL(id, 55);
     CU_ASSERT_EQUAL(index, 2);
     CU_ASSERT_EQUAL(length, 3);
@@ -138,10 +132,10 @@ static void test_tlv_parse()
     result = lwm2m_data_parse(NULL, data1, sizeof(data1), LWM2M_CONTENT_TLV, &dataP);
     CU_ASSERT_EQUAL(result, 1);
     CU_ASSERT_PTR_NOT_NULL_FATAL(dataP);
-    CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_RESOURCE);
+    CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OPAQUE);
     CU_ASSERT_EQUAL(dataP->id, 55);
-    CU_ASSERT_EQUAL(dataP->length, 3);
-    CU_ASSERT(0 == memcmp(dataP->value, &data1[2], 3));
+    CU_ASSERT_EQUAL(dataP->value.asBuffer.length, 3);
+    CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, &data1[2], 3));
     lwm2m_data_free(result, dataP);
 
     result = lwm2m_data_parse(NULL, data2, sizeof(data2), LWM2M_CONTENT_TLV, &dataP);
@@ -149,19 +143,19 @@ static void test_tlv_parse()
     CU_ASSERT_PTR_NOT_NULL_FATAL(dataP);
     CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OBJECT_INSTANCE);
     CU_ASSERT_EQUAL(dataP->id, 0x203);
-    CU_ASSERT_EQUAL(dataP->length, 2);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value);
-    tlvSubP = (lwm2m_data_t *)dataP->value;
+    CU_ASSERT_EQUAL(dataP->value.asChildren.num, 2);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value.asChildren.array);
+    tlvSubP = dataP->value.asChildren.array;
 
-    CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_RESOURCE);
+    CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_OPAQUE);
     CU_ASSERT_EQUAL(tlvSubP[0].id, 55);
-    CU_ASSERT_EQUAL(tlvSubP[0].length, 3);
-    CU_ASSERT(0 == memcmp(tlvSubP[0].value, &data2[6], 3));
+    CU_ASSERT_EQUAL(tlvSubP[0].value.asBuffer.length, 3);
+    CU_ASSERT(0 == memcmp(tlvSubP[0].value.asBuffer.buffer, &data2[6], 3));
 
-    CU_ASSERT_EQUAL(tlvSubP[1].type, LWM2M_TYPE_RESOURCE);
+    CU_ASSERT_EQUAL(tlvSubP[1].type, LWM2M_TYPE_OPAQUE);
     CU_ASSERT_EQUAL(tlvSubP[1].id, 66);
-    CU_ASSERT_EQUAL(tlvSubP[1].length, 9);
-    CU_ASSERT(0 == memcmp(tlvSubP[1].value, &data2[12], 9));
+    CU_ASSERT_EQUAL(tlvSubP[1].value.asBuffer.length, 9);
+    CU_ASSERT(0 == memcmp(tlvSubP[1].value.asBuffer.buffer, &data2[12], 9));
     lwm2m_data_free(result, dataP);
 
     result = lwm2m_data_parse(NULL, data3, sizeof(data3), LWM2M_CONTENT_TLV, &dataP);
@@ -169,25 +163,25 @@ static void test_tlv_parse()
     CU_ASSERT_PTR_NOT_NULL_FATAL(dataP);
     CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OBJECT_INSTANCE);
     CU_ASSERT_EQUAL(dataP->id, 11);
-    CU_ASSERT_EQUAL(dataP->length, 1);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value);
-    tlvSubP = (lwm2m_data_t *)dataP->value;
+    CU_ASSERT_EQUAL(dataP->value.asChildren.num, 1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value.asChildren.array);
+    tlvSubP = dataP->value.asChildren.array;
 
     CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_MULTIPLE_RESOURCE);
     CU_ASSERT_EQUAL(tlvSubP[0].id, 77);
-    CU_ASSERT_EQUAL(tlvSubP[0].length, 2);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[0].value);
-    tlvSubP = (lwm2m_data_t *)tlvSubP[0].value;
+    CU_ASSERT_EQUAL(tlvSubP[0].value.asChildren.num, 2);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[0].value.asChildren.array);
+    tlvSubP = tlvSubP[0].value.asChildren.array;
 
-    CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_RESOURCE_INSTANCE);
+    CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_OPAQUE);
     CU_ASSERT_EQUAL(tlvSubP[0].id, 0);
-    CU_ASSERT_EQUAL(tlvSubP[0].length, 3);
-    CU_ASSERT(0 == memcmp(tlvSubP[0].value, &data3[8], 3));
+    CU_ASSERT_EQUAL(tlvSubP[0].value.asBuffer.length, 3);
+    CU_ASSERT(0 == memcmp(tlvSubP[0].value.asBuffer.buffer, &data3[8], 3));
 
-    CU_ASSERT_EQUAL(tlvSubP[1].type, LWM2M_TYPE_RESOURCE_INSTANCE);
+    CU_ASSERT_EQUAL(tlvSubP[1].type, LWM2M_TYPE_OPAQUE);
     CU_ASSERT_EQUAL(tlvSubP[1].id, 1);
-    CU_ASSERT_EQUAL(tlvSubP[1].length, 160);
-    CU_ASSERT(0 == memcmp(tlvSubP[1].value, &data3[14], 160));
+    CU_ASSERT_EQUAL(tlvSubP[1].value.asBuffer.length, 160);
+    CU_ASSERT(0 == memcmp(tlvSubP[1].value.asBuffer.buffer, &data3[14], 160));
     lwm2m_data_free(result, dataP);
 
     MEMORY_TRACE_AFTER_EQ;
@@ -200,37 +194,42 @@ static void test_tlv_serialize()
     int result;
     lwm2m_data_t *dataP;
     lwm2m_data_t *tlvSubP;
+    lwm2m_data_t *tlvRscInstP;
     uint8_t data1[] = {1, 2, 3, 4};
     uint8_t data2[170] = {5, 6, 7, 8};
     uint8_t* buffer;
 
-    dataP =  lwm2m_data_new(1);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(dataP);
-    dataP->type = LWM2M_TYPE_OBJECT_INSTANCE;
-    dataP->id = 3;
-    dataP->length = 2;
-    tlvSubP =  lwm2m_data_new(2);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP);
-    dataP->value = (uint8_t *) tlvSubP;
 
-    tlvSubP[0].type = LWM2M_TYPE_RESOURCE;
-    tlvSubP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
+
+    tlvSubP = lwm2m_data_new(2);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP);
+
     tlvSubP[0].id = 66;
-    tlvSubP[0].length = sizeof(data1);
-    tlvSubP[0].value = data1;
+    lwm2m_data_encode_opaque(data1, sizeof(data1), tlvSubP);
+    CU_ASSERT_EQUAL(tlvSubP[0].type, LWM2M_TYPE_OPAQUE);
+    CU_ASSERT_EQUAL(tlvSubP[0].value.asBuffer.length, sizeof(data1));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[0].value.asBuffer.buffer);
 
     tlvSubP[1].type = LWM2M_TYPE_MULTIPLE_RESOURCE;
     tlvSubP[1].id = 77;
-    tlvSubP[1].length = 1;
-    tlvSubP[1].value = (uint8_t *) lwm2m_data_new(1);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[1].value);
-    tlvSubP = (lwm2m_data_t *)tlvSubP[1].value;
+    tlvSubP[1].value.asChildren.num = 1;
+    tlvSubP[1].value.asChildren.array = lwm2m_data_new(1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP[1].value.asChildren.array);
+    tlvRscInstP = tlvSubP[1].value.asChildren.array;
 
-    tlvSubP[0].type = LWM2M_TYPE_RESOURCE_INSTANCE;
-    tlvSubP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-    tlvSubP[0].id = 0;
-    tlvSubP[0].length = sizeof(data2);
-    tlvSubP[0].value = data2;
+    tlvRscInstP[0].id = 0;
+    lwm2m_data_encode_opaque(data2, sizeof(data2), tlvRscInstP);
+    CU_ASSERT_EQUAL(tlvRscInstP[0].type, LWM2M_TYPE_OPAQUE);
+    CU_ASSERT_EQUAL(tlvRscInstP[0].value.asBuffer.length, sizeof(data2));
+    CU_ASSERT_PTR_NOT_NULL_FATAL(tlvRscInstP[0].value.asBuffer.buffer);
+
+    dataP = lwm2m_data_new(1);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(dataP);
+    dataP->id = 3;
+    lwm2m_data_include(tlvSubP, 2, dataP);
+    CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OBJECT_INSTANCE);
+    CU_ASSERT_EQUAL(dataP->value.asChildren.num, 2);
+    CU_ASSERT_EQUAL(dataP->value.asChildren.array, tlvSubP);
 
     lwm2m_media_type_t media_type = LWM2M_CONTENT_TLV;
     result = lwm2m_data_serialize(NULL, 1, dataP, &media_type, &buffer);
@@ -259,196 +258,167 @@ static void test_tlv_serialize()
     MEMORY_TRACE_AFTER_EQ;
 }
 
-static void test_tlv_encode_int(void)
+static void test_tlv_int(void)
 {
    MEMORY_TRACE_BEFORE;
-   lwm2m_data_t *dataP =  lwm2m_data_new(10);
-   CU_ASSERT_PTR_NOT_NULL(dataP);
-
-   lwm2m_data_encode_int(0x12, dataP);
-   dataP[0].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[0].flags, 0);
-   CU_ASSERT_EQUAL(dataP[0].length, 1);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[0].value);
-   CU_ASSERT_EQUAL(dataP[0].value[0], 0x12);
-
-   dataP[1].flags = LWM2M_TLV_FLAG_TEXT_FORMAT;
-   lwm2m_data_encode_int(18, &dataP[1]);
-   dataP[1].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[1].length, 2);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[1].value);
-   CU_ASSERT(0 == memcmp(dataP[1].value, "18", 2));
-
-   uint8_t data1[] = { 0xed, 0xcc };
-   lwm2m_data_encode_int(-0x1234, &dataP[2]);
-   dataP[2].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[2].length, 2);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[2].value);
-   CU_ASSERT(0 == memcmp(dataP[2].value, data1, 2));
-
-   dataP[3].flags = LWM2M_TLV_FLAG_TEXT_FORMAT;
-   lwm2m_data_encode_int(-14678, &dataP[3]);
-   dataP[3].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[3].length, 6);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[3].value);
-   CU_ASSERT(0 == memcmp(dataP[3].value, "-14678", 6));
-
-   uint8_t data2[] = { 0x7f, 0x34, 0x56, 0x78, 0x91, 0x22, 0x33, 0x44 };
-   lwm2m_data_encode_int(0x7f34567891223344, &dataP[4]);
-   dataP[4].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[4].length, 8);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[4].value);
-   CU_ASSERT(0 == memcmp(dataP[4].value, data2, 8));
-
-   lwm2m_data_free(10, dataP);
-   MEMORY_TRACE_AFTER_EQ;
-}
-
-static void test_tlv_decode_int(void)
-{
-   MEMORY_TRACE_BEFORE;
-   uint8_t data1[] = { 0x12, 0x34 };
-   uint8_t data2[] = { 0xed, 0xcc };
-   uint8_t data3[] = { 0x7f, 0x34, 0x56, 0x78, 0x91, 0x22, 0x33, 0x44 };
    int64_t value;
    int result;
-   lwm2m_data_t *dataP =  lwm2m_data_new(10);
+   lwm2m_data_t *dataP =  lwm2m_data_new(1);
    CU_ASSERT_PTR_NOT_NULL(dataP);
 
    result = lwm2m_data_decode_int(dataP, &value);
    CU_ASSERT_EQUAL(result, 0);
 
-   dataP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-   dataP[0].length = 1;
-   dataP[0].value = data1;
+   lwm2m_data_encode_int(0x12, dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_INTEGER);
+   CU_ASSERT_EQUAL(dataP->value.asInteger, 0x12);
    result = lwm2m_data_decode_int(dataP, &value);
    CU_ASSERT_EQUAL(result, 1);
    CU_ASSERT_EQUAL(value, 0x12);
 
-   dataP[0].length = 2;
-   dataP[0].value = data2;
-   result = lwm2m_data_decode_int(dataP, &value);
-   CU_ASSERT_EQUAL(result, 1);
-   CU_ASSERT_EQUAL(value, -0x1234);
-
-   dataP[0].length = 8;
-   dataP[0].value = data3;
-   result = lwm2m_data_decode_int(dataP, &value);
-   CU_ASSERT_EQUAL(result, 1);
-   CU_ASSERT_EQUAL(value, 0x7f34567891223344);
-
-   dataP[0].length = 9;
-   result = lwm2m_data_decode_int(dataP, &value);
-   CU_ASSERT_EQUAL(result, 0);
-
-   dataP[0].flags |= LWM2M_TLV_FLAG_TEXT_FORMAT;
-   dataP[0].length = 2;
-   dataP[0].value = (uint8_t *) "18";
+   lwm2m_data_encode_string("18", dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_STRING);
+   CU_ASSERT_EQUAL(dataP->value.asBuffer.length, 2);
+   CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, "18", 2));
    result = lwm2m_data_decode_int(dataP, &value);
    CU_ASSERT_EQUAL(result, 1);
    CU_ASSERT_EQUAL(value, 18);
 
-   dataP[0].length = 9;
-   dataP[0].value = (uint8_t *) "-56923456";
+   lwm2m_data_encode_string("-14678", dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_STRING);
+   CU_ASSERT_EQUAL(dataP->value.asBuffer.length, 6);
+   CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, "-14678", 6));
    result = lwm2m_data_decode_int(dataP, &value);
    CU_ASSERT_EQUAL(result, 1);
-   CU_ASSERT_EQUAL(value, -56923456);
+   CU_ASSERT_EQUAL(value, -14678);
 
-   lwm2m_data_free(10, dataP);
+   uint8_t data1[] = { 0xed, 0xcc };
+   lwm2m_data_encode_opaque(data1, sizeof(data1), dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OPAQUE);
+   CU_ASSERT_EQUAL(dataP->value.asBuffer.length, sizeof(data1));
+   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value.asBuffer.buffer);
+   CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, data1, sizeof(data1)));
+   result = lwm2m_data_decode_int(dataP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, -0x1234);
+   lwm2m_free(dataP->value.asBuffer.buffer);
+
+   uint8_t data2[] = { 0x7f, 0x34, 0x56, 0x78, 0x91, 0x22, 0x33, 0x44 };
+   lwm2m_data_encode_opaque(data2, sizeof(data2), dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OPAQUE);
+   CU_ASSERT_EQUAL(dataP->value.asBuffer.length, sizeof(data2));
+   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value.asBuffer.buffer);
+   CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, data2, sizeof(data2)));
+   result = lwm2m_data_decode_int(dataP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, 0x7f34567891223344);
+
+   lwm2m_data_free(1, dataP);
    MEMORY_TRACE_AFTER_EQ;
 }
 
-static void test_tlv_encode_bool(void)
+static void test_tlv_bool(void)
 {
    MEMORY_TRACE_BEFORE;
-   lwm2m_data_t *dataP =  lwm2m_data_new(10);
-   CU_ASSERT_PTR_NOT_NULL(dataP);
-
-   lwm2m_data_encode_bool(2, dataP);
-   dataP[0].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[0].flags, 0);
-   CU_ASSERT_EQUAL(dataP[0].length, 1);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[0].value);
-   CU_ASSERT_EQUAL(dataP[0].value[0], 1);
-
-   lwm2m_data_encode_bool(0, &dataP[1]);
-   dataP[1].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[1].flags, 0);
-   CU_ASSERT_EQUAL(dataP[1].length, 1);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[1].value);
-   CU_ASSERT_EQUAL(dataP[1].value[0], 0);
-
-   dataP[2].flags = LWM2M_TLV_FLAG_TEXT_FORMAT;
-   lwm2m_data_encode_bool(0, &dataP[2]);
-   dataP[2].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[2].flags, LWM2M_TLV_FLAG_TEXT_FORMAT);
-   CU_ASSERT_EQUAL(dataP[2].length, 1);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[2].value);
-   CU_ASSERT_EQUAL(dataP[2].value[0], '0');
-
-   dataP[3].flags = LWM2M_TLV_FLAG_TEXT_FORMAT;
-   lwm2m_data_encode_bool(4, &dataP[3]);
-   dataP[3].type = LWM2M_TYPE_RESOURCE;
-   CU_ASSERT_EQUAL(dataP[3].flags, LWM2M_TLV_FLAG_TEXT_FORMAT);
-   CU_ASSERT_EQUAL(dataP[3].length, 1);
-   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP[3].value);
-   CU_ASSERT_EQUAL(dataP[3].value[0], '1');
-
-   lwm2m_data_free(10, dataP);
-   MEMORY_TRACE_AFTER_EQ;
-}
-
-static void test_tlv_decode_bool(void)
-{
-   MEMORY_TRACE_BEFORE;
-   uint8_t data1[] = { 0 };
-   uint8_t data2[] = { 1 };
-   uint8_t data3[] = { 2 };
    bool value;
    int result;
-   lwm2m_data_t *dataP =  lwm2m_data_new(10);
+   lwm2m_data_t *dataP =  lwm2m_data_new(1);
    CU_ASSERT_PTR_NOT_NULL(dataP);
 
    result = lwm2m_data_decode_bool(dataP, &value);
    CU_ASSERT_EQUAL(result, 0);
 
-   dataP[0].length = 2;
-   result = lwm2m_data_decode_bool(dataP, &value);
-   CU_ASSERT_EQUAL(result, 0);
-
-   dataP[0].flags = LWM2M_TLV_FLAG_STATIC_DATA;
-   dataP[0].length = 1;
-   dataP[0].value = data1;
+   lwm2m_data_encode_bool(true, dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_BOOLEAN);
+   CU_ASSERT_EQUAL(dataP->value.asBoolean, true);
    result = lwm2m_data_decode_bool(dataP, &value);
    CU_ASSERT_EQUAL(result, 1);
-   CU_ASSERT_FALSE(value);
+   CU_ASSERT_EQUAL(value, true);
 
-   dataP[0].value = data2;
+   lwm2m_data_encode_bool(false, dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_BOOLEAN);
+   CU_ASSERT_EQUAL(dataP->value.asBoolean, false);
    result = lwm2m_data_decode_bool(dataP, &value);
    CU_ASSERT_EQUAL(result, 1);
-   CU_ASSERT_TRUE(value);
+   CU_ASSERT_EQUAL(value, false);
 
-   dataP[0].value = data3;
-   result = lwm2m_data_decode_bool(dataP, &value);
-   CU_ASSERT_EQUAL(result, 0);
-
-   dataP[0].flags |= LWM2M_TLV_FLAG_TEXT_FORMAT;
-   dataP[0].value = (uint8_t *)"0";
+   lwm2m_data_encode_string("1", dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_STRING);
+   CU_ASSERT_EQUAL(dataP->value.asBuffer.length, 1);
+   CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, "1", 1));
    result = lwm2m_data_decode_bool(dataP, &value);
    CU_ASSERT_EQUAL(result, 1);
-   CU_ASSERT_FALSE(value);
+   CU_ASSERT_EQUAL(value, true);
 
-   dataP[0].value = (uint8_t *)"1";
+   lwm2m_data_encode_string("0", dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_STRING);
+   CU_ASSERT_EQUAL(dataP->value.asBuffer.length, 1);
+   CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, "0", 1));
    result = lwm2m_data_decode_bool(dataP, &value);
    CU_ASSERT_EQUAL(result, 1);
-   CU_ASSERT_TRUE(value);
+   CU_ASSERT_EQUAL(value, false);
 
-   dataP[0].value = (uint8_t *)"2";
+   uint8_t data1[] = { 0x00 };
+   lwm2m_data_encode_opaque(data1, sizeof(data1), dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OPAQUE);
+   CU_ASSERT_EQUAL(dataP->value.asBuffer.length, sizeof(data1));
+   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value.asBuffer.buffer);
+   CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, data1, sizeof(data1)));
    result = lwm2m_data_decode_bool(dataP, &value);
-   CU_ASSERT_EQUAL(result, 0);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, false);
+   lwm2m_free(dataP->value.asBuffer.buffer);
 
-   lwm2m_data_free(10, dataP);
+   uint8_t data2[] = { 0x01 };
+   lwm2m_data_encode_opaque(data2, sizeof(data2), dataP);
+   CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_OPAQUE);
+   CU_ASSERT_EQUAL(dataP->value.asBuffer.length, sizeof(data2));
+   CU_ASSERT_PTR_NOT_NULL_FATAL(dataP->value.asBuffer.buffer);
+   CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, data2, sizeof(data2)));
+   result = lwm2m_data_decode_bool(dataP, &value);
+   CU_ASSERT_EQUAL(result, 1);
+   CU_ASSERT_EQUAL(value, true);
+
+   lwm2m_data_free(1, dataP);
    MEMORY_TRACE_AFTER_EQ;
+}
+
+static void test_tlv_float(void)
+{
+    MEMORY_TRACE_BEFORE;
+    double value;
+    int result;
+    lwm2m_data_t *dataP = lwm2m_data_new(1);
+    CU_ASSERT_PTR_NOT_NULL(dataP);
+
+    result = lwm2m_data_decode_float(dataP, &value);
+    CU_ASSERT_EQUAL(result, 0);
+
+    lwm2m_data_encode_float(1234.56, dataP);
+    CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_FLOAT);
+    CU_ASSERT_EQUAL(dataP->value.asFloat, 1234.56);
+    result = lwm2m_data_decode_float(dataP, &value);
+    CU_ASSERT_EQUAL(result, 1);
+    CU_ASSERT_EQUAL(value, 1234.56);
+
+    lwm2m_data_encode_string("1234.56", dataP);
+    CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_STRING);
+    CU_ASSERT_EQUAL(dataP->value.asBuffer.length, 7);
+    CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, "1234.56", 7));
+    result = lwm2m_data_decode_float(dataP, &value);
+    CU_ASSERT_EQUAL(result, 1);
+    CU_ASSERT_EQUAL(value, 1234.56);
+
+    lwm2m_data_encode_string("-123456789.987", dataP);
+    CU_ASSERT_EQUAL(dataP->type, LWM2M_TYPE_STRING);
+    CU_ASSERT_EQUAL(dataP->value.asBuffer.length, 14);
+    CU_ASSERT(0 == memcmp(dataP->value.asBuffer.buffer, "-123456789.987", 14));
+    result = lwm2m_data_decode_float(dataP, &value);
+    CU_ASSERT_EQUAL(result, 1);
+    CU_ASSERT_EQUAL(value, -123456789.987);
+
+    lwm2m_data_free(1, dataP);
+    MEMORY_TRACE_AFTER_EQ;
 }
 
 static struct TestTable table[] = {
@@ -458,10 +428,9 @@ static struct TestTable table[] = {
         { "test of lwm2m_opaqueToInt()", test_opaqueToInt },
         { "test of lwm2m_data_parse()", test_tlv_parse },
         { "test of lwm2m_data_serialize()", test_tlv_serialize },
-        { "test of lwm2m_data_encode_int()", test_tlv_encode_int },
-        { "test of lwm2m_data_decode_int()", test_tlv_decode_int },
-        { "test of lwm2m_data_encode_bool()", test_tlv_encode_bool },
-        { "test of lwm2m_data_decode_bool()", test_tlv_decode_bool },
+        { "test of lwm2m_data_encode_int() and lwm2m_data_decode_int()", test_tlv_int },
+        { "test of lwm2m_data_encode_bool()and lwm2m_data_decode_bool()", test_tlv_bool },
+        { "test of lwm2m_data_encode_float() and lwm2m_data_decode_float()", test_tlv_float },
         { NULL, NULL },
 };
 


### PR DESCRIPTION
lwm2m_data_t structure is simpler to use. ```type``` and ```dataType``` fileds were merged and the ```flags``` field was removed.
lwm2m_data_encode_*() functions are enough to construct lwm2m_data_t arrays. The caller has to set the id manually.
lwm2m_data_decode_*() functions are more powerful as they try to convert strings or opaque to the required data type.

There is no distinction between resource values and resource instance values.

Note that TLV parsing always sets the lwm2m_data_t::type to opaque. JSON parsing sets the lwm2m_data_t::type to string, boolean, integer or float.