### PR TITLE
Fix for issue #266: Handle JSON and TLV old content format values

### DIFF
--- a/core/data.c
+++ b/core/data.c
@@ -514,7 +514,8 @@ int lwm2m_data_serialize(lwm2m_uri_t * uriP,
         return (int)dataP->value.asBuffer.length;
 
     case LWM2M_CONTENT_TLV:
-        {
+    case LWM2M_CONTENT_TLV_OLD:
+    {
             bool isResourceInstance;
 
             if (uriP != NULL && LWM2M_URI_IS_SET_RESOURCE(uriP)
@@ -535,6 +536,7 @@ int lwm2m_data_serialize(lwm2m_uri_t * uriP,
 #endif
 #ifdef LWM2M_SUPPORT_JSON
     case LWM2M_CONTENT_JSON:
+    case LWM2M_CONTENT_JSON_OLD:
         return json_serialize(uriP, size, dataP, bufferP);
 #endif
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -595,6 +595,7 @@ typedef struct _lwm2m_watcher_
     bool update;
     lwm2m_server_t * server;
     lwm2m_attributes_t * parameters;
+    lwm2m_media_type_t format;
     uint8_t token[8];
     size_t tokenLen;
     time_t lastTime;

--- a/core/management.c
+++ b/core/management.c
@@ -214,6 +214,15 @@ coap_status_t dm_handleRequest(lwm2m_context_t * contextP,
                     result = observe_handleRequest(contextP, uriP, serverP, size, dataP, message, response);
                     if (COAP_205_CONTENT == result)
                     {
+                        if (IS_OPTION(message, COAP_OPTION_ACCEPT))
+                        {
+                            format = utils_convertMediaType(message->accept[0]);
+                        }
+                        else
+                        {
+                            format = LWM2M_CONTENT_TLV;
+                        }
+
                         res = lwm2m_data_serialize(uriP, size, dataP, &format, &buffer);
                         if (res < 0)
                         {

--- a/core/observe.c
+++ b/core/observe.c
@@ -457,7 +457,6 @@ void observe_step(lwm2m_context_t * contextP,
         double floatValue = 0;
         int64_t integerValue = 0;
         bool storeValue = false;
-        lwm2m_media_type_t format = LWM2M_CONTENT_TEXT;
         coap_packet_t message[1];
         time_t interval;
 
@@ -661,7 +660,7 @@ void observe_step(lwm2m_context_t * contextP,
                             }
                         }
                         coap_init_message(message, COAP_TYPE_NON, COAP_205_CONTENT, 0);
-                        coap_set_header_content_type(message, format);
+                        coap_set_header_content_type(message, watcherP->format);
                         coap_set_payload(message, buffer, length);
                     }
                     watcherP->lastTime = currentTime;

--- a/core/observe.c
+++ b/core/observe.c
@@ -882,7 +882,6 @@ int lwm2m_observe(lwm2m_context_t * contextP,
     observationP->clientP->observationList = (lwm2m_observation_t *)LWM2M_LIST_ADD(observationP->clientP->observationList, observationP);
 
     coap_set_header_observe(transactionP->message, 0);
-    coap_set_header_token(transactionP->message, token, sizeof(token));
     if (clientP->supportJSON == true)
     {
         coap_set_header_accept(transactionP->message, LWM2M_CONTENT_JSON);
@@ -924,8 +923,14 @@ int lwm2m_observe_cancel(lwm2m_context_t * contextP,
     {
         lwm2m_transaction_t * transactionP;
         cancellation_data_t * cancelP;
+        uint8_t token[4];
 
-        transactionP = transaction_new(clientP->sessionH, COAP_GET, clientP->altPath, uriP, contextP->nextMID++, 0, NULL);
+        token[0] = clientP->internalID >> 8;
+        token[1] = clientP->internalID & 0xFF;
+        token[2] = observationP->id >> 8;
+        token[3] = observationP->id & 0xFF;
+
+        transactionP = transaction_new(clientP->sessionH, COAP_GET, clientP->altPath, uriP, contextP->nextMID++, 4, token);
         if (transactionP == NULL)
         {
             return COAP_500_INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
when encoding data to match the accept option of the request.
Also consider the accept option in observe requests.

Signed-off-by: David Navarro <david.navarro@intel.com>