### PR TITLE
API CHANGE: Add a new connection layer callback: lwm2m_close_connection()

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -165,11 +165,19 @@ void bootstrap_step(lwm2m_context_t * contextP,
             break;
 
         case STATE_BS_FINISHED:
-            // do nothing
+            if (targetP->sessionH != NULL)
+            {
+                lwm2m_close_connection(targetP->sessionH, contextP->userData);
+                targetP->sessionH = NULL;
+            }
             break;
 
         case STATE_BS_FAILED:
-            // do nothing
+            if (targetP->sessionH != NULL)
+            {
+                lwm2m_close_connection(targetP->sessionH, contextP->userData);
+                targetP->sessionH = NULL;
+            }
             break;
 
         default:

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -114,6 +114,10 @@ void lwm2m_printf(const char * format, ...);
 // secObjInstID: ID of the Securty Object instance to open a connection to
 // userData: parameter to lwm2m_init()
 void * lwm2m_connect_server(uint16_t secObjInstID, void * userData);
+// Close a session created by lwm2m_connect_server()
+// sessionH: session handle identifying the peer (opaque to the core)
+// userData: parameter to lwm2m_init()
+void lwm2m_close_connection(void * sessionH, void * userData);
 #endif
 // Send data to a peer
 // Returns COAP_NO_ERROR or a COAP_NNN error code

--- a/core/registration.c
+++ b/core/registration.c
@@ -1095,7 +1095,9 @@ void registration_step(lwm2m_context_t * contextP,
     targetP = contextP->serverList;
     while (targetP != NULL)
     {
-        if (targetP->status == STATE_REGISTERED)
+        switch (targetP->status)
+        {
+        case STATE_REGISTERED:
         {
             time_t nextUpdate;
             time_t interval;
@@ -1116,6 +1118,19 @@ void registration_step(lwm2m_context_t * contextP,
             {
                 *timeoutP = interval;
             }
+        }
+        break;
+
+        case STATE_REG_FAILED:
+            if (targetP->sessionH != NULL)
+            {
+                lwm2m_close_connection(targetP->sessionH, contextP->userData);
+                targetP->sessionH = NULL;
+            }
+            break;
+
+        default:
+            break;
         }
         targetP = targetP->next;
     }

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -280,10 +280,18 @@ void lwm2m_close_connection(void * sessionH,
                             void * userData)
 {
     client_data_t * app_data;
+#ifdef WITH_TINYDTLS
+    dtls_connection_t * targetP;
+#else
     connection_t * targetP;
+#endif
 
     app_data = (client_data_t *)userData;
+#ifdef WITH_TINYDTLS
+    targetP = (dtls_connection_t *)sessionH;
+#else
     targetP = (connection_t *)sessionH;
+#endif
 
     if (targetP == app_data->connList)
     {
@@ -292,7 +300,11 @@ void lwm2m_close_connection(void * sessionH,
     }
     else
     {
+#ifdef WITH_TINYDTLS
+        dtls_connection_t * parentP;
+#else
         connection_t * parentP;
+#endif
 
         parentP = app_data->connList;
         while (parentP != NULL && parentP->next != targetP)

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -276,6 +276,37 @@ exit:
 }
 #endif
 
+void lwm2m_close_connection(void * sessionH,
+                            void * userData)
+{
+    client_data_t * app_data;
+    connection_t * targetP;
+
+    app_data = (client_data_t *)userData;
+    targetP = (connection_t *)sessionH;
+
+    if (targetP == app_data->connList)
+    {
+        app_data->connList = targetP->next;
+        lwm2m_free(targetP);
+    }
+    else
+    {
+        connection_t * parentP;
+
+        parentP = app_data->connList;
+        while (parentP != NULL && parentP->next != targetP)
+        {
+            parentP = parentP->next;
+        }
+        if (parentP != NULL)
+        {
+            parentP->next = targetP->next;
+            lwm2m_free(targetP);
+        }
+    }
+}
+
 static void prv_output_servers(char * buffer,
                                void * user_data)
 {
@@ -742,18 +773,6 @@ static void prv_restore_objects(lwm2m_context_t * context)
     fprintf(stdout, "[BOOTSTRAP] ObjectList restored\r\n");
 }
 
-static void prv_connections_free(lwm2m_context_t * context)
-{
-    client_data_t * app_data;
-
-    app_data = context->userData;
-    if (NULL != app_data)
-    {
-        connection_free(app_data->connList);
-        app_data->connList = NULL;
-    }
-}
-
 static void update_bootstrap_info(lwm2m_client_state_t * previousBootstrapState,
         lwm2m_context_t * context)
 {
@@ -767,12 +786,6 @@ static void update_bootstrap_info(lwm2m_client_state_t * previousBootstrapState,
                 fprintf(stdout, "[BOOTSTRAP] backup security and server objects\r\n");
 #endif
                 prv_backup_objects(context);
-                break;
-            case STATE_REGISTER_REQUIRED:
-#ifdef WITH_LOGS
-                fprintf(stdout, "[BOOTSTRAP] free connections\r\n");
-#endif
-                prv_connections_free(context);
                 break;
             default:
                 break;
@@ -1225,7 +1238,6 @@ int main(int argc, char *argv[])
 #ifdef WITH_LOGS
                 fprintf(stdout, "[BOOTSTRAP] restore security and server objects\r\n");
 #endif
-                prv_connections_free(lwm2mH);
                 prv_restore_objects(lwm2mH);
                 lwm2mH->state = STATE_INITIAL;
             }

--- a/examples/lightclient/lightclient.c
+++ b/examples/lightclient/lightclient.c
@@ -161,6 +161,37 @@ exit:
     return (void *)newConnP;
 }
 
+void lwm2m_close_connection(void * sessionH,
+                            void * userData)
+{
+    client_data_t * app_data;
+    connection_t * targetP;
+
+    app_data = (client_data_t *)userData;
+    targetP = (connection_t *)sessionH;
+
+    if (targetP == app_data->connList)
+    {
+        app_data->connList = targetP->next;
+        lwm2m_free(targetP);
+    }
+    else
+    {
+        connection_t * parentP;
+
+        parentP = app_data->connList;
+        while (parentP != NULL && parentP->next != targetP)
+        {
+            parentP = parentP->next;
+        }
+        if (parentP != NULL)
+        {
+            parentP->next = targetP->next;
+            lwm2m_free(targetP);
+        }
+    }
+}
+
 void print_usage(void)
 {
     fprintf(stdout, "Usage: lwm2mclient [OPTION]\r\n");


### PR DESCRIPTION
Fix issue #155.
In client mode, the core now calls  lwm2m_close_connection() at the end of the bootstrap (successful or not) and when a registration fails.

Signed-off-by: David Navarro <david.navarro@intel.com>