### PR TITLE
Avoid accessing freed memory when deleting object

### DIFF
--- a/core/objects.c
+++ b/core/objects.c
@@ -384,11 +384,11 @@ uint8_t object_delete(lwm2m_context_t * contextP,
         while (NULL != instanceP
             && result == COAP_202_DELETED)
         {
+            uriP->instanceId = instanceP->id;
             result = objectP->deleteFunc(instanceP->id, objectP);
             if (result == COAP_202_DELETED)
             {
                 uriP->flag |= LWM2M_URI_FLAG_INSTANCE_ID;
-                uriP->instanceId = instanceP->id;
                 observe_clear(contextP, uriP);
                 uriP->flag &= ~LWM2M_URI_FLAG_INSTANCE_ID;
             }


### PR DESCRIPTION
Calling deleteFunc for object instance will invalidate the instance
pointer. Store instanceId before calling deleteFunc for object instance
to avoid use after free.