### PR TITLE
free memory on successful and failed observation read object.

### DIFF
--- a/core/management.c
+++ b/core/management.c
@@ -234,8 +234,8 @@ uint8_t dm_handleRequest(lwm2m_context_t * contextP,
                             LOG_ARG("Observe Request[/%d/%d/%d]: %.*s\n", uriP->objectId, uriP->instanceId, uriP->resourceId, length, buffer);
                         }
                     }
-                    lwm2m_data_free(size, dataP);
                 }
+                lwm2m_data_free(size, dataP);
             }
             else if (IS_OPTION(message, COAP_OPTION_ACCEPT)
                   && message->accept_num == 1


### PR DESCRIPTION
**Problem** 
Data isn't freed after a failed readout on an observation request.

**Explanation**
After an observe option is send to the client, a data readout on the object is preformed.
The callback `target->readFunc` is been called (data is already allocated), if this fails, data isn't freed.
Only on a successful readout.

**Steps to reproduce** 
1. Create a resource which returns an error.
2. Observe this resource. 
3. Check `core/management.c` line  `208`
