### PR TITLE
Correct step CoRE Link param as "st"

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -183,8 +183,8 @@
 #define ATTR_GREATER_THAN_LEN    3
 #define ATTR_LESS_THAN_STR       "lt="
 #define ATTR_LESS_THAN_LEN       3
-#define ATTR_STEP_STR            "stp="
-#define ATTR_STEP_LEN            4
+#define ATTR_STEP_STR            "st="
+#define ATTR_STEP_LEN            3
 #define ATTR_DIMENSION_STR       "dim="
 #define ATTR_DIMENSION_LEN       4
 


### PR DESCRIPTION
Per OMA-TS-LightweightM2M-V1_0_1-20170704-A, section 5.1.2, table 4.
The step attribute Core link param should be "st" instead of "stp"

Signed-off-by: Robert Chou <robert.ch.chou@acer.com>