### PR TITLE
Rehandshake on NAT timeout

### DIFF
--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -78,7 +78,7 @@ char * security_get_public_id(lwm2m_object_t * obj, int instanceId, int * length
         dataP->type == LWM2M_TYPE_OPAQUE)
     {
         char * buff;
-        
+
         buff = (char*)lwm2m_malloc(dataP->value.asBuffer.length);
         if (buff != 0)
         {
@@ -88,7 +88,7 @@ char * security_get_public_id(lwm2m_object_t * obj, int instanceId, int * length
         lwm2m_data_free(size, dataP);
 
         return buff;
-    }else{
+    } else {
         return NULL;
     }
 }
@@ -114,7 +114,7 @@ char * security_get_secret_key(lwm2m_object_t * obj, int instanceId, int * lengt
         lwm2m_data_free(size, dataP);
 
         return buff;
-    }else{
+    } else {
         return NULL;
     }
 }
@@ -139,7 +139,7 @@ int send_data(dtls_connection_t *connP,
         struct sockaddr_in *saddr = (struct sockaddr_in *)&connP->addr;
         inet_ntop(saddr->sin_family, &saddr->sin_addr, s, INET6_ADDRSTRLEN);
         port = saddr->sin_port;
-}
+    }
     else if (AF_INET6 == connP->addr.sin6_family)
     {
         struct sockaddr_in6 *saddr = (struct sockaddr_in6 *)&connP->addr;
@@ -167,8 +167,7 @@ int send_data(dtls_connection_t *connP,
 /* This function is the "key store" for tinyDTLS. It is called to
  * retrieve a key for the given identity within this particular
  * session. */
-static int
-get_psk_info(struct dtls_context_t *ctx,
+static int get_psk_info(struct dtls_context_t *ctx,
         const session_t *session,
         dtls_credentials_type_t type,
         const unsigned char *id, size_t id_len,
@@ -221,8 +220,7 @@ get_psk_info(struct dtls_context_t *ctx,
     return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
 }
 
-static int
-send_to_peer(struct dtls_context_t *ctx,
+static int send_to_peer(struct dtls_context_t *ctx,
         session_t *session, uint8 *data, size_t len) {
 
     // find connection
@@ -231,6 +229,8 @@ send_to_peer(struct dtls_context_t *ctx,
     if (cnx != NULL)
     {
         // send data to peer
+
+        // TODO: nat expiration?
         int err = send_data(cnx,data,len);
         if (COAP_NO_ERROR != err)
         {
@@ -241,8 +241,7 @@ send_to_peer(struct dtls_context_t *ctx,
     return -1;
 }
 
-static int
-read_from_peer(struct dtls_context_t *ctx,
+static int read_from_peer(struct dtls_context_t *ctx,
           session_t *session, uint8 *data, size_t len) {
 
     // find connection
@@ -568,6 +567,20 @@ int connection_handle_packet(dtls_connection_t *connP, uint8_t * buffer, size_t 
         lwm2m_handle_packet(connP->lwm2mH, buffer, numBytes, (void*)connP);
         return 0;
     }
+}
+
+int connection_rehandshake(dtls_connection_t *connP) {
+
+    // if not a dtls connection we do nothing
+    if (connP->dtlsSession == NULL) {
+        return 0;
+    }
+
+    int result = dtls_connect(connP->dtlsContext, connP->dtlsSession);
+    if (result !=0) {
+         printf("error dtls reconnection %d\n",result);
+    }
+    return result;
 }
 
 uint8_t lwm2m_buffer_send(void * sessionH,

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -547,7 +547,7 @@ int connection_send(dtls_connection_t *connP, uint8_t * buffer, size_t length){
             return -1 ;
         }
     } else {
-        if ( (now - connP->lastSend) < DTLS_NAT_TIMEOUT)
+        if ( (now - connP->lastSend) > DTLS_NAT_TIMEOUT)
         {
             // we need to rehandhake because our source IP/port probably changed for the server
 

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -547,7 +547,7 @@ int connection_send(dtls_connection_t *connP, uint8_t * buffer, size_t length){
             return -1 ;
         }
     } else {
-        if ((now - connP->lastSend) > DTLS_NAT_TIMEOUT)
+        if (DTLS_NAT_TIMEOUT > 0 && (now - connP->lastSend) > DTLS_NAT_TIMEOUT)
         {
             // we need to rehandhake because our source IP/port probably changed for the server
             if ( connection_rehandshake(connP, false) != 0 )

--- a/examples/shared/dtlsconnection.h
+++ b/examples/shared/dtlsconnection.h
@@ -51,6 +51,7 @@ typedef struct _dtls_connection_t
     int securityInstId;
     lwm2m_context_t * lwm2mH;
     dtls_context_t * dtlsContext;
+    time_t lastSend; // last time a data was sent to the server (used for NAT timeouts)
 } dtls_connection_t;
 
 int create_socket(const char * portStr, int ai_family);
@@ -63,5 +64,8 @@ void connection_free(dtls_connection_t * connList);
 
 int connection_send(dtls_connection_t *connP, uint8_t * buffer, size_t length);
 int connection_handle_packet(dtls_connection_t *connP, uint8_t * buffer, size_t length);
+
+// rehandshake a connection, usefull when your NAT timeouted and your client have a new IP/PORT
+int connection_rehandshake(dtls_connection_t *connP);
 
 #endif

--- a/examples/shared/dtlsconnection.h
+++ b/examples/shared/dtlsconnection.h
@@ -40,6 +40,9 @@
 #define LWM2M_BSSERVER_PORT_STR "5685"
 #define LWM2M_BSSERVER_PORT      5685
 
+// after 40sec of inactivity we rehandshake
+#define DTLS_NAT_TIMEOUT 40
+
 typedef struct _dtls_connection_t
 {
     struct _dtls_connection_t *  next;

--- a/examples/shared/dtlsconnection.h
+++ b/examples/shared/dtlsconnection.h
@@ -69,6 +69,6 @@ int connection_send(dtls_connection_t *connP, uint8_t * buffer, size_t length);
 int connection_handle_packet(dtls_connection_t *connP, uint8_t * buffer, size_t length);
 
 // rehandshake a connection, usefull when your NAT timeouted and your client have a new IP/PORT
-int connection_rehandshake(dtls_connection_t *connP);
+int connection_rehandshake(dtls_connection_t *connP, bool sendCloseNotify);
 
 #endif


### PR DESCRIPTION
When a LWM2M client is behind a NAT, if it doesn't send data for a period of time, it can lost its assigned IP. This period (NAT timeout) depends of the NAT configuration.

In DTLS, the session used to decrypt packet is linked to the IP address/port of the peer. This means thats is the client lost its assigned IP, It should redo an handshake with its new IP address/port. 

This PR, based on @jvermillard code in [rehandshake-on-NAT-timeout](https://github.com/eclipse/wakaama/tree/rehandshake-on-NAT-timeout) branch,  defines a value for the NAT period, if the device is mute for `DTLS_NAT_TIMEOUT`, it will do a new handshake before to communicate again.