### PR TITLE
json: fix URIs handling bug and add associated unit tests

### DIFF
--- a/core/json.c
+++ b/core/json.c
@@ -598,7 +598,7 @@ static int prv_convertRecord(lwm2m_uri_t * uriP,
                 parentP->value.asChildren.array = lwm2m_data_new(1);
                 if (NULL == parentP->value.asChildren.array) goto error;
                 parentP = parentP->value.asChildren.array;
-                parentP->type = LWM2M_TYPE_UNDEFINED;
+                parentP->type = LWM2M_TYPE_INTEGER;
                 parentP->id = uriP->resourceId;
                 rootLevel = URI_DEPTH_RESOURCE_INSTANCE;
             }

--- a/tests/tlv_json_lwm2m_data_test.c
+++ b/tests/tlv_json_lwm2m_data_test.c
@@ -384,6 +384,26 @@ static void test_10(void)
     test_data("/12/0", LWM2M_CONTENT_JSON, data1, 17, "10b");
 }
 
+static void test_11(void)
+{
+    const char * buffer = "{\"bn\":\"/5/0/1\",              \
+                         \"e\":[                            \
+                           {\"n\":\"/1\",\"sv\":\"http\"}]  \
+                      }";
+
+    test_raw(NULL, (uint8_t *)buffer, strlen(buffer), LWM2M_CONTENT_JSON, "11");
+}
+
+static void test_12(void)
+{
+    const char * buffer = "{\"bn\":\"/5/0\",                \
+                         \"e\":[                            \
+                           {\"n\":\"/1\",\"sv\":\"http\"}]  \
+                      }";
+
+    test_raw(NULL, (uint8_t *)buffer, strlen(buffer), LWM2M_CONTENT_JSON, "12");
+}
+
 static struct TestTable table[] = {
         { "test of test_1()", test_1 },
         { "test of test_2()", test_2 },
@@ -395,6 +415,8 @@ static struct TestTable table[] = {
         { "test of test_8()", test_8 },
         { "test of test_9()", test_9 },
         { "test of test_10()", test_10 },
+        { "test of test_11()", test_11 },
+        { "test of test_12()", test_12 },
         { NULL, NULL },
 };
 


### PR DESCRIPTION
This PR adds two new unit tests for JSON parsing, one of which causes a bug in parsing URIs with a resource ID included. It also fixes the issue in the JSON parsing code.