### PR TITLE
Various fixes to small issues.

### DIFF
--- a/core/data.c
+++ b/core/data.c
@@ -502,14 +502,10 @@ size_t lwm2m_data_serialize(lwm2m_uri_t * uriP,
 
     case LWM2M_CONTENT_TLV:
         {
-            uint8_t baseUriStr[URI_MAX_STRING_LEN];
-            size_t baseUriLen;
-            uri_depth_t rootLevel;
             bool isResourceInstance;
 
-            baseUriLen = uri_toString(uriP, baseUriStr, URI_MAX_STRING_LEN, &rootLevel);
-            if (baseUriLen <= 0) return 0;
-            if (rootLevel == URI_DEPTH_RESOURCE_INSTANCE)
+            if (LWM2M_URI_IS_SET_RESOURCE(uriP)
+             && (size != 1 || dataP->id != uriP->resourceId))
             {
                 isResourceInstance = true;
             }

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -181,6 +181,7 @@ bool lwm2m_session_is_equal(void * session1, void * session2, void * userData);
 #define LWM2M_SECURITY_SMS_SERVER_NUMBER_ID   9
 #define LWM2M_SECURITY_SHORT_SERVER_ID        10
 #define LWM2M_SECURITY_HOLD_OFF_ID            11
+#define LWM2M_SECURITY_BOOTSTRAP_TIMEOUT_ID   12
 
 /*
  * Ressource IDs for the LWM2M Server Object

--- a/core/management.c
+++ b/core/management.c
@@ -170,7 +170,15 @@ coap_status_t dm_handleRequest(lwm2m_context_t * contextP,
 
     LOG_ARG("Code: %02X, server status: %s", message->code, STR_STATUS(serverP->status));
     LOG_URI(uriP);
-    format = utils_convertMediaType(message->content_type);
+
+    if (IS_OPTION(message, COAP_OPTION_CONTENT_TYPE))
+    {
+        format = utils_convertMediaType(message->content_type);
+    }
+    else
+    {
+        format = LWM2M_CONTENT_TEXT;
+    }
 
     if (uriP->objectId == LWM2M_SECURITY_OBJECT_ID)
     {
@@ -226,6 +234,11 @@ coap_status_t dm_handleRequest(lwm2m_context_t * contextP,
             }
             else
             {
+                if (IS_OPTION(message, COAP_OPTION_ACCEPT))
+                {
+                    format = utils_convertMediaType(message->accept[0]);
+                }
+
                 result = object_read(contextP, uriP, &format, &buffer, &length);
             }
             if (COAP_205_CONTENT == result)
@@ -521,6 +534,7 @@ int lwm2m_dm_create(lwm2m_context_t * contextP,
 {
     LOG_ARG("clientID: %d, format: %s, length: %d", clientID, STR_MEDIA_TYPE(format), length);
     LOG_URI(uriP);
+
     if (LWM2M_URI_IS_SET_INSTANCE(uriP)
      || length == 0)
     {

--- a/core/objects.c
+++ b/core/objects.c
@@ -276,6 +276,7 @@ coap_status_t object_execute(lwm2m_context_t * contextP,
     targetP = (lwm2m_object_t *)LWM2M_LIST_FIND(contextP->objectList, uriP->objectId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
     if (NULL == targetP->executeFunc) return COAP_405_METHOD_NOT_ALLOWED;
+    if (NULL == lwm2m_list_find(targetP->instanceList, uriP->instanceId)) return COAP_404_NOT_FOUND;
 
     return targetP->executeFunc(uriP->instanceId, uriP->resourceId, buffer, length, targetP);
 }
@@ -292,7 +293,8 @@ coap_status_t object_create(lwm2m_context_t * contextP,
     uint8_t result;
 
     LOG_URI(uriP);
-    if (length == 0 || buffer == 0)
+
+    if (length == 0 || buffer == 0 || LWM2M_URI_IS_SET_INSTANCE(uriP))
     {
         return COAP_400_BAD_REQUEST;
     }
@@ -669,6 +671,7 @@ int object_getServers(lwm2m_context_t * contextP)
     lwm2m_list_t * securityInstP;   // instanceID of the server in the LWM2M Security Object
 
     LOG("Entering");
+
     for (objectP = contextP->objectList; objectP != NULL; objectP = objectP->next)
     {
         if (objectP->objID == LWM2M_SECURITY_OBJECT_ID)


### PR DESCRIPTION
- TLV encoding of single resource was using resource instance type instead of resource type
- Correct handling of content-type options in requests
- Check instance ID in Execute operation
- Instance ID must be set in Create operation 

Signed-off-by: David Navarro <david.navarro@intel.com>