### PR TITLE
Fix for issue #346: memory free bug！

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -300,6 +300,8 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
             }
             if (coap_error_code==NO_ERROR)
             {
+                /* Save original payload pointer for later freeing. Payload in response may be updated. */
+                uint8_t *payload = response->payload;
                 if ( IS_OPTION(message, COAP_OPTION_BLOCK2) )
                 {
                     /* unchanged new_offset indicates that resource is unaware of blockwise transfer */
@@ -337,7 +339,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
 
                 coap_error_code = message_send(contextP, response, fromSessionH);
 
-                lwm2m_free(response->payload);
+                lwm2m_free(payload);
                 response->payload = NULL;
                 response->payload_len = 0;
             }


### PR DESCRIPTION
Saves original payload pointer to use in the lwmwm_free call. This
avoids passing the adjusted pointer or the constant string
"BlockOutOfScope" to lwm2m_free, either of which would be an error.

Signed-off-by: Scott Bertin <sbertin@telular.com>