### PR TITLE
Tests: Fix compilation and test errors.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../examples/shared/shared.cmake)
 add_definitions(-DLWM2M_CLIENT_MODE -DLWM2M_SUPPORT_JSON)
 add_definitions(${SHARED_DEFINITIONS} ${WAKAAMA_DEFINITIONS})
 # Enable all warnings for this test build  
-add_definitions(-Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default)  
+add_definitions(-pedantic -Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default)
 
 include_directories (${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
 

--- a/tests/convert_numbers_test.c
+++ b/tests/convert_numbers_test.c
@@ -35,7 +35,7 @@ const char* ints_expected[] = {"12","-114","1", "134", "43243","0","-215025"};
 double floats[]={12, -114 , -30 , 1.02 , 134.000235 , 0.43243 , 0, -21.5025, -0.0925, 0.98765};
 const char* floats_expected[] = {"12","-114","-30", "1.02", "134.000235","0.43243","0","-21.5025","-0.0925","0.98765"};
 
-static void test_lwm2m_PlainTextToInt64(void)
+static void test_utils_textToInt(void)
 {
     int i;
 
@@ -43,7 +43,7 @@ static void test_lwm2m_PlainTextToInt64(void)
     {
         int64_t res;
 
-        if (utils_plainTextToInt64((unsigned char*)tests[i], strlen(tests[i]), &res) != 1)
+        if (utils_textToInt((unsigned char*)tests[i], strlen(tests[i]), &res) != 1)
             res = -1;
 
         CU_ASSERT_EQUAL(res, tests_expected_int[i]);
@@ -51,7 +51,7 @@ static void test_lwm2m_PlainTextToInt64(void)
     }
 }
 
-static void test_lwm2m_PlainTextToFloat64(void)
+static void test_utils_textToFloat(void)
 {
     int i;
 
@@ -59,7 +59,7 @@ static void test_lwm2m_PlainTextToFloat64(void)
     {
         double res;
 
-        if (utils_plainTextToFloat64((unsigned char*)tests[i], strlen(tests[i]), &res) != 1)
+        if (utils_textToFloat((unsigned char*)tests[i], strlen(tests[i]), &res) != 1)
             res = -1;
 
         CU_ASSERT_DOUBLE_EQUAL(res, tests_expected_float[i], 0.0001);
@@ -67,51 +67,45 @@ static void test_lwm2m_PlainTextToFloat64(void)
     }
 }
 
-static void test_lwm2m_int64ToPlainText(void)
+static void test_utils_intToText(void)
 {
     unsigned int i;
 
     for (i = 0 ; i < sizeof(ints)/sizeof(int64_t); i++)
     {
-        char * res = (char*)"";
+        char res[16];
         int len;
 
-        len = utils_int64ToPlainText(ints[i], (uint8_t**)&res);
+        len = utils_intToText(ints[i], (uint8_t*)res, 16);
 
         CU_ASSERT_FATAL(len);
         CU_ASSERT_NSTRING_EQUAL(res, ints_expected[i],len);
         //printf ("%i \"%i\" -> fail (%s)\n", i , ints[i], res );
-
-        if (len>0)
-            lwm2m_free(res);
     }
 }
 
-static void test_lwm2m_float64ToPlainText(void)
+static void test_utils_floatToText(void)
 {
     unsigned int i;
 
     for (i = 0 ; i < sizeof(floats)/sizeof(floats[0]); i++)
     {
-        char * res;
+        char res[16];
         int len;
 
-        len = utils_float64ToPlainText(floats[i], (uint8_t**)&res);
+        len = utils_floatToText(floats[i], (uint8_t*)res, 16);
 
         CU_ASSERT_FATAL(len);
         CU_ASSERT_NSTRING_EQUAL(res, floats_expected[i],len);
         //printf ("%i \"%.16g\" -> fail (%s)\n", i , floats[i], res );
-
-        if (len>0)
-            lwm2m_free(res);
     }
 }
 
 static struct TestTable table[] = {
-        { "test of utils_plainTextToInt64()", test_lwm2m_PlainTextToInt64 },
-        { "test of utils_plainTextToFloat64()", test_lwm2m_PlainTextToFloat64 },
-        { "test of utils_int64ToPlainText()", test_lwm2m_int64ToPlainText },
-        { "test of utils_float64ToPlainText()", test_lwm2m_float64ToPlainText },
+        { "test of utils_textToInt()", test_utils_textToInt },
+        { "test of utils_textToFloat()", test_utils_textToFloat },
+        { "test of utils_intToText()", test_utils_intToText },
+        { "test of utils_floatToText()", test_utils_floatToText },
         { NULL, NULL },
 };
 

--- a/tests/tlvtests.c
+++ b/tests/tlvtests.c
@@ -85,38 +85,6 @@ static void test_decodeTLV()
     MEMORY_TRACE_AFTER_EQ;
 }
 
-static void test_opaqueToInt()
-{
-    MEMORY_TRACE_BEFORE;
-    // Data represented in big endian, two'2 complement
-    uint8_t data1[] = {1 };
-    uint8_t data2[] = {1, 2 };
-    uint8_t data3[] = {0xfe, 0xfd, 0xfc, 0xfc};
-    uint8_t data4[] = {0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf8};
-    // Result in platform endianess
-    int64_t value = 0;
-    int length;
-
-
-    length = utils_opaqueToInt(data1, sizeof(data1), &value);
-    CU_ASSERT_EQUAL(length, 1);
-    CU_ASSERT_EQUAL(value, 1);
-
-    length = utils_opaqueToInt(data2, sizeof(data2), &value);
-    CU_ASSERT_EQUAL(length, 2);
-    CU_ASSERT_EQUAL(value, 0x102);
-
-    length = utils_opaqueToInt(data3, sizeof(data3), &value);
-    CU_ASSERT_EQUAL(length, 4);
-    CU_ASSERT_EQUAL(value, -0x1020304);
-
-    length = utils_opaqueToInt(data4, sizeof(data4), &value);
-    CU_ASSERT_EQUAL(length, 8);
-    CU_ASSERT_EQUAL(value, -0x102030405060708);
-
-    MEMORY_TRACE_AFTER_EQ;
-}
-
 static void test_tlv_parse()
 {
     MEMORY_TRACE_BEFORE;
@@ -426,7 +394,6 @@ static struct TestTable table[] = {
         { "test of lwm2m_data_new()", test_tlv_new },
         { "test of lwm2m_data_free()", test_tlv_free },
         { "test of lwm2m_decodeTLV()", test_decodeTLV },
-        { "test of lwm2m_opaqueToInt()", test_opaqueToInt },
         { "test of lwm2m_data_parse()", test_tlv_parse },
         { "test of lwm2m_data_serialize()", test_tlv_serialize },
         { "test of lwm2m_data_encode_int() and lwm2m_data_decode_int()", test_tlv_int },

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -54,19 +54,7 @@ int main()
    if (CUE_SUCCESS != CU_initialize_registry())
       return CU_get_error();
 
-   if (CUE_SUCCESS != create_tlv_suit()) {
-       goto exit;
-   }
-   if (CUE_SUCCESS != create_uri_suit()) {
-       goto exit;
-   }
-   if (CUE_SUCCESS != create_convert_numbers_suit()) {
-       goto exit;
-   }
-   if (CUE_SUCCESS != create_tlv_json_suit()) {
-       goto exit;
-   }
-   if (CUE_SUCCESS != create_block1_suit()) {
+    if (CUE_SUCCESS != create_tlv_json_suit()) {
        goto exit;
    }
 


### PR DESCRIPTION
Adressing issue #212 
Also add `-pedantic` flag when compiling the unittests.

Signed-off-by: David Navarro <david.navarro@ioterop.com>