### PR TITLE
Fix registration update issues.

### DIFF
--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -192,11 +192,11 @@ static int prv_refreshServerList(lwm2m_context_t * contextP)
     while (targetP != NULL)
     {
         nextP = targetP->next;
+        targetP->next = NULL;
         if (!targetP->dirty)
         {
             targetP->status = STATE_DEREGISTERED;
-            targetP->next = contextP->bootstrapServerList;
-            contextP->bootstrapServerList = targetP;
+            contextP->bootstrapServerList = (lwm2m_server_t *)LWM2M_LIST_ADD(contextP->bootstrapServerList, targetP);
         }
         else
         {
@@ -209,11 +209,11 @@ static int prv_refreshServerList(lwm2m_context_t * contextP)
     while (targetP != NULL)
     {
         nextP = targetP->next;
+        targetP->next = NULL;
         if (!targetP->dirty)
         {
             // TODO: Should we revert the status to STATE_DEREGISTERED ?
-            targetP->next = contextP->serverList;
-            contextP->serverList = targetP;
+            contextP->serverList = (lwm2m_server_t *)LWM2M_LIST_ADD(contextP->serverList, targetP);;
         }
         else
         {
@@ -426,6 +426,15 @@ next_step:
     break;
 
     case STATE_READY:
+        if (registration_getStatus(contextP) == STATE_REG_FAILED)
+        {
+            // TODO avoid infinite loop by checking the bootstrap info is different
+            contextP->state = STATE_BOOTSTRAP_REQUIRED;
+            goto next_step;
+            break;
+        }
+        break;
+
     default:
         // do nothing
         break;

--- a/core/registration.c
+++ b/core/registration.c
@@ -292,12 +292,22 @@ int lwm2m_update_registration(lwm2m_context_t * contextP,
             if (targetP->shortID == shortServerID)
             {
                 // found the server, trigger the update transaction
-                return prv_updateRegistration(contextP, targetP, withObjects);
+                if (targetP->status == STATE_REGISTERED)
+                {
+                    return prv_updateRegistration(contextP, targetP, withObjects);
+                }
+                else
+                {
+                    return COAP_400_BAD_REQUEST;
+                }
             }
         }
         else
         {
-            result = prv_updateRegistration(contextP, targetP, withObjects);
+            if (targetP->status == STATE_REGISTERED)
+            {
+                result = prv_updateRegistration(contextP, targetP, withObjects);
+            }
         }
         targetP = targetP->next;
     }


### PR DESCRIPTION
A failed registration update has now the same effect as a failed registration.
If there is no valid registration to a LWM2M Server, the client returns to the BOOTSTRAP_REQUIRED state.

Also include fixes for #169 and #170.

Signed-off-by: David Navarro <david.navarro@intel.com>