### PR TITLE
Fix for #320: only opaque data can be encoded in opaque.

### DIFF
--- a/core/data.c
+++ b/core/data.c
@@ -99,6 +99,22 @@ static int prv_textSerialize(lwm2m_data_t * dataP,
     }
 
     case LWM2M_TYPE_OPAQUE:
+    {
+        size_t length;
+
+        length = utils_base64GetSize(dataP->value.asBuffer.length);
+        *bufferP = (uint8_t *)lwm2m_malloc(length);
+        if (*bufferP == NULL) return 0;
+        length = utils_base64Encode(dataP->value.asBuffer.buffer, dataP->value.asBuffer.length, *bufferP, length);
+        if (length == 0)
+        {
+            lwm2m_free(*bufferP);
+            *bufferP = NULL;
+            return 0;
+        }
+        return (int)length;
+    }
+
     case LWM2M_TYPE_UNDEFINED:
     default:
         return -1;
@@ -586,11 +602,13 @@ int lwm2m_data_serialize(lwm2m_uri_t * uriP,
         }
     }
 
-    if (*formatP == LWM2M_CONTENT_TEXT
-     && dataP->type == LWM2M_TYPE_OPAQUE)
+    if (*formatP == LWM2M_TYPE_OPAQUE
+     && dataP->type != LWM2M_TYPE_OPAQUE)
     {
-        *formatP = LWM2M_CONTENT_OPAQUE;
+        LOG("Opaque format is reserved to opaque resources.");
+        return -1;
     }
+
     LOG_ARG("Final format: %s", STR_MEDIA_TYPE(*formatP));
 
     switch (*formatP)

--- a/core/data.c
+++ b/core/data.c
@@ -602,7 +602,7 @@ int lwm2m_data_serialize(lwm2m_uri_t * uriP,
         }
     }
 
-    if (*formatP == LWM2M_TYPE_OPAQUE
+    if (*formatP == LWM2M_CONTENT_OPAQUE
      && dataP->type != LWM2M_TYPE_OPAQUE)
     {
         LOG("Opaque format is reserved to opaque resources.");

--- a/core/internals.h
+++ b/core/internals.h
@@ -331,6 +331,7 @@ size_t utils_floatToText(double data, uint8_t * string, size_t length);
 int utils_textToInt(uint8_t * buffer, int length, int64_t * dataP);
 int utils_textToFloat(uint8_t * buffer, int length, double * dataP);
 void utils_copyValue(void * dst, const void * src, size_t len);
+size_t utils_base64GetSize(size_t dataLen);
 size_t utils_base64Encode(uint8_t * dataP, size_t dataLen, uint8_t * bufferP, size_t bufferLen);
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * utils_findServer(lwm2m_context_t * contextP, void * fromSessionH);

--- a/core/utils.c
+++ b/core/utils.c
@@ -483,7 +483,7 @@ static void prv_encodeBlock(uint8_t input[3],
     output[3] = b64Alphabet[input[2] & 0x3F];
 }
 
-static size_t prv_getBase64Size(size_t dataLen)
+size_t utils_base64GetSize(size_t dataLen)
 {
     size_t result_len;
 
@@ -502,7 +502,7 @@ size_t utils_base64Encode(uint8_t * dataP,
     unsigned int result_index;
     size_t result_len;
 
-    result_len = prv_getBase64Size(dataLen);
+    result_len = utils_base64GetSize(dataLen);
 
     if (result_len > bufferLen) return 0;
 


### PR DESCRIPTION
Also introduce text encoding of opaque data.

Signed-off-by: David Navarro <david.navarro@ioterop.com>