### PR TITLE
Add a new compilation flag WITH_CONFIG_HEADER.

### DIFF
--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -62,6 +62,10 @@ extern "C" {
 #include <stdbool.h>
 #include <time.h>
 
+#ifdef WITH_CONFIG_HEADER
+#include "liblwm2m_config.h"
+#endif
+
 #ifdef LWM2M_SERVER_MODE
 #ifndef LWM2M_SUPPORT_JSON
 #define LWM2M_SUPPORT_JSON


### PR DESCRIPTION
This allows to have all other compilation flags defined in a user-specific header file named "lwm2m_config.h".

This is useful for bulding in an IDE.

Signed-off-by: David Navarro <david.navarro@intel.com>