### PR TITLE
Fix for issue #241: in object_create(), no need to check for the instance ID in the URI.

### DIFF
--- a/core/data.c
+++ b/core/data.c
@@ -469,7 +469,7 @@ size_t lwm2m_data_serialize(lwm2m_uri_t * uriP,
      || *formatP == LWM2M_CONTENT_OPAQUE)
     {
         if (size != 1
-         || !LWM2M_URI_IS_SET_RESOURCE(uriP)
+         || (uriP != NULL && !LWM2M_URI_IS_SET_RESOURCE(uriP))
          || dataP->type == LWM2M_TYPE_OBJECT
          || dataP->type == LWM2M_TYPE_OBJECT_INSTANCE
          || dataP->type == LWM2M_TYPE_MULTIPLE_RESOURCE)
@@ -504,7 +504,7 @@ size_t lwm2m_data_serialize(lwm2m_uri_t * uriP,
         {
             bool isResourceInstance;
 
-            if (LWM2M_URI_IS_SET_RESOURCE(uriP)
+            if (uriP != NULL && LWM2M_URI_IS_SET_RESOURCE(uriP)
              && (size != 1 || dataP->id != uriP->resourceId))
             {
                 isResourceInstance = true;

--- a/core/objects.c
+++ b/core/objects.c
@@ -294,7 +294,7 @@ coap_status_t object_create(lwm2m_context_t * contextP,
 
     LOG_URI(uriP);
 
-    if (length == 0 || buffer == 0 || LWM2M_URI_IS_SET_INSTANCE(uriP))
+    if (length == 0 || buffer == 0)
     {
         return COAP_400_BAD_REQUEST;
     }


### PR DESCRIPTION
The check is already done in dm_handleRequest()

Signed-off-by: David Navarro <david.navarro@intel.com>