### PR TITLE
Account for payload marker in coap_serialize_get_size to fix #285.

### DIFF
--- a/core/er-coap-13/er-coap-13.c
+++ b/core/er-coap-13/er-coap-13.c
@@ -514,6 +514,12 @@ size_t coap_serialize_get_size(void *packet)
         length += COAP_MAX_OPTION_HEADER_LEN + coap_pkt->proxy_uri_len;
     }
 
+    if (coap_pkt->payload_len)
+    {
+        // Account for the payload marker.
+        length += 1;
+    }
+
     return length;
 }
 


### PR DESCRIPTION
Signed-off-by: Scott Bertin <sbertin@telular.com>