### PR TITLE
Make examples win32 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,93 @@
-Wakaama (formerly liblwm2m) is an implementation of the Open Mobile Alliance's LightWeight M2M
-protocol (LWM2M).
+Wakaama (formerly liblwm2m) is an implementation of the OMA LightWeight M2M
+protocol (LWM2M) in C suitable for gateway devices as well as embedded devices.
+
+Lightweight M2M is a protocol from the Open Mobile Alliance for M2M or IoT device management
+and communication. It uses CoAP, a light and compact protocol with an efficient resource data model,
+for the application layer communication between LWM2M Servers and LWM2M Clients.
 
 Developers mailing list: https://dev.eclipse.org/mailman/listinfo/wakaama-dev
 
-Source Layout
--------------
+## Compiling
+Wakaama is not a library but files to be built with your application.
+The integration is very easy if you also use the cmake buildsystem. Please
+have a look at one of the CMakeLists.txt files in the __examples__ directory.
+
+Compilation switches for enabling the server/client/bootstrap implementations:
+ - ``LWM2M_CLIENT_MODE`` to enable LWM2M Client interfaces.
+ - ``LWM2M_SERVER_MODE`` to enable LWM2M Server interfaces.
+ - ``LWM2M_BOOTSTRAP_SERVER_MODE`` to enable LWM2M Bootstrap Server interfaces.
+ - ``LWM2M_BOOTSTRAP`` to enable LWM2M Bootstrap support in a LWM2M Client.
+You cannot compile a library with bootstrap client and server support!
+
+Compilation switches for additional features:
+ - ``LWM2M_SUPPORT_JSON`` to enable JSON payload support (implicit when defining LWM2M_SERVER_MODE)
+
+Automatically determined compilation flags:
+ - ``LWM2M_LITTLE_ENDIAN`` if your target platform uses little-endian format. CMake determines this
+   automatically, you may overwrite this in a cross compilation file. If you do not use cmake, you have
+   define this if appropriate.
+
+## Network stack and platform integration
+Wakaama does not assume any specific network stack or platform calls to be present. You have to provide
+some platform abstraction methods and implement the glue code for your network stack yourself instead.
+
+Look at the __platforms__ directory for examples.
+
+## Examples
+There are some example applications provided to test the server, client and bootstrap capabilities of Wakaama.
+The following recipes assume you are on a unix like platform, you have cmake and make installed and your
+current directory is the wakaama repository root. Some of the examples also compile for Windows systems.
+
+### Server example
+Unix with make:
+ * ``mkdir build && cd build``
+ * ``cmake ../examples/server``
+ * ``make``
+ * ``./lwm2mserver [Options]``
+
+The lwm2mserver listens on UDP port 5683. It features a basic command line
+interface. Type 'help' for a list of supported commands.
+
+Options are:
+ - -4		Use IPv4 connection. Default: IPv6 connection
+
+
+### Client example
+Unix with make:
+ * ``mkdir build && cd build``
+ * ``cmake -DDTLS=0|1 ../examples/client`` Set DTLS to 1 if you want this feature.
+ * ``make``
+ * ``./lwm2mclient [Options]``
+
+The DTLS feature requires tinydtls. CMake will try to download and configure tinydtls for you.
+
+The lwm2mclient opens udp port 56830 and tries to register to a LWM2M Server at
+127.0.0.1:5683 (if IPv4 enabled). It features a basic command line interface. Type 'help' for a
+list of supported commands. To launch a bootstrap session: ``./lwm2mclient -b``
+
+Important options are:
+ - -4		Use IPv4 connection. Default: IPv6 connection
+
+Further implementation, command line and tinydtls details are documented in [[examples/client/README.md]]
+
+### Simpler client example
+Unix with make:
+ * ``mkdir build && cd build``
+ * ``cmake ../examples/lightclient``
+ * ``make``
+ * ``./lightclient [Options]``
+
+If you use Visual Studio 2010 or newer on a Windows operating system:
+ - Open CMake and choose [liblwm2m directory]/examples/lightclient as source dir and an arbitrary directory as build dir.
+ - Choose your VS compiler in the popoup dialog,
+ - Click __configure__ and __generate__ and open the ``.sln`` project file in the build directory.
+
+Important options are:
+ - -4		Use IPv4 connection. Default: IPv6 connection
+
+Further implementation details are documented in [[examples/lightclient/README.md]]
+
+## Source Layout
     -+- core                   (the LWM2M engine)
      |    |
      |    +- er-coap-13        (Erbium's CoAP engine from
@@ -29,124 +112,4 @@ Source Layout
           |
           +- utils             (utility functions for connection handling and command-
                                 line interface)
-
-
-Compiling
----------
-
-Despite its name, liblwm2m is not a library but files to be built with an
-application. liblwm2m uses CMake. Look at examples/server/CMakeLists.txt for an
-example of how to include it.
-Several compilation switches are used:
- - LWM2M_BIG_ENDIAN if your target platform uses big-endian format.
- - LWM2M_LITTLE_ENDIAN if your target platform uses little-endian format.
- - LWM2M_CLIENT_MODE to enable LWM2M Client interfaces.
- - LWM2M_SERVER_MODE to enable LWM2M Server interfaces.
- - LWM2M_BOOTSTRAP_SERVER_MODE to enable LWM2M Bootstrap Server interfaces.
- - LWM2M_BOOTSTRAP to enable LWM2M Bootstrap support in a LWM2M Client.
- - LWM2M_SUPPORT_JSON to enable JSON payload support (implicit when defining LWM2M_SERVER_MODE)
-Depending on your platform, you need to define LWM2M_BIG_ENDIAN or LWM2M_LITTLE_ENDIAN.
-LWM2M_CLIENT_MODE and LWM2M_SERVER_MODE can be defined at the same time.
-
-
-Examples
---------
-There are some example applications provided to test the server, client and bootstrap capabilities of Wakaama.
-The following recipes assume you are on a unix like platform and you have cmake and make installed.
-
-### Server example
- * Create a build directory and change to that.
- * ``cmake [liblwm2m directory]/examples/server``
- * ``make``
- * ``./lwm2mserver [Options]``
-
-The lwm2mserver listens on UDP port 5683. It features a basic command line
-interface. Type 'help' for a list of supported commands.
-
-Options are:
- - -4		Use IPv4 connection. Default: IPv6 connection
-
-
-### Test client example
- * Create a build directory and change to that.
- * ``cmake [liblwm2m directory]/examples/client``
- * ``make``
- * ``./lwm2mclient [Options]``
-
-DTLS feature requires tinydtls submodule. Look at examples/client/README.md for an example of how 
-to include tinydtls.
-
-Build with tinydtls:
- * Create a build directory and change to that.
- * ``cmake -DDTLS=1 [liblwm2m directory]/examples/client``
- * ``make``
- * ``./lwm2mclient_dtls [Options]``
-
-The lwm2mclient features nine LWM2M objects:
- - Security Object (id: 0)
- - Server Object (id: 1)
- - Access Control Object (id: 2) as a skeleton
- - Device Object (id: 3) containing hard-coded values from the Example LWM2M
- Client of Appendix E of the LWM2M Technical Specification.
- - Connectivity Monitoring Object (id: 2) as a skeleton
- - Firmware Update Object (id: 5) as a skeleton.
- - Location Object (id: 6) as a skeleton.
- - Connectivity Statistics Object (id: 7) as a skeleton.
- - a test object (id: 1024) with the following description:
-
-                           Multiple
-          Object |  ID  | Instances | Mandatoty |
-           Test  | 1024 |    Yes    |    No     |
-
-           Ressources:
-                       Supported    Multiple
-           Name | ID | Operations | Instances | Mandatory |  Type   | Range |
-           test |  1 |    R/W     |    No     |    Yes    | Integer | 0-255 |
-           exec |  2 |     E      |    No     |    Yes    |         |       |
-           dec  |  3 |    R/W     |    No     |    Yes    |  Float  |       |
-
-The lwm2mclient opens udp port 56830 and tries to register to a LWM2M Server at
-127.0.0.1:5683. It features a basic command line interface. Type 'help' for a
-list of supported commands.
-
-Options are:
-- -n NAME	Set the endpoint name of the Client. Default: testlwm2mclient
-- -l PORT	Set the local UDP port of the Client. Default: 56830
-- -h HOST	Set the hostname of the LWM2M Server to connect to. Default: localhost
-- -p HOST	Set the port of the LWM2M Server to connect to. Default: 5683
-- -4		Use IPv4 connection. Default: IPv6 connection
-- -t TIME	Set the lifetime of the Client. Default: 300
-- -b		Bootstrap requested.
-- -c		Change battery level over time.
-  
-If DTLS feature enable:
-- -i Set the device management or bootstrap server PSK identity. If not set use none secure mode
-- -s Set the device management or bootstrap server Pre-Shared-Key. If not set use none secure mode
-
-To launch a bootstrap session:
-``./lwm2mclient -b``
-
-
-### Simpler test client example
-
-In the any directory, run the following commands:
- * Create a build directory and change to that.
- * ``cmake [liblwm2m directory]/examples/lightclient``
- * ``make``
- * ``./lightclient [Options]``
-
-The lightclient is much simpler that the lwm2mclient and features only four
-LWM2M objects:
- - Security Object (id: 0)
- - Server Object (id: 1)
- - Device Object (id: 3) containing hard-coded values from the Example LWM2M
- Client of Appendix E of the LWM2M Technical Specification.
- - Test object (id: 1024) from the lwm2mclient as described above.
-
-The lightclient does not feature any command-line interface.
-
-Options are:
- -  -n NAME	Set the endpoint name of the Client. Default: testlightclient
- - -l PORT	Set the local UDP port of the Client. Default: 56830
- - -4		Use IPv4 connection. Default: IPv6 connection
 

--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -24,12 +24,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <sys/select.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netdb.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include <signal.h>

--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -1,27 +1,49 @@
-Compiling without DTLS 
----------
+## Implementation details
 
-You can then build the client using the commands:
-cmake wakaama/examples/client
-make
+The lwm2mclient features nine LWM2M objects:
+ - Security Object (id: 0)
+ - Server Object (id: 1)
+ - Access Control Object (id: 2) as a skeleton
+ - Device Object (id: 3) containing hard-coded values from the Example LWM2M
+ Client of Appendix E of the LWM2M Technical Specification.
+ - Connectivity Monitoring Object (id: 2) as a skeleton
+ - Firmware Update Object (id: 5) as a skeleton.
+ - Location Object (id: 6) as a skeleton.
+ - Connectivity Statistics Object (id: 7) as a skeleton.
+ - a test object (id: 1024) with the following description:
 
-Compiling with DTLS
----------
+                           Multiple
+          Object |  ID  | Instances | Mandatoty |
+           Test  | 1024 |    Yes    |    No     |
 
-This client can support DTLS. You can switch by DTLS=1.
+           Ressources:
+                       Supported    Multiple
+           Name | ID | Operations | Instances | Mandatory |  Type   | Range |
+           test |  1 |    R/W     |    No     |    Yes    | Integer | 0-255 |
+           exec |  2 |     E      |    No     |    Yes    |         |       |
+           dec  |  3 |    R/W     |    No     |    Yes    |  Float  |       |
 
-DTLS feature requires tinyDTLS.
-TinyDTLS is included as a GIT submodule. On first usage, you need to run the following commands to retrieve the sources:
-git submodule init
-git submodule update
+## Command line options
+Options are:
+- -n NAME	Set the endpoint name of the Client. Default: testlwm2mclient
+- -l PORT	Set the local UDP port of the Client. Default: 56830
+- -h HOST	Set the hostname of the LWM2M Server to connect to. Default: localhost
+- -p HOST	Set the port of the LWM2M Server to connect to. Default: 5683
+- -4		Use IPv4 connection. Default: IPv6 connection
+- -t TIME	Set the lifetime of the Client. Default: 300
+- -b		Bootstrap requested.
+- -c		Change battery level over time.
+  
+If DTLS feature enable:
+- -i Set the device management or bootstrap server PSK identity. If not set use none secure mode
+- -s Set the device management or bootstrap server Pre-Shared-Key. If not set use none secure mode
 
-You need to install the packages libtool and autoreconf.
-
-In the wakaama/examples/utils/tinydtls run the following commands:
-autoreconf -i
-./configure
-
-You can then build the client using the commands:
-cmake -DDTLS=1 wakaama/examples/client
-make
-
+## DTLS
+This client can support DTLS, enable by using DTLS=1.
+The DTLS feature requires tinyDTLS on the posix platform implementation.
+TinyDTLS is included as a GIT submodule and will be configured automatically for you by cmake.
+If that fails, you have to make sure that you have installed libtool and autoreconf and you need to run the following commands
+in __wakaama/platforms/Linux/tinydtls__:
+* git submodule update --init
+* autoreconf -i
+* ./configure

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -70,12 +70,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <sys/select.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netdb.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include <signal.h>

--- a/examples/lightclient/CMakeLists.txt
+++ b/examples/lightclient/CMakeLists.txt
@@ -22,5 +22,10 @@ SET(SOURCES
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${WAKAAMA_SOURCES} ${PLATFORM_SOURCES} ${UTILS_SOURCES})
 
+if (WIN32)
+	target_link_libraries(${PROJECT_NAME} wsock32 ws2_32)
+endif()
+
+
 # Add WITH_LOGS to debug variant
 set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:WITH_LOGS>)

--- a/examples/lightclient/README.md
+++ b/examples/lightclient/README.md
@@ -1,0 +1,26 @@
+## Implementation details
+
+The lightclient features the mandatory LWM2M objects 0, 1 and 3 and additionally a custom object:
+ - Security Object (id: 0)
+ - Server Object (id: 1)
+ - Device Object (id: 3) containing hard-coded values from the Example LWM2M
+ Client of Appendix E of the LWM2M Technical Specification.
+ - a test object (id: 1024) with the following description:
+
+                           Multiple
+          Object |  ID  | Instances | Mandatoty |
+           Test  | 1024 |    Yes    |    No     |
+
+           Ressources:
+                       Supported    Multiple
+           Name | ID | Operations | Instances | Mandatory |  Type   | Range |
+           test |  1 |    R/W     |    No     |    Yes    | Integer | 0-255 |
+           exec |  2 |     E      |    No     |    Yes    |         |       |
+           dec  |  3 |    R/W     |    No     |    Yes    |  Float  |       |
+
+## Command line options
+Options are:
+ - -n NAME	Set the endpoint name of the Client. Default: testlightclient
+ - -l PORT	Set the local UDP port of the Client. Default: 56830
+ - -4		Use IPv4 connection. Default: IPv6 connection
+

--- a/examples/lightclient/lightclient.c
+++ b/examples/lightclient/lightclient.c
@@ -63,12 +63,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <sys/select.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netdb.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include <signal.h>

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -59,12 +59,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <sys/select.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netdb.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include <signal.h>

--- a/examples/utils/commandline.c
+++ b/examples/utils/commandline.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
-#include <unistd.h>
 #include <inttypes.h>
 #include "liblwm2m.h"
 

--- a/platforms/Linux/connection.c
+++ b/platforms/Linux/connection.c
@@ -21,11 +21,22 @@
 #include <ctype.h>
 #include "connection.h"
 
+#ifdef _WIN32
+#define close(s) closesocket(s)
+#endif
+
 // from commandline.c
 void output_buffer(FILE * stream, uint8_t * buffer, int length, int indent);
 
 int create_socket(const char * portStr, int addressFamily)
 {
+    #ifdef _WIN32
+    struct WSAData d;
+    if (WSAStartup(MAKEWORD(2, 2), &d) != 0) {
+	    return -1;
+    }
+    #endif
+
     int s = -1;
     struct addrinfo hints;
     struct addrinfo *res;
@@ -140,7 +151,7 @@ connection_t * connection_create(connection_t * connList,
         close(s);
     }
     if (NULL != servinfo) {
-        free(servinfo);
+        freeaddrinfo(servinfo);
     }
 
     return connP;

--- a/platforms/Linux/connection.h
+++ b/platforms/Linux/connection.h
@@ -19,11 +19,22 @@
 #define CONNECTION_H_
 
 #include <stdio.h>
+#include <stdint.h>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <Winsock2.h>
+#include <ws2tcpip.h>
+#define LOG_ERR 3
+typedef uint16_t in_port_t;
+#else
 #include <unistd.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/socket.h>
+#include <sys/select.h>
+#endif
 #include <sys/stat.h>
 #include <liblwm2m.h>
 

--- a/platforms/Linux/platform.c
+++ b/platforms/Linux/platform.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include <sys/time.h>
+#include <sys/timeb.h> 
 
 #ifndef LWM2M_MEMORY_TRACE
 
@@ -49,14 +49,9 @@ int lwm2m_strncmp(const char * s1,
 
 time_t lwm2m_gettime(void)
 {
-    struct timeval tv;
-
-    if (0 != gettimeofday(&tv, NULL))
-    {
-        return -1;
-    }
-
-    return tv.tv_sec;
+	struct timeb start;
+	ftime(&start);
+	return start.time;
 }
 
 void lwm2m_printf(const char * format, ...)

--- a/platforms/Linux/platform.cmake
+++ b/platforms/Linux/platform.cmake
@@ -16,3 +16,8 @@ else()
     set(PLATFORM_INCLUDE_DIRS ${PLATFORM_SOURCES_DIR})
 endif()
 
+if(MSVC)
+	set(PLATFORM_SOURCES ${PLATFORM_SOURCES}
+		${PLATFORM_SOURCES_DIR}/visual_studio_compiler/getopt.c)
+	set(PLATFORM_INCLUDE_DIRS ${PLATFORM_INCLUDE_DIRS} ${PLATFORM_SOURCES_DIR}/visual_studio_compiler)
+endif()

--- a/platforms/Linux/visual_studio_compiler/getopt.c
+++ b/platforms/Linux/visual_studio_compiler/getopt.c
@@ -1,0 +1,106 @@
+/*
+* Copyright (c) 1987, 1993, 1994
+*      The Regents of the University of California.  All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*      This product includes software developed by the University of
+*      California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+
+#include "unistd.h"
+
+#include <string.h>
+#include <stdio.h>
+
+int opterr = 1, /* if error message should be printed */
+    optind = 1, /* index into parent argv vector */
+    optopt,     /* character checked for validity */
+    optreset;   /* reset getopt */
+char *optarg;   /* argument associated with option */
+
+#define BADCH   (int)'?'
+#define BADARG  (int)':'
+#define EMSG    ""
+
+/*
+ * getopt --
+ *      Parse argc/argv argument vector.
+ */
+int getopt(int nargc, char * const nargv[], const char *ostr)
+{
+  static char *place = EMSG;              /* option letter processing */
+  const char *oli;                        /* option letter list index */
+
+  if (optreset || !*place) {              /* update scanning pointer */
+    optreset = 0;
+    if (optind >= nargc || *(place = nargv[optind]) != '-') {
+      place = EMSG;
+      return (-1);
+    }
+    if (place[1] && *++place == '-') {      /* found "--" */
+      ++optind;
+      place = EMSG;
+      return (-1);
+    }
+  }                                       /* option letter okay? */
+  if ((optopt = (int)*place++) == (int)':' ||
+    !(oli = strchr(ostr, optopt))) {
+      /*
+      * if the user didn't specify '-' as an option,
+      * assume it means -1.
+      */
+      if (optopt == (int)'-')
+        return (-1);
+      if (!*place)
+        ++optind;
+      if (opterr && *ostr != ':')
+        (void)printf("illegal option -- %c\n", optopt);
+      return (BADCH);
+  }
+  if (*++oli != ':') {                    /* don't need argument */
+    optarg = NULL;
+    if (!*place)
+      ++optind;
+  }
+  else {                                  /* need an argument */
+    if (*place)                     /* no white space */
+      optarg = place;
+    else if (nargc <= ++optind) {   /* no arg */
+      place = EMSG;
+      if (*ostr == ':')
+        return (BADARG);
+      if (opterr)
+        (void)printf("option requires an argument -- %c\n", optopt);
+      return (BADCH);
+    }
+    else                            /* white space */
+      optarg = nargv[optind];
+    place = EMSG;
+    ++optind;
+  }
+  return (optopt);                        /* dump back option letter */
+}

--- a/platforms/Linux/visual_studio_compiler/unistd.h
+++ b/platforms/Linux/visual_studio_compiler/unistd.h
@@ -1,0 +1,38 @@
+/*
+* Copyright (c) 1987, 1993, 1994
+*      The Regents of the University of California.  All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. All advertising materials mentioning features or use of this software
+*    must display the following acknowledgement:
+*      This product includes software developed by the University of
+*      California, Berkeley and its contributors.
+* 4. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*/
+#pragma once
+
+extern char *optarg;
+
+int getopt(int argc, char * const argv[],
+	const char *optstring);


### PR DESCRIPTION
This pull request contains only minimal invasive changes to make
the platform sources win32 compatible. The third commit provides
visual studio compatibility: The VS compiler does not provide unistd.h with getopt.

The entire pull request allows the light client example to be build
on windows with visual studio.

Benefits:
- Windows users can setup a working wakaama application and
  may contribute to the core library more easily.
- The enhanced debugging tools of Visual Studio allow for example to analyse the
  memory profile of the core out of the box. 

Please note: Windows does not allow stdin for select() so all examples with an interactive
shell cannot be build for windows without more invasive changes.

If accepted: It may make sense in that case to rename platforms/Linux to platforms/Posix or something similar. The socket api is posix and platform calls, too.
