### PR TITLE
Change object_checkReadable function.

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -253,8 +253,7 @@ uint8_t object_create(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_medi
 uint8_t object_execute(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * buffer, size_t length);
 uint8_t object_delete(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 uint8_t object_discover(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, uint8_t ** bufferP, size_t * lengthP);
-uint8_t object_checkReadable(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
-uint8_t object_checkNumeric(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
+uint8_t object_checkReadable(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_attributes_t * attrP);
 bool object_isInstanceNew(lwm2m_context_t * contextP, uint16_t objectId, uint16_t instanceId);
 int object_getRegisterPayloadBufferLength(lwm2m_context_t * contextP);
 int object_getRegisterPayload(lwm2m_context_t * contextP, uint8_t * buffer, size_t length);

--- a/core/observe.c
+++ b/core/observe.c
@@ -322,14 +322,8 @@ uint8_t observe_setParameters(lwm2m_context_t * contextP,
 
     if (!LWM2M_URI_IS_SET_INSTANCE(uriP) && LWM2M_URI_IS_SET_RESOURCE(uriP)) return COAP_400_BAD_REQUEST;
 
-    result = object_checkReadable(contextP, uriP);
+    result = object_checkReadable(contextP, uriP, attrP);
     if (COAP_205_CONTENT != result) return result;
-
-    if (0 != (attrP->toSet & ATTR_FLAG_NUMERIC))
-    {
-        result = object_checkNumeric(contextP, uriP);
-        if (COAP_205_CONTENT != result) return result;
-    }
 
     watcherP = prv_getWatcher(contextP, uriP, serverP);
     if (watcherP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
object_checkReadable and object_checkNumeric code are duplicated.
When it called, it have to call readFunc to check readable. 
If object_checkReadable have attr argument, It could check resource is numeric or not.

Signed-off-by: Changkeun IM <asarabi8282@gmail.com>