### PR TITLE
Fix for issue #360

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -126,7 +126,7 @@ static void prv_requestBootstrap(lwm2m_context_t * context,
 }
 
 void bootstrap_step(lwm2m_context_t * contextP,
-                    uint32_t currentTime,
+                    time_t currentTime,
                     time_t * timeoutP)
 {
     lwm2m_server_t * targetP;

--- a/core/internals.h
+++ b/core/internals.h
@@ -294,7 +294,7 @@ lwm2m_status_t registration_getStatus(lwm2m_context_t * contextP);
 uint8_t message_send(lwm2m_context_t * contextP, coap_packet_t * message, void * sessionH);
 
 // defined in bootstrap.c
-void bootstrap_step(lwm2m_context_t * contextP, uint32_t currentTime, time_t* timeoutP);
+void bootstrap_step(lwm2m_context_t * contextP, time_t currentTime, time_t* timeoutP);
 uint8_t bootstrap_handleCommand(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
 uint8_t bootstrap_handleDeleteAll(lwm2m_context_t * context, void * fromSessionH);
 uint8_t bootstrap_handleFinish(lwm2m_context_t * context, void * fromSessionH);


### PR DESCRIPTION
Changes to use time_t instead of uint32_t for bootstrap_step currentTime
argument. Logic was already doing operations against time_t values. This
could have caused problems as lwm2m_gettime approaches the limit of
uint32_t.

Other step functions were already using time_t.

Signed-off-by: Scott Bertin <sbertin@telular.com>