### PR TITLE
Update er-coap-13.c

### DIFF
--- a/core/er-coap-13/er-coap-13.c
+++ b/core/er-coap-13/er-coap-13.c
@@ -46,7 +46,7 @@
 
 #include "er-coap-13.h"
 
-#include "liblwm2m.h" /* for lwm2m_malloc() and lwm2m_free() */
+#include "../liblwm2m.h" /* for lwm2m_malloc() and lwm2m_free() */
 
 #define DEBUG 0
 #if DEBUG


### PR DESCRIPTION
Use relative path to lwm2m.h header file. This is the only place preventing wakaama and its only API header ("lwm2m.h") to be compiled and used relative from other code without having wakaama in the global include directive of the compiler.

Signed-off-by: David Gräff <david.graeff@web.de>