### PR TITLE
Examples: remove usage of getopt() for portability reasons.

### DIFF
--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -89,7 +89,7 @@ void print_usage(char * filename,
     fprintf(stderr, "Launch a LWM2M Bootstrap Server.\r\n\n");
     fprintf(stdout, "Options:\r\n");
     fprintf(stdout, "  -f FILE\tSpecify BootStrap Information file. Default: ./%s\r\n", filename);
-    fprintf(stdout, "  -p PORT\tSet the local UDP port of the Client. Default: %s\r\n", port);
+    fprintf(stdout, "  -l PORT\tSet the local UDP port of the Client. Default: %s\r\n", port);
     fprintf(stdout, "  -4\t\tUse IPv4 connection. Default: IPv6 connection\r\n");
     fprintf(stdout, "\r\n");
 }
@@ -498,15 +498,35 @@ int main(int argc, char *argv[])
 
     data.addressFamily = AF_INET6;
 
-    while ((opt = getopt(argc, argv, "f:p:4")) != -1)
+    opt = 1;
+    while (opt < argc)
     {
-        switch (opt)
+        if (argv[opt] == NULL
+         || argv[opt][0] != '-'
+         || argv[opt][2] != 0)
+        {
+            print_usage(filename, port);
+            return 0;
+        }
+        switch (argv[opt][1])
         {
         case 'f':
-            filename = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage(filename, port);
+                return 0;
+            }
+            filename = argv[opt];
             break;
-        case 'p':
-            port = optarg;
+        case 'l':
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage(filename, port);
+                return 0;
+            }
+            port = argv[opt];
             break;
         case '4':
             data.addressFamily = AF_INET;
@@ -515,6 +535,7 @@ int main(int argc, char *argv[])
             print_usage(filename, port);
             return 0;
         }
+        opt += 1;
     }
 
     data.sock = create_socket(port, data.addressFamily);

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -884,13 +884,17 @@ int main(int argc, char *argv[])
     memset(&data, 0, sizeof(client_data_t));
     data.addressFamily = AF_INET6;
 
-#ifdef WITH_TINYDTLS
-    while ((opt = getopt(argc, argv, "bcl:n:p:t:i:s:h:4")) != -1)
-#else
-    while ((opt = getopt(argc, argv, "bcl:n:p:t:h:4")) != -1)
-#endif
+    opt = 1;
+    while (opt < argc)
     {
-        switch (opt)
+        if (argv[opt] == NULL
+            || argv[opt][0] != '-'
+            || argv[opt][2] != 0)
+        {
+            print_usage();
+            return 0;
+        }
+        switch (argv[opt][1])
         {
         case 'b':
             bootstrapRequested = true;
@@ -900,27 +904,73 @@ int main(int argc, char *argv[])
             batterylevelchanging = 1;
             break;
         case 't':
-            sscanf(optarg, "%d", &lifetime);
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            if (1 != sscanf(argv[opt], "%d", &lifetime))
+            {
+                print_usage();
+                return 0;
+            }
             break;
 #ifdef WITH_TINYDTLS
         case 'i':
-            pskId = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            pskId = argv[opt];
             break;
         case 's':
-            psk = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            psk = argv[opt];
             break;
 #endif						
         case 'n':
-            name = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            name = argv[opt];
             break;
         case 'l':
-            localPort = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            localPort = argv[opt];
             break;
         case 'h':
-            server = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            server = argv[opt];
             break;
         case 'p':
-            serverPort = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            serverPort = argv[opt];
             serverPortChanged = true;
             break;
         case '4':
@@ -930,6 +980,7 @@ int main(int argc, char *argv[])
             print_usage();
             return 0;
         }
+        opt += 1;
     }
 
     if (!server)

--- a/examples/lightclient/lightclient.c
+++ b/examples/lightclient/lightclient.c
@@ -301,15 +301,35 @@ int main(int argc, char *argv[])
 
     data.addressFamily = AF_INET6;
 
-    while ((opt = getopt(argc, argv, "l:n:t:4")) != -1)
+    opt = 1;
+    while (opt < argc)
     {
-        switch (opt)
+        if (argv[opt] == NULL
+            || argv[opt][0] != '-'
+            || argv[opt][2] != 0)
+        {
+            print_usage();
+            return 0;
+        }
+        switch (argv[opt][1])
         {
         case 'n':
-            name = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            name = argv[opt];
             break;
         case 'l':
-            localPort = optarg;
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            localPort = argv[opt];
             break;
         case '4':
             data.addressFamily = AF_INET;
@@ -318,6 +338,7 @@ int main(int argc, char *argv[])
             print_usage();
             return 0;
         }
+        opt += 1;
     }
 
     /*

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -788,9 +788,10 @@ void handle_sigint(int signum)
 void print_usage(void)
 {
     fprintf(stderr, "Usage: lwm2mserver [OPTION]\r\n");
-    fprintf(stderr, "Launch a LWM2M server on localhost port "LWM2M_STANDARD_PORT_STR".\r\n\n");
+    fprintf(stderr, "Launch a LWM2M server on localhost.\r\n\n");
     fprintf(stdout, "Options:\r\n");
     fprintf(stdout, "  -4\t\tUse IPv4 connection. Default: IPv6 connection\r\n");
+    fprintf(stdout, "  -l PORT\tSet the local UDP port of the Server. Default: "LWM2M_STANDARD_PORT_STR"\r\n");
     fprintf(stdout, "\r\n");
 }
 
@@ -806,6 +807,7 @@ int main(int argc, char *argv[])
     connection_t * connList = NULL;
     int addressFamily = AF_INET6;
     int opt;
+    const char * localPort = LWM2M_STANDARD_PORT_STR;
 
     command_desc_t commands[] =
     {
@@ -867,21 +869,38 @@ int main(int argc, char *argv[])
             COMMAND_END_LIST
     };
 
-    while ((opt = getopt(argc, argv, "4")) != -1)
+    opt = 1;
+    while (opt < argc)
     {
-        switch (opt)
+        if (argv[opt] == NULL
+            || argv[opt][0] != '-'
+            || argv[opt][2] != 0)
+        {
+            print_usage();
+            return 0;
+        }
+        switch (argv[opt][1])
         {
         case '4':
             addressFamily = AF_INET;
+            break;
+        case 'l':
+            opt++;
+            if (opt >= argc)
+            {
+                print_usage();
+                return 0;
+            }
+            localPort = argv[opt];
             break;
         default:
             print_usage();
             return 0;
         }
+        opt += 1;
     }
 
-
-    sock = create_socket(LWM2M_STANDARD_PORT_STR, addressFamily);
+    sock = create_socket(localPort, addressFamily);
     if (sock < 0)
     {
         fprintf(stderr, "Error opening socket: %d\r\n", errno);


### PR DESCRIPTION
Signed-off-by: David Navarro <david.navarro@intel.com>