### PR TITLE
issue 382: observation memory free exception

### DIFF
--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -484,7 +484,8 @@ typedef void (*lwm2m_result_callback_t) (uint16_t clientID, lwm2m_uri_t * uriP, 
 /*
  * LWM2M Observations
  *
- * Used to store observation of remote clients resources.
+ * Used to store latest user operation on the observation of remote clients resources.
+ * Any node in the observation list means observation was established with client already.
  * status STATE_REG_PENDING means the observe request was sent to the client but not yet answered.
  * status STATE_REGISTERED means the client acknowledged the observe request.
  * status STATE_DEREG_PENDING means the user canceled the request before the client answered it.
@@ -496,7 +497,7 @@ typedef struct _lwm2m_observation_
     uint16_t                     id;    // matches lwm2m_list_t::id
     struct _lwm2m_client_ * clientP;
     lwm2m_uri_t             uri;
-    lwm2m_status_t          status;
+    lwm2m_status_t          status;     // latest user operation
     lwm2m_result_callback_t callback;
     void *                  userData;
 } lwm2m_observation_t;
@@ -554,6 +555,7 @@ typedef struct _lwm2m_client_
     void *                  sessionH;
     lwm2m_client_object_t * objectList;
     lwm2m_observation_t *   observationList;
+    uint16_t                observationId;
 } lwm2m_client_t;
 
 

--- a/core/observe.c
+++ b/core/observe.c
@@ -757,10 +757,24 @@ void observe_step(lwm2m_context_t * contextP,
 
 typedef struct
 {
-    lwm2m_observation_t * observationP;
+    uint16_t                client;
+    lwm2m_uri_t             uri;
     lwm2m_result_callback_t callbackP;
-    void * userDataP;
+    void *                  userDataP;
+    lwm2m_context_t *       contextP;
 } cancellation_data_t;
+
+typedef struct
+{
+    uint16_t                id;
+    uint16_t                client;
+    lwm2m_uri_t             uri;
+    lwm2m_result_callback_t callback;
+    void *                  userData;
+    lwm2m_context_t *       contextP;
+} observation_data_t;
+
+
 
 static lwm2m_observation_t * prv_findObservationByURI(lwm2m_client_t * clientP,
                                                       lwm2m_uri_t * uriP)
@@ -792,33 +806,39 @@ void observe_remove(lwm2m_observation_t * observationP)
 }
 
 static void prv_obsRequestCallback(lwm2m_transaction_t * transacP,
-                                   void * message)
+        void * message)
 {
-    lwm2m_observation_t * observationP = (lwm2m_observation_t *)transacP->userData;
+    lwm2m_observation_t * observationP = NULL;
+    observation_data_t * observationData = (observation_data_t *)transacP->userData;
     coap_packet_t * packet = (coap_packet_t *)message;
     uint8_t code;
+    lwm2m_client_t * clientP;
+    lwm2m_uri_t * uriP = & observationData->uri;
 
-    switch (observationP->status)
+    clientP = (lwm2m_client_t *)lwm2m_list_find((lwm2m_list_t *)observationData->contextP->clientList, observationData->client);
+    if (clientP == NULL)
     {
-    case STATE_DEREG_PENDING:
-        // Observation was canceled by the user.
-        observe_remove(observationP);
-        return;
-
-    case STATE_REG_PENDING:
-        observationP->status = STATE_REGISTERED;
-        break;
-
-    default:
-        break;
+        observationData->callback(observationData->client,
+                &observationData->uri,
+                COAP_500_INTERNAL_SERVER_ERROR,  //?
+                0, NULL, 0,
+                observationData->userData);
+        goto end;
     }
 
-    if (message == NULL)
+    observationP = prv_findObservationByURI(clientP, uriP);
+
+    // Fail it if the latest user intention is cancellation
+    if(observationP && observationP->status == STATE_DEREG_PENDING)
+    {
+        code = COAP_400_BAD_REQUEST;
+    }
+    else if (message == NULL)
     {
         code = COAP_503_SERVICE_UNAVAILABLE;
     }
     else if (packet->code == COAP_205_CONTENT
-         && !IS_OPTION(packet, COAP_OPTION_OBSERVE))
+            && !IS_OPTION(packet, COAP_OPTION_OBSERVE))
     {
         code = COAP_405_METHOD_NOT_ALLOWED;
     }
@@ -829,30 +849,74 @@ static void prv_obsRequestCallback(lwm2m_transaction_t * transacP,
 
     if (code != COAP_205_CONTENT)
     {
-        observationP->callback(observationP->clientP->internalID,
-                               &observationP->uri,
-                               code,
-                               LWM2M_CONTENT_TEXT, NULL, 0,
-                               observationP->userData);
-        observe_remove(observationP);
+        observationData->callback(clientP->internalID,
+                &observationData->uri,
+                code,
+                LWM2M_CONTENT_TEXT, NULL, 0,
+                observationData->userData);
     }
     else
     {
-        observationP->callback(observationP->clientP->internalID,
-                               &observationP->uri,
-                               0,
-                               packet->content_type, packet->payload, packet->payload_len,
-                               observationP->userData);
+        if(observationP == NULL)
+        {
+            observationP = (lwm2m_observation_t *)lwm2m_malloc(sizeof(*observationP));
+            if (observationP == NULL) goto end;
+            memset(observationP, 0, sizeof(*observationP));
+        }
+        else
+        {
+            observationP->clientP->observationList = (lwm2m_observation_t *) LWM2M_LIST_RM(observationP->clientP->observationList, observationP->id, NULL);
+
+            // give the user chance to free previous observation userData
+            // indicator: COAP_202_DELETED and (Length ==0)
+            observationP->callback(observationP->clientP->internalID,
+                    &observationP->uri,
+                    COAP_202_DELETED,
+                    0, NULL, 0,
+                    observationP->userData);
+        }
+
+        observationP->id = observationData->id;
+        observationP->clientP = clientP;
+
+        observationP->callback = observationData->callback;
+        observationP->userData = observationData->userData;
+        observationP->status = STATE_REGISTERED;
+        memcpy(&observationP->uri, uriP, sizeof(lwm2m_uri_t));
+
+        observationP->clientP->observationList = (lwm2m_observation_t *)LWM2M_LIST_ADD(observationP->clientP->observationList, observationP);
+
+        observationData->callback(observationData->client,
+                &observationData->uri,
+                0,
+                packet->content_type, packet->payload, packet->payload_len,
+                observationData->userData);
     }
+
+end:
+    lwm2m_free(observationData);
 }
 
 
 static void prv_obsCancelRequestCallback(lwm2m_transaction_t * transacP,
-                                         void * message)
+        void * message)
 {
     cancellation_data_t * cancelP = (cancellation_data_t *)transacP->userData;
     coap_packet_t * packet = (coap_packet_t *)message;
     uint8_t code;
+    lwm2m_client_t * clientP = (lwm2m_client_t *)lwm2m_list_find((lwm2m_list_t *)cancelP->contextP->clientList, cancelP->client);
+
+    if (clientP == NULL)
+    {
+        cancelP->callbackP(cancelP->client,
+                &cancelP->uri,
+                COAP_500_INTERNAL_SERVER_ERROR,
+                packet->content_type, NULL, 0,
+                cancelP->userDataP);
+        goto end;
+    }
+
+    lwm2m_observation_t * observationP = prv_findObservationByURI(clientP, &cancelP->uri);
 
     if (message == NULL)
     {
@@ -865,35 +929,36 @@ static void prv_obsCancelRequestCallback(lwm2m_transaction_t * transacP,
 
     if (code != COAP_205_CONTENT)
     {
-        cancelP->callbackP(cancelP->observationP->clientP->internalID,
-                           &cancelP->observationP->uri,
-                           code,
-                           LWM2M_CONTENT_TEXT, NULL, 0,
-                           cancelP->userDataP);
+        cancelP->callbackP(cancelP->client,
+                &cancelP->uri,
+                code,
+                LWM2M_CONTENT_TEXT, NULL, 0,
+                cancelP->userDataP);
     }
     else
     {
-        cancelP->callbackP(cancelP->observationP->clientP->internalID,
-                           &cancelP->observationP->uri,
-                           0,
-                           packet->content_type, packet->payload, packet->payload_len,
-                           cancelP->userDataP);
+        cancelP->callbackP(cancelP->client,
+                &cancelP->uri,
+                0,
+                packet->content_type, packet->payload, packet->payload_len,
+                cancelP->userDataP);
     }
 
-    observe_remove(cancelP->observationP);
-
+    observe_remove(observationP);
+end:
     lwm2m_free(cancelP);
 }
 
 
 int lwm2m_observe(lwm2m_context_t * contextP,
-                  uint16_t clientID,
-                  lwm2m_uri_t * uriP,
-                  lwm2m_result_callback_t callback,
-                  void * userData)
+        uint16_t clientID,
+        lwm2m_uri_t * uriP,
+        lwm2m_result_callback_t callback,
+        void * userData)
 {
     lwm2m_client_t * clientP;
     lwm2m_transaction_t * transactionP;
+    observation_data_t * observationData;
     lwm2m_observation_t * observationP;
     uint8_t token[4];
 
@@ -905,43 +970,39 @@ int lwm2m_observe(lwm2m_context_t * contextP,
     clientP = (lwm2m_client_t *)lwm2m_list_find((lwm2m_list_t *)contextP->clientList, clientID);
     if (clientP == NULL) return COAP_404_NOT_FOUND;
 
-    for (observationP = clientP->observationList; observationP != NULL; observationP = observationP->next)
-    {
-        if (uriP->objectId == observationP->uri.objectId
-            && (LWM2M_URI_IS_SET_INSTANCE(uriP) == false
-                || observationP->uri.instanceId == uriP->instanceId)
-            && (LWM2M_URI_IS_SET_RESOURCE(uriP) == false
-                || observationP->uri.resourceId == uriP->resourceId))
-        {
-            break;
-        }
-    }
-    if (observationP == NULL)
-    {
-        observationP = (lwm2m_observation_t *)lwm2m_malloc(sizeof(lwm2m_observation_t));
-        if (observationP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
-        memset(observationP, 0, sizeof(lwm2m_observation_t));
+    observationP = prv_findObservationByURI(clientP, uriP);
 
-        observationP->id = lwm2m_list_newId((lwm2m_list_t *)clientP->observationList);
-        memcpy(&observationP->uri, uriP, sizeof(lwm2m_uri_t));
-        observationP->clientP = clientP;
+    observationData = (observation_data_t *)lwm2m_malloc(sizeof(observation_data_t));
+    if (observationData == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
+    memset(observationData, 0, sizeof(observation_data_t));
 
-        observationP->clientP->observationList = (lwm2m_observation_t *)LWM2M_LIST_ADD(observationP->clientP->observationList, observationP);
+    observationData->id = ++clientP->observationId;
+
+    // observationId can overflow. ensure new ID is not already present
+    if(lwm2m_list_find((lwm2m_list_t *)clientP->observationList, observationData->id))
+    {
+        LOG("Can't get available observation ID. Request failed.\n");
+        lwm2m_free(observationData);
+        return COAP_500_INTERNAL_SERVER_ERROR;
     }
-    observationP->status = STATE_REG_PENDING;
-    observationP->callback = callback;
-    observationP->userData = userData;
+
+    memcpy(&observationData->uri, uriP, sizeof(lwm2m_uri_t));
+
+    // don't hold refer to the clientP
+    observationData->client = clientP->internalID;
+    observationData->callback = callback;
+    observationData->userData = userData;
+    observationData->contextP = contextP;
 
     token[0] = clientP->internalID >> 8;
     token[1] = clientP->internalID & 0xFF;
-    token[2] = observationP->id >> 8;
-    token[3] = observationP->id & 0xFF;
+    token[2] = observationData->id >> 8;
+    token[3] = observationData->id & 0xFF;
 
     transactionP = transaction_new(clientP->sessionH, COAP_GET, clientP->altPath, uriP, contextP->nextMID++, 4, token);
     if (transactionP == NULL)
     {
-        observationP->clientP->observationList = (lwm2m_observation_t *)LWM2M_LIST_RM(observationP->clientP->observationList, observationP->id, NULL);
-        lwm2m_free(observationP);
+        lwm2m_free(observationData);
         return COAP_500_INTERNAL_SERVER_ERROR;
     }
 
@@ -956,21 +1017,31 @@ int lwm2m_observe(lwm2m_context_t * contextP,
     }
 
     transactionP->callback = prv_obsRequestCallback;
-    transactionP->userData = (void *)observationP;
+    transactionP->userData = (void *)observationData;
 
     contextP->transactionList = (lwm2m_transaction_t *)LWM2M_LIST_ADD(contextP->transactionList, transactionP);
 
-    return transaction_send(contextP, transactionP);
+    // update the user latest intention
+    if(observationP) observationP->status = STATE_REG_PENDING;
+
+    int ret = transaction_send(contextP, transactionP);
+    if (ret != 0)
+    {
+        LOG("transaction_send failed!");
+        lwm2m_free(observationData);
+    }
+    return ret;
 }
 
 int lwm2m_observe_cancel(lwm2m_context_t * contextP,
-                         uint16_t clientID,
-                         lwm2m_uri_t * uriP,
-                         lwm2m_result_callback_t callback,
-                         void * userData)
+        uint16_t clientID,
+        lwm2m_uri_t * uriP,
+        lwm2m_result_callback_t callback,
+        void * userData)
 {
     lwm2m_client_t * clientP;
     lwm2m_observation_t * observationP;
+    int ret;
 
     LOG_ARG("clientID: %d", clientID);
     LOG_URI(uriP);
@@ -1008,28 +1079,41 @@ int lwm2m_observe_cancel(lwm2m_context_t * contextP,
 
         coap_set_header_observe(transactionP->message, 1);
 
-        cancelP->observationP = observationP;
+        // don't hold refer to the clientP
+        cancelP->client = clientP->internalID;
+        memcpy(&cancelP->uri, uriP, sizeof(lwm2m_uri_t));
         cancelP->callbackP = callback;
         cancelP->userDataP = userData;
+        cancelP->contextP = contextP;
 
         transactionP->callback = prv_obsCancelRequestCallback;
         transactionP->userData = (void *)cancelP;
 
         contextP->transactionList = (lwm2m_transaction_t *)LWM2M_LIST_ADD(contextP->transactionList, transactionP);
 
-        return transaction_send(contextP, transactionP);
+        observationP->status = STATE_DEREG_PENDING;
+
+        int ret = transaction_send(contextP, transactionP);
+        if (ret != 0) lwm2m_free(cancelP);
+        return ret;
     }
 
     case STATE_REG_PENDING:
         observationP->status = STATE_DEREG_PENDING;
+        ret = COAP_204_CHANGED;
         break;
 
     default:
         // Should not happen
+        ret = COAP_IGNORE;
         break;
     }
 
-    return COAP_NO_ERROR;
+    // no other chance to remove the observationP since not sending a transaction
+    observe_remove(observationP);
+
+    // need to give a indicator (non-zero) to user for properly freeing the userData
+    return ret;
 }
 
 bool observe_handleNotify(lwm2m_context_t * contextP,

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -232,7 +232,7 @@ lwm2m_transaction_t * transaction_new(void * sessionH,
         }
     }
 
-    LOG("Exiting on success");
+    LOG_ARG("Exiting on success. new transac=%p", transacP);
     return transacP;
 
 error:
@@ -243,7 +243,7 @@ error:
 
 void transaction_free(lwm2m_transaction_t * transacP)
 {
-    LOG("Entering");
+    LOG_ARG("Entering. transaction=%p", transacP);
     if (transacP->message)
     {
        coap_free_header(transacP->message);
@@ -257,7 +257,7 @@ void transaction_free(lwm2m_transaction_t * transacP)
 void transaction_remove(lwm2m_context_t * contextP,
                         lwm2m_transaction_t * transacP)
 {
-    LOG("Entering");
+    LOG_ARG("Entering. transaction=%p", transacP);
     contextP->transactionList = (lwm2m_transaction_t *) LWM2M_LIST_RM(contextP->transactionList, transacP->mID, NULL);
     transaction_free(transacP);
 }
@@ -348,7 +348,7 @@ int transaction_send(lwm2m_context_t * contextP,
 {
     bool maxRetriesReached = false;
 
-    LOG("Entering");
+    LOG_ARG("Entering: transaction=%p", transacP);
     if (transacP->buffer == NULL)
     {
         transacP->buffer_len = coap_serialize_get_size(transacP->message);
@@ -415,6 +415,7 @@ int transaction_send(lwm2m_context_t * contextP,
     {
         if (transacP->callback)
         {
+            LOG_ARG("transaction %p expired..calling callback", transacP);
             transacP->callback(transacP, NULL);
         }
         transaction_remove(contextP, transacP);


### PR DESCRIPTION
This patch is created to fix the issue #382. The solution followed the proposal provided in the #382.

    Don't hold the pointer to client and observation object in the transaction object since many possible situations can happen during the transaction. for example, the client could reset, the user application could cancel the obs or start a new observation on the same client resource.

    Ensure in any case the user application can have a chance to handle cleanup for the pointer "UserData" passed in the lwm2m_observe() and lwm2m_observe_cancel() , through the callback function it also passed into the functions.
