### PR TITLE
Prevent usage of option -DDTLS=1 in example server and bootstrap_server.

### DIFF
--- a/examples/bootstrap_server/CMakeLists.txt
+++ b/examples/bootstrap_server/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required (VERSION 3.0)
 
 project (bootstrap_server)
 
+if(DTLS)
+    message(FATAL_ERROR "DTLS option is not supported." )
+endif()
+
 include(${CMAKE_CURRENT_LIST_DIR}/../../core/wakaama.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/shared.cmake)
 

--- a/examples/lightclient/CMakeLists.txt
+++ b/examples/lightclient/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required (VERSION 3.0)
 
 project (lightclient)
 
+if(DTLS)
+    message(FATAL_ERROR "DTLS option is not supported." )
+endif()
+
 include(${CMAKE_CURRENT_LIST_DIR}/../../core/wakaama.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/shared.cmake)
 

--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required (VERSION 2.8)
 
 project (lwm2mserver)
 
-unset(DTLS CACHE)
+if(DTLS)
+    message(FATAL_ERROR "DTLS option is not supported." )
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../../core/wakaama.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/shared.cmake)


### PR DESCRIPTION
server and bootstrap_server are not designed to handle dtls connections.

Signed-off-by: David Navarro <david.navarro@intel.com>