### PR TITLE
Fix wrong parameter in debug log "Checking maximal period"

### DIFF
--- a/core/observe.c
+++ b/core/observe.c
@@ -669,7 +669,7 @@ void observe_step(lwm2m_context_t * contextP,
                  && watcherP->parameters != NULL
                  && (watcherP->parameters->toSet & LWM2M_ATTR_FLAG_MAX_PERIOD) != 0)
                 {
-                    LOG_ARG("Checking maximal period (%d s)", watcherP->parameters->minPeriod);
+                    LOG_ARG("Checking maximal period (%d s)", watcherP->parameters->maxPeriod);
 
                     if (watcherP->lastTime + watcherP->parameters->maxPeriod <= currentTime)
                     {


### PR DESCRIPTION
commit c66e4a33ea7cfe1ec07948304adb3a68cc5bc68c
Author: Wyatt Sun <wyattsun@gmail.com>
Date:   Mon Jul 3 20:13:57 2017 +8000

    Fix wrong parameter in debug log "Checking maximal period"
    
    Signed-off-by: Wyatt Sun <wyattsun@gmail.com>