### PR TITLE
add block1 support of incoming request for LWM2M client.

### DIFF
--- a/core/block1.c
+++ b/core/block1.c
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2016 Intel Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Simon Bernard - initial API and implementation
+ *
+ *******************************************************************************/
+/*
+ Copyright (c) 2016 Intel Corporation
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+     * Neither the name of Intel Corporation nor the names of its contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "internals.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+coap_status_t coap_block1_handler(lwm2m_block1_data_t ** head,
+                                  uint16_t mid,
+                                  uint8_t * buffer,
+                                  size_t length,
+                                  lwm2m_server_t * server,
+                                  uint16_t blockSize,
+                                  uint32_t blockNum,
+                                  bool blockMore,
+                                  uint8_t ** outputBuffer,
+                                  size_t * outputLength)
+{
+    if (server == NULL)
+    {
+        return COAP_500_INTERNAL_SERVER_ERROR;
+    }
+
+    // find current block1 data for this server
+    lwm2m_block1_data_t * block1Data = (lwm2m_block1_data_t *) LWM2M_LIST_FIND(*head, server->shortID);
+
+
+    // manage new block1 transfer
+    if (blockNum == 0)
+    {
+       // we already have block1 data for this server, clear it
+       if (block1Data != NULL)
+       {
+           lwm2m_free(block1Data->block1buffer);
+       }
+       else
+       {
+           block1Data = lwm2m_malloc(sizeof(lwm2m_block1_data_t));
+           if (NULL == block1Data) return COAP_500_INTERNAL_SERVER_ERROR;
+           block1Data->serverID = server->shortID;
+           *head = (lwm2m_block1_data_t *) LWM2M_LIST_ADD(*head, block1Data);
+       }
+
+       block1Data->block1buffer = lwm2m_malloc(length);
+       block1Data->block1bufferSize = length;
+
+       // write new block in buffer
+       memcpy(block1Data->block1buffer, buffer, length);
+       block1Data->lastmid = mid;
+    }
+    // manage already started block1 transfer
+    else
+    {
+       if (block1Data == NULL)
+       {
+           // we never receive the first block
+           // TODO should we clean block1 data for this server ?
+           return COAP_408_REQ_ENTITY_INCOMPLETE;
+       }
+
+       // If this is a retransmission, we already do that.
+       if (block1Data->lastmid != mid)
+       {
+           if (block1Data->block1bufferSize != blockSize * blockNum)
+          {
+              // we don't receive block in right order
+              // TODO should we clean block1 data for this server ?
+              return COAP_408_REQ_ENTITY_INCOMPLETE;
+          }
+
+          // re-alloc new buffer
+          uint8_t * oldBuffer = block1Data->block1buffer;
+          size_t oldSize = block1Data->block1bufferSize;
+          block1Data->block1bufferSize = oldSize+length;
+          block1Data->block1buffer = lwm2m_malloc(block1Data->block1bufferSize);
+          if (NULL == block1Data->block1buffer) return COAP_500_INTERNAL_SERVER_ERROR;
+          memcpy(block1Data->block1buffer, oldBuffer, oldSize);
+          lwm2m_free(oldBuffer);
+
+          // write new block in buffer
+          memcpy(block1Data->block1buffer + oldSize, buffer, length);
+          block1Data->lastmid = mid;
+       }
+    }
+
+    if (blockMore)
+    {
+        *outputLength = -1;
+        return COAP_231_CONTINUE;
+    }
+    else
+    {
+        // buffer is full, set output parameter
+        // we don't free it to be able to send retransmission
+        *outputLength = block1Data->block1bufferSize;
+        *outputBuffer = block1Data->block1buffer;
+
+        return NO_ERROR;
+    }
+}
+
+void free_block1_buffer(lwm2m_block1_data_t * head)
+{
+    if (head != NULL)
+    {
+        // free block1 buffer
+        lwm2m_free(head->block1buffer);
+        head->block1bufferSize = 0 ;
+
+        // free current element
+        lwm2m_block1_data_t * nextP;
+        nextP = head->next;
+        lwm2m_free(head);
+
+        // free next element
+        free_block1_buffer(nextP);
+    }
+}

--- a/core/block1.c
+++ b/core/block1.c
@@ -46,6 +46,9 @@
 #include <string.h>
 #include <stdio.h>
 
+// the maximum payload transfered by block1 we accumulate per server
+#define MAX_BLOCK1_SIZE 4096
+
 coap_status_t coap_block1_handler(lwm2m_block1_data_t ** pBlock1Data,
                                   uint16_t mid,
                                   uint8_t * buffer,
@@ -90,7 +93,7 @@ coap_status_t coap_block1_handler(lwm2m_block1_data_t ** pBlock1Data,
            return COAP_408_REQ_ENTITY_INCOMPLETE;
        }
 
-       // If this is a retransmission, we already do that.
+       // If this is a retransmission, we already did that.
        if (block1Data->lastmid != mid)
        {
            if (block1Data->block1bufferSize != blockSize * blockNum)
@@ -100,6 +103,10 @@ coap_status_t coap_block1_handler(lwm2m_block1_data_t ** pBlock1Data,
               return COAP_408_REQ_ENTITY_INCOMPLETE;
           }
 
+          // is it too large?
+          if (block1Data->block1bufferSize + length >= MAX_BLOCK1_SIZE) {
+              return COAP_413_ENTITY_TOO_LARGE;
+          }
           // re-alloc new buffer
           uint8_t * oldBuffer = block1Data->block1buffer;
           size_t oldSize = block1Data->block1bufferSize;

--- a/core/internals.h
+++ b/core/internals.h
@@ -306,8 +306,8 @@ size_t json_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * tlvP, uint8_t
 int discover_serialize(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
 
 // defined in block1.c
-coap_status_t coap_block1_handler(lwm2m_block1_data_t ** head, uint16_t mid, uint8_t * buffer, size_t length, lwm2m_server_t * server, uint16_t blockSize, uint32_t blockNum, bool blockMore, uint8_t ** outputBuffer, size_t * outputLength);
-void free_block1_buffer(lwm2m_block1_data_t * head);
+coap_status_t coap_block1_handler(lwm2m_block1_data_t ** block1Data, uint16_t mid, uint8_t * buffer, size_t length, uint16_t blockSize, uint32_t blockNum, bool blockMore, uint8_t ** outputBuffer, size_t * outputLength);
+void free_block1_buffer(lwm2m_block1_data_t * block1Data);
 
 // defined in utils.c
 lwm2m_data_type_t utils_depthToDatatype(uri_depth_t depth);

--- a/core/internals.h
+++ b/core/internals.h
@@ -305,6 +305,10 @@ size_t json_serialize(lwm2m_uri_t * uriP, int size, lwm2m_data_t * tlvP, uint8_t
 // defined in discover.c
 int discover_serialize(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
 
+// defined in block1.c
+coap_status_t coap_block1_handler(lwm2m_block1_data_t ** head, uint16_t mid, uint8_t * buffer, size_t length, lwm2m_server_t * server, uint16_t blockSize, uint32_t blockNum, bool blockMore, uint8_t ** outputBuffer, size_t * outputLength);
+void free_block1_buffer(lwm2m_block1_data_t * head);
+
 // defined in utils.c
 lwm2m_data_type_t utils_depthToDatatype(uri_depth_t depth);
 lwm2m_binding_t utils_stringToBinding(uint8_t *buffer, size_t length);

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -94,6 +94,7 @@ static void prv_deleteServer(lwm2m_server_t * serverP)
     {
         lwm2m_free(serverP->location);
     }
+    free_block1_buffer(serverP->block1Data);
     lwm2m_free(serverP);
 }
 
@@ -108,10 +109,23 @@ static void prv_deleteServerList(lwm2m_context_t * context)
     }
 }
 
-static void prv_deleteBootstrapServerList(lwm2m_context_t * contextP)
+static void prv_deleteBootstrapServer(lwm2m_server_t * serverP)
 {
-    LWM2M_LIST_FREE(contextP->bootstrapServerList);
-    contextP->bootstrapServerList = NULL;
+    // TODO should we free location as in prv_deleteServer ?
+    // TODO should we parse transaction and observation to remove the ones related to this server ?
+    free_block1_buffer(serverP->block1Data);
+    lwm2m_free(serverP);
+}
+
+static void prv_deleteBootstrapServerList(lwm2m_context_t * context)
+{
+    while (NULL != context->bootstrapServerList)
+    {
+        lwm2m_server_t * server;
+        server = context->bootstrapServerList;
+        context->bootstrapServerList = server->next;
+        prv_deleteBootstrapServer(server);
+    }
 }
 
 static void prv_deleteObservedList(lwm2m_context_t * contextP)
@@ -165,11 +179,6 @@ void lwm2m_close(lwm2m_context_t * contextP)
     {
         lwm2m_free(contextP->altPath);
     }
-    if (contextP->block1DataList != NULL)
-    {
-        free_block1_buffer(contextP->block1DataList);
-    }
-
 
 #endif
 

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -165,6 +165,11 @@ void lwm2m_close(lwm2m_context_t * contextP)
     {
         lwm2m_free(contextP->altPath);
     }
+    if (contextP->block1DataList != NULL)
+    {
+        free_block1_buffer(contextP->block1DataList);
+    }
+
 
 #endif
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -427,18 +427,34 @@ typedef enum
     BINDING_UQS  // UDP queue mode plus SMS
 } lwm2m_binding_t;
 
+/*
+ * LWM2M block1 data
+ *
+ * Temporary data needed to handle block1 request.
+ * Currently support only one block1 request by server.
+ */
+typedef struct _lwm2m_block1_data_ lwm2m_block1_data_t;
+
+struct _lwm2m_block1_data_
+{
+    uint8_t *             block1buffer;     // data buffer
+    size_t                block1bufferSize; // buffer size
+    uint16_t              lastmid;          // mid of the last message received
+};
+
 typedef struct _lwm2m_server_
 {
-    struct _lwm2m_server_ * next;   // matches lwm2m_list_t::next
-    uint16_t          secObjInstID; // matches lwm2m_list_t::id
-    uint16_t          shortID;      // servers short ID, may be 0 for bootstrap server
-    time_t            lifetime;     // lifetime of the registration in sec or 0 if default value (86400 sec), also used as hold off time for bootstrap servers
-    time_t            registration; // date of the last registration in sec or end of client hold off time for bootstrap servers
-    lwm2m_binding_t   binding;      // client connection mode with this server
-    void *            sessionH;
-    lwm2m_status_t    status;
-    char *            location;
-    bool              dirty;
+    struct _lwm2m_server_ * next;         // matches lwm2m_list_t::next
+    uint16_t                secObjInstID; // matches lwm2m_list_t::id
+    uint16_t                shortID;      // servers short ID, may be 0 for bootstrap server
+    time_t                  lifetime;     // lifetime of the registration in sec or 0 if default value (86400 sec), also used as hold off time for bootstrap servers
+    time_t                  registration; // date of the last registration in sec or end of client hold off time for bootstrap servers
+    lwm2m_binding_t         binding;      // client connection mode with this server
+    void *                  sessionH;
+    lwm2m_status_t          status;
+    char *                  location;
+    bool                    dirty;
+    lwm2m_block1_data_t *   block1Data;   // buffer to handle block1 data, should be replace by a list to support several block1 transfer by server.
 } lwm2m_server_t;
 
 
@@ -562,24 +578,6 @@ struct _lwm2m_transaction_
     void * userData;
 };
 
-
-/*
- * LWM2M block1 data
- *
- * Temporary data needed to handle block1 request.
- * Currently support only one block1 request by server.
- */
-typedef struct _lwm2m_block1_data_ lwm2m_block1_data_t;
-
-struct _lwm2m_block1_data_
-{
-    lwm2m_block1_data_t * next;             // matches lwm2m_list_t::next
-    uint16_t              serverID;         // matches lwm2m_list_t::id
-    uint8_t *             block1buffer;     // data buffer
-    size_t                block1bufferSize; // buffer size
-    uint16_t              lastmid;          // mid of the last message received
-};
-
 /*
  * LWM2M observed resources
  */
@@ -663,7 +661,6 @@ typedef struct
     uint16_t                nextMID;
     lwm2m_transaction_t *   transactionList;
     void *                  userData;
-    lwm2m_block1_data_t *   block1DataList;
 } lwm2m_context_t;
 
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -149,6 +149,7 @@ bool lwm2m_session_is_equal(void * session1, void * session2, void * userData);
 #define COAP_405_METHOD_NOT_ALLOWED     (uint8_t)0x85
 #define COAP_406_NOT_ACCEPTABLE         (uint8_t)0x86
 #define COAP_408_REQ_ENTITY_INCOMPLETE  (uint8_t)0x88
+#define COAP_413_ENTITY_TOO_LARGE       (uint8_t)0x8F
 #define COAP_500_INTERNAL_SERVER_ERROR  (uint8_t)0xA0
 #define COAP_501_NOT_IMPLEMENTED        (uint8_t)0xA1
 #define COAP_503_SERVICE_UNAVAILABLE    (uint8_t)0xA3

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -141,12 +141,14 @@ bool lwm2m_session_is_equal(void * session1, void * session2, void * userData);
 #define COAP_202_DELETED                (uint8_t)0x42
 #define COAP_204_CHANGED                (uint8_t)0x44
 #define COAP_205_CONTENT                (uint8_t)0x45
+#define COAP_231_CONTINUE               (uint8_t)0x5F
 #define COAP_400_BAD_REQUEST            (uint8_t)0x80
 #define COAP_401_UNAUTHORIZED           (uint8_t)0x81
 #define COAP_402_BAD_OPTION             (uint8_t)0x82
 #define COAP_404_NOT_FOUND              (uint8_t)0x84
 #define COAP_405_METHOD_NOT_ALLOWED     (uint8_t)0x85
 #define COAP_406_NOT_ACCEPTABLE         (uint8_t)0x86
+#define COAP_408_REQ_ENTITY_INCOMPLETE  (uint8_t)0x88
 #define COAP_500_INTERNAL_SERVER_ERROR  (uint8_t)0xA0
 #define COAP_501_NOT_IMPLEMENTED        (uint8_t)0xA1
 #define COAP_503_SERVICE_UNAVAILABLE    (uint8_t)0xA3
@@ -560,6 +562,24 @@ struct _lwm2m_transaction_
     void * userData;
 };
 
+
+/*
+ * LWM2M block1 data
+ *
+ * Temporary data needed to handle block1 request.
+ * Currently support only one block1 request by server.
+ */
+typedef struct _lwm2m_block1_data_ lwm2m_block1_data_t;
+
+struct _lwm2m_block1_data_
+{
+    lwm2m_block1_data_t * next;             // matches lwm2m_list_t::next
+    uint16_t              serverID;         // matches lwm2m_list_t::id
+    uint8_t *             block1buffer;     // data buffer
+    size_t                block1bufferSize; // buffer size
+    uint16_t              lastmid;          // mid of the last message received
+};
+
 /*
  * LWM2M observed resources
  */
@@ -643,6 +663,7 @@ typedef struct
     uint16_t                nextMID;
     lwm2m_transaction_t *   transactionList;
     void *                  userData;
+    lwm2m_block1_data_t *   block1DataList;
 } lwm2m_context_t;
 
 

--- a/core/packet.c
+++ b/core/packet.c
@@ -246,17 +246,53 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
                 new_offset = block_offset;
             }
 
-            coap_error_code = handle_request(contextP, fromSessionH, message, response);
+            /* handle block1 option */
+            if (IS_OPTION(message, COAP_OPTION_BLOCK1))
+            {
+#ifdef LWM2M_CLIENT_MODE
+                // get server
+                lwm2m_server_t * serverP;
+                serverP = utils_findServer(contextP, fromSessionH);
+#ifdef LWM2M_BOOTSTRAP
+                if (serverP == NULL)
+                {
+                    serverP = utils_findBootstrapServer(contextP, fromSessionH);
+                }
+#endif
+                // parse block1 header
+                uint32_t block1_num;
+                uint8_t  block1_more;
+                uint16_t block1_size;
+                coap_get_header_block1(message, &block1_num, &block1_more, &block1_size, NULL);
+                LOG_ARG("Blockwise: block1 request NUM %u (SZX %u/ SZX Max%u) MORE %u", block1_num, block1_size, REST_MAX_CHUNK_SIZE, block1_more);
+
+                // handle block 1
+                uint8_t * complete_buffer = NULL;
+                size_t complete_buffer_size;
+                coap_error_code = coap_block1_handler(&contextP->block1DataList, message->mid, message->payload, message->payload_len, serverP, block1_size, block1_num, block1_more, &complete_buffer, &complete_buffer_size);
+
+                // if payload is complete, replace it in the coap message.
+                if (coap_error_code == NO_ERROR)
+                {
+                    message->payload = complete_buffer;
+                    message->payload_len = complete_buffer_size;
+                }
+                else if (coap_error_code == COAP_231_CONTINUE)
+                {
+                    block1_size = MIN(block1_size, REST_MAX_CHUNK_SIZE);
+                    coap_set_header_block1(response,block1_num, block1_more,block1_size);
+                }
+#else
+                coap_error_code = COAP_501_NOT_IMPLEMENTED;
+#endif
+            }
+            if (coap_error_code == NO_ERROR)
+            {
+                coap_error_code = handle_request(contextP, fromSessionH, message, response);
+            }
             if (coap_error_code==NO_ERROR)
             {
-                /* Apply blockwise transfers. */
-                if ( IS_OPTION(message, COAP_OPTION_BLOCK1) && response->code<COAP_400_BAD_REQUEST && !IS_OPTION(response, COAP_OPTION_BLOCK1) )
-                {
-                    LOG("Block1 NOT IMPLEMENTED");
-
-                    coap_error_code = COAP_501_NOT_IMPLEMENTED;
-                }
-                else if ( IS_OPTION(message, COAP_OPTION_BLOCK2) )
+                if ( IS_OPTION(message, COAP_OPTION_BLOCK2) )
                 {
                     /* unchanged new_offset indicates that resource is unaware of blockwise transfer */
                     if (new_offset==block_offset)

--- a/core/wakaama.cmake
+++ b/core/wakaama.cmake
@@ -27,6 +27,7 @@ set(WAKAAMA_SOURCES
     ${WAKAAMA_SOURCES_DIR}/observe.c
     ${WAKAAMA_SOURCES_DIR}/json.c
     ${WAKAAMA_SOURCES_DIR}/discover.c
+    ${WAKAAMA_SOURCES_DIR}/block1.c
     ${EXT_SOURCES})
 
 # This will not work for multi project cmake generators like the Visual Studio Generator

--- a/tests/block1tests.c
+++ b/tests/block1tests.c
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2015 Bosch Software Innovations GmbH, Germany.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *   Julien Vermillard - Please refer to git log
+ *
+ *******************************************************************************/
+
+#include "tests.h"
+#include "CUnit/Basic.h"
+#include "internals.h"
+#include "liblwm2m.h"
+
+
+static void handle_12345(lwm2m_block1_data_t ** blk1,
+                                  uint16_t mid) {
+    uint8_t *buffer = "12345";
+    size_t bsize;
+    uint8_t *resultBuffer = NULL;
+
+    coap_status_t st = coap_block1_handler(blk1, mid, buffer, 5, 5, 0, true, &resultBuffer, &bsize);
+    CU_ASSERT_EQUAL(st, COAP_231_CONTINUE);
+    CU_ASSERT_PTR_NULL(resultBuffer);
+}
+
+static void handle_67(lwm2m_block1_data_t ** blk1,
+                                  uint16_t mid) {
+    uint8_t *buffer = "67";
+    size_t bsize;
+    uint8_t *resultBuffer = NULL;
+
+    coap_status_t st = coap_block1_handler(blk1, mid, buffer, 2, 5, 1, false, &resultBuffer, &bsize);
+    CU_ASSERT_EQUAL(st, NO_ERROR);
+    CU_ASSERT_PTR_NOT_NULL(*resultBuffer);
+    CU_ASSERT_EQUAL(bsize, 7);
+    CU_ASSERT_NSTRING_EQUAL(resultBuffer, "1234567", 7);
+}
+
+
+static void test_block1_nominal(void)
+{
+    lwm2m_block1_data_t * blk1 = NULL;
+
+    handle_12345(&blk1, 123);
+    handle_67(&blk1, 346);
+
+    free_block1_buffer(blk1);
+}
+
+static void test_block1_retransmit(void)
+{
+    lwm2m_block1_data_t * blk1 = NULL;
+
+    handle_12345(&blk1, 1);
+    handle_12345(&blk1, 1);
+    handle_67(&blk1, 3);
+    handle_67(&blk1, 3);
+    handle_67(&blk1, 3);
+
+    free_block1_buffer(blk1);
+}
+
+static struct TestTable table[] = {
+        { "test of test_block1_nominal()", test_block1_nominal },
+        { "test of test_block1_retransmit()", test_block1_retransmit },
+        { NULL, NULL },
+};
+
+CU_ErrorCode create_block1_suit() {
+    CU_pSuite pSuite = NULL;
+    pSuite = CU_add_suite("Suite_block1", NULL, NULL);
+
+    if (NULL == pSuite) {
+        return CU_get_error();
+    }
+    return add_tests(pSuite, table);
+}

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -31,5 +31,6 @@ CU_ErrorCode create_tlv_suit();
 CU_ErrorCode create_object_read_suit();
 CU_ErrorCode create_convert_numbers_suit();
 CU_ErrorCode create_tlv_json_suit();
+CU_ErrorCode create_block1_suit();
 
 #endif /* TESTS_H_ */

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -66,6 +66,9 @@ int main()
    if (CUE_SUCCESS != create_tlv_json_suit()) {
        goto exit;
    }
+   if (CUE_SUCCESS != create_block1_suit()) {
+       goto exit;
+   }
 
    CU_basic_set_mode(CU_BRM_VERBOSE);
    CU_basic_run_tests();


### PR DESCRIPTION
I added the support of block1 for incoming request only for LWM2M client.

Here a list of limitation or not implemented features:
- it supports only 1 block1 transfer by server. (and not 1 transfer by server/resource URI)
- as the key/ID for block1 is the serverID, ideally we should remove pending block1 on bootstrap finished ?
- we don't check if the URI and the content format is the same from one block to another.
- we don't clean block1 buffer after EXCHANGE_LIFETIME. (we keep 1 buffer by server for retransmission)
