### PR TITLE
Improve floating point to text conversion

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,10 +8,10 @@ include(${CMAKE_CURRENT_LIST_DIR}/../examples/shared/shared.cmake)
 add_definitions(-DLWM2M_CLIENT_MODE -DLWM2M_SUPPORT_JSON)
 add_definitions(${SHARED_DEFINITIONS} ${WAKAAMA_DEFINITIONS})
 # Enable all warnings for this test build  
-add_definitions(-pedantic -Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default)
+add_compile_options(-pedantic -Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default)
 
 include_directories (${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
-
+set_source_files_properties(${WAKAAMA_SOURCES_DIR}/utils.c PROPERTIES COMPILE_FLAGS -Wno-float-equal)
 
 file(GLOB SOURCES "*.c")
 


### PR DESCRIPTION
Floating point conversion had a limited range that was supported. This improves the range but requires space in the buffer for the trailing null.