### PR TITLE
Fix transaction userData for deregistration.

### DIFF
--- a/core/registration.c
+++ b/core/registration.c
@@ -578,7 +578,7 @@ void registration_deregister(lwm2m_context_t * contextP,
     coap_set_header_uri_path(transaction->message, serverP->location);
 
     transaction->callback = prv_handleDeregistrationReply;
-    transaction->userData = (void *) contextP;
+    transaction->userData = (void *) serverP;
 
     contextP->transactionList = (lwm2m_transaction_t *)LWM2M_LIST_ADD(contextP->transactionList, transaction);
     if (transaction_send(contextP, transaction) == 0)


### PR DESCRIPTION
prv_handleDeregistrationReply() was expecting the transaction userData
to be the server, but it was being set to the context in
registration_deregister().

Signed-off-by: Scott Bertin <sbertin@telular.com>