### PR TITLE
Add a bootstrap timeout to fix issue #282

### DIFF
--- a/core/er-coap-13/er-coap-13.h
+++ b/core/er-coap-13/er-coap-13.h
@@ -57,8 +57,12 @@
 #define COAP_RESPONSE_TIMEOUT                2
 #define COAP_MAX_RETRANSMIT                  4
 #define COAP_ACK_RANDOM_FACTOR               1.5
+#define COAP_MAX_LATENCY                     100
+#define COAP_PROCESSING_DELAY                COAP_RESPONSE_TIMEOUT
 
 #define COAP_MAX_TRANSMIT_WAIT               ((COAP_RESPONSE_TIMEOUT * ( (1 << (COAP_MAX_RETRANSMIT + 1) ) - 1) * COAP_ACK_RANDOM_FACTOR))
+#define COAP_MAX_TRANSMIT_SPAN               ((COAP_RESPONSE_TIMEOUT * ( (1 << COAP_MAX_RETRANSMIT) - 1) * COAP_ACK_RANDOM_FACTOR))
+#define COAP_EXCHANGE_LIFETIME               (COAP_MAX_TRANSMIT_SPAN + (2 * COAP_MAX_LATENCY) + COAP_PROCESSING_DELAY)
 
 #define COAP_HEADER_LEN                      4 /* | version:0x03 type:0x0C tkl:0xF0 | code | mid:0x00FF | mid:0xFF00 | */
 #define COAP_ETAG_LEN                        8 /* The maximum number of bytes for the ETag */


### PR DESCRIPTION
er-coap-13.h is modified to calculate the exchange lifetime.

When the ACK to the bootstrap request, or any bootstrap command is
received, the server registration time is updated to be the current
time plus the exchange lifetime. If this time has passed in the
pending state, the state is set to failing.

Signed-off-by: Scott Bertin <sbertin@telular.com>