### PR TITLE
Change lessThan and greaterThan condition.

### DIFF
--- a/core/observe.c
+++ b/core/observe.c
@@ -557,9 +557,9 @@ void observe_step(lwm2m_context_t * contextP,
                             switch (dataP->type)
                             {
                             case LWM2M_TYPE_INTEGER:
-                                if ((integerValue <= watcherP->parameters->lessThan
+                                if ((integerValue < watcherP->parameters->lessThan
                                   && watcherP->lastValue.asInteger > watcherP->parameters->lessThan)
-                                 || (integerValue >= watcherP->parameters->lessThan
+                                 || (integerValue > watcherP->parameters->lessThan
                                   && watcherP->lastValue.asInteger < watcherP->parameters->lessThan))
                                 {
                                     LOG("Notify on lower threshold crossing");
@@ -567,9 +567,9 @@ void observe_step(lwm2m_context_t * contextP,
                                 }
                                 break;
                             case LWM2M_TYPE_FLOAT:
-                                if ((floatValue <= watcherP->parameters->lessThan
+                                if ((floatValue < watcherP->parameters->lessThan
                                   && watcherP->lastValue.asFloat > watcherP->parameters->lessThan)
-                                 || (floatValue >= watcherP->parameters->lessThan
+                                 || (floatValue > watcherP->parameters->lessThan
                                   && watcherP->lastValue.asFloat < watcherP->parameters->lessThan))
                                 {
                                     LOG("Notify on lower threshold crossing");
@@ -587,9 +587,9 @@ void observe_step(lwm2m_context_t * contextP,
                             switch (dataP->type)
                             {
                             case LWM2M_TYPE_INTEGER:
-                                if ((integerValue <= watcherP->parameters->greaterThan
+                                if ((integerValue < watcherP->parameters->greaterThan
                                   && watcherP->lastValue.asInteger > watcherP->parameters->greaterThan)
-                                 || (integerValue >= watcherP->parameters->greaterThan
+                                 || (integerValue > watcherP->parameters->greaterThan
                                   && watcherP->lastValue.asInteger < watcherP->parameters->greaterThan))
                                 {
                                     LOG("Notify on lower upper crossing");
@@ -597,9 +597,9 @@ void observe_step(lwm2m_context_t * contextP,
                                 }
                                 break;
                             case LWM2M_TYPE_FLOAT:
-                                if ((floatValue <= watcherP->parameters->greaterThan
+                                if ((floatValue < watcherP->parameters->greaterThan
                                   && watcherP->lastValue.asFloat > watcherP->parameters->greaterThan)
-                                 || (floatValue >= watcherP->parameters->greaterThan
+                                 || (floatValue > watcherP->parameters->greaterThan
                                   && watcherP->lastValue.asFloat < watcherP->parameters->greaterThan))
                                 {
                                     LOG("Notify on lower upper crossing");


### PR DESCRIPTION
It is not working properly if lessThan or greaterThan is same as lastValue.
Let assume that lessThan value is 10 and lastValue is 7.
At this situation, if object_readData get value of 10, it satisfy equal condtion
and then it will save 10 as lastvalue.
So, lastValue and lessThan are same, (lastValue > lessThan) and
(lastValue < lessThan) condition always return false.
It need to change condtion from <= to <, and from >= to >.

Signed-off-by: Changkeun IM <asarabi8282@gmail.com>