### PR TITLE
Support old content format values (TLV/JSON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Several compilation switches are used:
  - LWM2M_BOOTSTRAP_SERVER_MODE to enable LWM2M Bootstrap Server interfaces.
  - LWM2M_BOOTSTRAP to enable LWM2M Bootstrap support in a LWM2M Client.
  - LWM2M_SUPPORT_JSON to enable JSON payload support (implicit when defining LWM2M_SERVER_MODE)
+ - LWM2M_OLD_CONTENT_FORMAT_SUPPORT to support the deprecated content format values for TLV and JSON.
 Depending on your platform, you need to define LWM2M_BIG_ENDIAN or LWM2M_LITTLE_ENDIAN.
 LWM2M_CLIENT_MODE and LWM2M_SERVER_MODE can be defined at the same time.
 

--- a/core/data.c
+++ b/core/data.c
@@ -441,10 +441,16 @@ int lwm2m_data_parse(lwm2m_uri_t * uriP,
         (*dataP)->type = LWM2M_TYPE_OPAQUE;
         return prv_setBuffer(*dataP, buffer, bufferLen);
 
+#ifdef LWM2M_OLD_CONTENT_FORMAT_SUPPORT
+    case LWM2M_CONTENT_TLV_OLD:
+#endif
     case LWM2M_CONTENT_TLV:
         return tlv_parse(buffer, bufferLen, dataP);
 
 #ifdef LWM2M_SUPPORT_JSON
+#ifdef LWM2M_OLD_CONTENT_FORMAT_SUPPORT
+    case LWM2M_CONTENT_JSON_OLD:
+#endif
     case LWM2M_CONTENT_JSON:
         return json_parse(uriP, buffer, bufferLen, dataP);
 #endif

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -325,7 +325,9 @@ typedef enum
     LWM2M_CONTENT_TEXT      = 0,        // Also used as undefined
     LWM2M_CONTENT_LINK      = 40,
     LWM2M_CONTENT_OPAQUE    = 42,
+    LWM2M_CONTENT_TLV_OLD   = 1542,     // Keep old value for backward-compatibility
     LWM2M_CONTENT_TLV       = 11542,
+    LWM2M_CONTENT_JSON_OLD  = 1543,     // Keep old value for backward-compatibility
     LWM2M_CONTENT_JSON      = 11543
 } lwm2m_media_type_t;
 

--- a/core/utils.c
+++ b/core/utils.c
@@ -386,8 +386,12 @@ lwm2m_media_type_t utils_convertMediaType(coap_content_type_t type)
         return LWM2M_CONTENT_TEXT;
     case APPLICATION_OCTET_STREAM:
         return LWM2M_CONTENT_OPAQUE;
+    case LWM2M_CONTENT_TLV_OLD:
+        return LWM2M_CONTENT_TLV_OLD;
     case LWM2M_CONTENT_TLV:
         return LWM2M_CONTENT_TLV;
+    case LWM2M_CONTENT_JSON_OLD:
+        return LWM2M_CONTENT_JSON_OLD;
     case LWM2M_CONTENT_JSON:
         return LWM2M_CONTENT_JSON;
     case APPLICATION_LINK_FORMAT:


### PR DESCRIPTION
Add the support of the initial/deprecated content format codes for TLV (1542) and JSON (1543) in order to keep the backward-compatibility.