### PR TITLE
Fix DTLS connection for client example

### DIFF
--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -1014,7 +1014,11 @@ int main(int argc, char *argv[])
 
     char serverUri[50];
     int serverId = 123;
+#ifdef WITH_TINYDTLS
+    sprintf (serverUri, "coaps://%s:%s", server, serverPort);
+#else
     sprintf (serverUri, "coap://%s:%s", server, serverPort);
+#endif
 #ifdef LWM2M_BOOTSTRAP
     objArray[0] = get_security_object(serverId, serverUri, pskId, pskBuffer, pskLen, bootstrapRequested);
 #else


### PR DESCRIPTION
When DTLS option is set, default protocol should be COAPS.
Here is an example to connect to sandbox leshan server:

./lwm2mclient -h leshan.eclipse.org -p 5684 -i <identity> -s <key> -n <endpoint> -4

Signed-off-by: Vincent Prince <vincent.prince.fr@gmail.com>