### PR TITLE
Bug fix: Add a missing break in lwm2m_data_decode_float().

### DIFF
--- a/core/data.c
+++ b/core/data.c
@@ -265,6 +265,7 @@ int lwm2m_data_decode_float(const lwm2m_data_t * dataP,
         {
             result = 0;
         }
+        break;
 
     default:
         return 0;


### PR DESCRIPTION
Signed-off-by: David Navarro <david.navarro@intel.com>