### PR TITLE
Examples: Check PSK command line argument

### DIFF
--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -17,7 +17,7 @@ git submodule update
 
 You need to install the packages libtool and autoreconf.
 
-In the wakaama/examples/utils/tinydtls run the following commands:
+In the wakaama/examples/shared/tinydtls run the following commands:
 autoreconf -i
 ./configure
 

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -1004,10 +1004,11 @@ int main(int argc, char *argv[])
      * Those functions are located in their respective object file.
      */
 #ifdef WITH_TINYDTLS
-    if (psk!= NULL)
+    if (psk != NULL)
     {
-        pskLen = (strlen(psk) / 2);
-        pskBuffer = malloc(pskLen+1);
+        pskLen = strlen(psk) / 2;
+        pskBuffer = malloc(pskLen);
+
         if (NULL == pskBuffer)
         {
             fprintf(stderr, "Failed to create PSK binary buffer\r\n");
@@ -1020,7 +1021,16 @@ int main(int argc, char *argv[])
 
         for ( ; *h; h += 2, ++b)
         {
-           *b = ((strchr(xlate, toupper(*h)) - xlate) * 16) + ((strchr(xlate, toupper(*(h+1))) - xlate));
+            char *l = strchr(xlate, toupper(*h));
+            char *r = strchr(xlate, toupper(*(h+1)));
+
+            if (!r || !l)
+            {
+                fprintf(stderr, "Failed to parse Pre-Shared-Key HEXSTRING\r\n");
+                return -1;
+            }
+
+            *b = ((l - xlate) << 4) + (r - xlate);
         }
     }
 #endif


### PR DESCRIPTION
An information about the error is a little bit better than a segmentation fault. Segfaults make new coming users confused. To avoid this we need to provide maximum information about possible faults in examples.

I've also made some changes in the security object. Mostly I've added a few checks of pointers. I'm not sure that we can use PSK without PSK-Id. Anyway that checks allow to avoid possible segmentation faults on strdup's.

README.md is updated up to current .gitmodules file.