### PR TITLE
URI updates

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -531,8 +531,7 @@ uint8_t bootstrap_handleDeleteAll(lwm2m_context_t * contextP,
     {
         lwm2m_uri_t uri;
 
-        memset(&uri, 0, sizeof(lwm2m_uri_t));
-        uri.flag = LWM2M_URI_FLAG_OBJECT_ID;
+        LWM2M_URI_RESET(&uri);
         uri.objectId = objectP->objID;
 
         if (objectP->objID == LWM2M_SECURITY_OBJECT_ID)
@@ -549,7 +548,6 @@ uint8_t bootstrap_handleDeleteAll(lwm2m_context_t * contextP,
                 }
                 else
                 {
-                    uri.flag = LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID;
                     uri.instanceId = instanceP->id;
                     result = object_delete(contextP, &uri);
                     instanceP = objectP->instanceList;
@@ -631,7 +629,7 @@ static void prv_resultCallback(lwm2m_context_t * contextP,
 
     (void)contextP; /* unused */
 
-    if (dataP->isUri == true)
+    if (LWM2M_URI_IS_SET_OBJECT(&dataP->uri))
     {
         uriP = &dataP->uri;
     }
@@ -680,11 +678,10 @@ int lwm2m_bootstrap_delete(lwm2m_context_t * contextP,
     }
     if (uriP == NULL)
     {
-        dataP->isUri = false;
+        LWM2M_URI_RESET(&dataP->uri);
     }
     else
     {
-        dataP->isUri = true;
         memcpy(&dataP->uri, uriP, sizeof(lwm2m_uri_t));
     }
     dataP->callback = contextP->bootstrapCallback;
@@ -728,7 +725,6 @@ int lwm2m_bootstrap_write(lwm2m_context_t * contextP,
         transaction_free(transaction);
         return COAP_500_INTERNAL_SERVER_ERROR;
     }
-    dataP->isUri = true;
     memcpy(&dataP->uri, uriP, sizeof(lwm2m_uri_t));
     dataP->callback = contextP->bootstrapCallback;
     dataP->userData = contextP->bootstrapUserData;
@@ -759,7 +755,7 @@ int lwm2m_bootstrap_finish(lwm2m_context_t * contextP,
         transaction_free(transaction);
         return COAP_500_INTERNAL_SERVER_ERROR;
     }
-    dataP->isUri = false;
+    LWM2M_URI_RESET(&dataP->uri);
     dataP->callback = contextP->bootstrapCallback;
     dataP->userData = contextP->bootstrapUserData;
 

--- a/core/data.c
+++ b/core/data.c
@@ -655,6 +655,10 @@ int lwm2m_data_parse(lwm2m_uri_t * uriP,
     {
     case LWM2M_CONTENT_TEXT:
         if (!LWM2M_URI_IS_SET_RESOURCE(uriP)) return 0;
+#ifndef LWM2M_VERSION_1_0
+		// TODO: Support resource instance
+        if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP)) return 0;
+#endif
         *dataP = lwm2m_data_new(1);
         if (*dataP == NULL) return 0;
         (*dataP)->id = uriP->resourceId;
@@ -669,6 +673,10 @@ int lwm2m_data_parse(lwm2m_uri_t * uriP,
 
     case LWM2M_CONTENT_OPAQUE:
         if (!LWM2M_URI_IS_SET_RESOURCE(uriP)) return 0;
+#ifndef LWM2M_VERSION_1_0
+		// TODO: Support resource instance
+        if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP)) return 0;
+#endif
         *dataP = lwm2m_data_new(1);
         if (*dataP == NULL) return 0;
         (*dataP)->id = uriP->resourceId;
@@ -678,7 +686,7 @@ int lwm2m_data_parse(lwm2m_uri_t * uriP,
         {
             lwm2m_data_free(1, *dataP);
             *dataP = NULL;
-    }
+        }
         return res;
 
 #ifdef LWM2M_OLD_CONTENT_FORMAT_SUPPORT
@@ -754,6 +762,14 @@ int lwm2m_data_serialize(lwm2m_uri_t * uriP,
     {
             bool isResourceInstance;
 
+#ifndef LWM2M_VERSION_1_0
+            if (uriP != NULL && LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP))
+            {
+                if(size != 1 || dataP->id != uriP->resourceInstanceId) return -1;
+                isResourceInstance = true;
+            }
+            else
+#endif
             if (uriP != NULL && LWM2M_URI_IS_SET_RESOURCE(uriP)
              && (size != 1 || dataP->id != uriP->resourceId))
             {

--- a/core/discover.c
+++ b/core/discover.c
@@ -422,7 +422,6 @@ int discover_serialize(lwm2m_context_t * contextP,
 
     baseUriLen = uri_toString(uriP, baseUriStr, URI_MAX_STRING_LEN, NULL);
     if (baseUriLen < 0) return -1;
-    baseUriLen -= 1;
 
     for (index = 0; index < size && head < PRV_LINK_BUFFER_SIZE; index++)
     {

--- a/core/discover.c
+++ b/core/discover.c
@@ -225,7 +225,6 @@ static int prv_serializeLinkData(lwm2m_context_t * contextP,
         {
             memcpy(&uri, parentUriP, sizeof(lwm2m_uri_t));
             uri.resourceId = tlvP->id;
-            uri.flag |= LWM2M_URI_FLAG_RESOURCE_ID;
             res = prv_serializeAttributes(contextP, &uri, serverP, objectParamP, buffer, head - 1, bufferLen);
             if (res < 0) return -1;    // careful, 0 is valid
             if (res > 0) head += res;
@@ -259,7 +258,6 @@ static int prv_serializeLinkData(lwm2m_context_t * contextP,
 
         memcpy(&uri, parentUriP, sizeof(lwm2m_uri_t));
         uri.instanceId = tlvP->id;
-        uri.flag |= LWM2M_URI_FLAG_INSTANCE_ID;
 
         head = 0;
         PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ITEM_START, LINK_ITEM_START_SIZE);
@@ -303,6 +301,7 @@ int discover_serialize(lwm2m_context_t * contextP,
     size_t head;
     int res;
     lwm2m_uri_t parentUri;
+    lwm2m_uri_t baseUri;
     lwm2m_attributes_t * paramP;
     lwm2m_attributes_t mergedParam;
 
@@ -310,9 +309,8 @@ int discover_serialize(lwm2m_context_t * contextP,
     LOG_URI(uriP);
 
     head = 0;
-    memset(&parentUri, 0, sizeof(lwm2m_uri_t));
+    LWM2M_URI_RESET(&parentUri);
     parentUri.objectId = uriP->objectId;
-    parentUri.flag = LWM2M_URI_FLAG_OBJECT_ID;
 
     if (LWM2M_URI_IS_SET_RESOURCE(uriP))
     {
@@ -320,16 +318,15 @@ int discover_serialize(lwm2m_context_t * contextP,
         lwm2m_attributes_t * objParamP;
         lwm2m_attributes_t * instParamP;
 
-        memset(&parentUri, 0, sizeof(lwm2m_uri_t));
+        LWM2M_URI_RESET(&parentUri);
+        LWM2M_URI_RESET(&tempUri);
         tempUri.objectId = uriP->objectId;
-        tempUri.flag = LWM2M_URI_FLAG_OBJECT_ID;
 
         // get object level attributes
         objParamP = prv_findAttributes(contextP, &tempUri, serverP);
         
         // get object instance level attributes
         tempUri.instanceId = uriP->instanceId;
-        tempUri.flag = LWM2M_URI_FLAG_INSTANCE_ID;
         instParamP = prv_findAttributes(contextP, &tempUri, serverP);
 
         if (objParamP != NULL)
@@ -371,7 +368,9 @@ int discover_serialize(lwm2m_context_t * contextP,
         {
             paramP = instParamP;
         }
-        uriP->flag &= ~LWM2M_URI_FLAG_RESOURCE_ID;
+        memcpy(&baseUri, uriP, sizeof(baseUri));
+        baseUri.resourceId = LWM2M_MAX_ID;
+        uriP = &baseUri;
     }
     else
     {
@@ -390,7 +389,6 @@ int discover_serialize(lwm2m_context_t * contextP,
             head += res;
             PRV_CONCAT_STR(bufferLink, PRV_LINK_BUFFER_SIZE, head, LINK_ITEM_END, LINK_ITEM_END_SIZE);
             parentUri.instanceId = uriP->instanceId;
-            parentUri.flag = LWM2M_URI_FLAG_INSTANCE_ID;
             if (serverP != NULL)
             {
                 res = prv_serializeAttributes(contextP, &parentUri, serverP, NULL, bufferLink, head - 1, PRV_LINK_BUFFER_SIZE);

--- a/core/internals.h
+++ b/core/internals.h
@@ -67,17 +67,27 @@
 #include <inttypes.h>
 #define LOG(STR) lwm2m_printf("[%s:%d] " STR "\r\n", __func__ , __LINE__)
 #define LOG_ARG(FMT, ...) lwm2m_printf("[%s:%d] " FMT "\r\n", __func__ , __LINE__ , __VA_ARGS__)
+#ifdef LWM2M_VERSION_1_0
 #define LOG_URI(URI)                                                                \
 {                                                                                   \
-    if ((URI) == NULL) lwm2m_printf("[%s:%d] NULL\r\n", __func__ , __LINE__);     \
+    if ((URI) == NULL) lwm2m_printf("[%s:%d] NULL\r\n", __func__ , __LINE__);       \
     else                                                                            \
     {                                                                               \
-        lwm2m_printf("[%s:%d] /%d", __func__ , __LINE__ , (URI)->objectId);       \
+        lwm2m_printf("[%s:%d] /%d", __func__ , __LINE__ , (URI)->objectId);         \
         if (LWM2M_URI_IS_SET_INSTANCE(URI)) lwm2m_printf("/%d", (URI)->instanceId); \
         if (LWM2M_URI_IS_SET_RESOURCE(URI)) lwm2m_printf("/%d", (URI)->resourceId); \
         lwm2m_printf("\r\n");                                                       \
     }                                                                               \
 }
+#else
+#define LOG_URI(URI)                                                                \
+    if ((URI) == NULL) lwm2m_printf("[%s:%d] NULL\r\n", __func__ , __LINE__);       \
+    else if (!LWM2M_URI_IS_SET_OBJECT(URI)) lwm2m_printf("[%s:%d] /\r\n", __func__ , __LINE__); \
+    else if (!LWM2M_URI_IS_SET_INSTANCE(URI)) lwm2m_printf("[%s:%d] /%d\r\n", __func__ , __LINE__, (URI)->objectId); \
+    else if (!LWM2M_URI_IS_SET_RESOURCE(URI)) lwm2m_printf("[%s:%d] /%d/%d\r\n", __func__ , __LINE__, (URI)->objectId, (URI)->instanceId); \
+    else if (!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(URI)) lwm2m_printf("[%s:%d] /%d/%d/%d\r\n", __func__ , __LINE__, (URI)->objectId, (URI)->instanceId, (URI)->resourceId); \
+    else lwm2m_printf("[%s:%d] /%d/%d/%d/%d\r\n", __func__ , __LINE__, (URI)->objectId, (URI)->instanceId, (URI)->resourceId, (URI)->resourceInstanceId)
+#endif
 #define STR_STATUS(S)                                           \
 ((S) == STATE_DEREGISTERED ? "STATE_DEREGISTERED" :             \
 ((S) == STATE_REG_HOLD_OFF ? "STATE_REG_HOLD_OFF" :             \
@@ -197,7 +207,11 @@
 #define ATTR_DIMENSION_STR       "dim="
 #define ATTR_DIMENSION_LEN       4
 
+#ifdef LWM2M_VERSION_1_0
 #define URI_MAX_STRING_LEN    18      // /65535/65535/65535
+#else
+#define URI_MAX_STRING_LEN    24      // /65535/65535/65535/65535
+#endif
 #define _PRV_64BIT_BUFFER_SIZE 8
 
 #define LINK_ITEM_START             "<"
@@ -221,7 +235,11 @@
 #define LWM2M_URI_FLAG_BOOTSTRAP    (uint8_t)0x40
 
 #define LWM2M_URI_MASK_TYPE (uint8_t)0x70
+#ifdef LWM2M_VERSION_1_0
 #define LWM2M_URI_MASK_ID   (uint8_t)0x07
+#else
+#define LWM2M_URI_MASK_ID   (uint8_t)0x0F
+#endif
 
 typedef struct
 {

--- a/core/internals.h
+++ b/core/internals.h
@@ -229,18 +229,6 @@
 
 #define ATTR_FLAG_NUMERIC (uint8_t)(LWM2M_ATTR_FLAG_LESS_THAN | LWM2M_ATTR_FLAG_GREATER_THAN | LWM2M_ATTR_FLAG_STEP)
 
-#define LWM2M_URI_FLAG_DM           (uint8_t)0x00
-#define LWM2M_URI_FLAG_DELETE_ALL   (uint8_t)0x10
-#define LWM2M_URI_FLAG_REGISTRATION (uint8_t)0x20
-#define LWM2M_URI_FLAG_BOOTSTRAP    (uint8_t)0x40
-
-#define LWM2M_URI_MASK_TYPE (uint8_t)0x70
-#ifdef LWM2M_VERSION_1_0
-#define LWM2M_URI_MASK_ID   (uint8_t)0x07
-#else
-#define LWM2M_URI_MASK_ID   (uint8_t)0x0F
-#endif
-
 typedef struct
 {
     uint16_t clientID;
@@ -261,15 +249,23 @@ typedef enum
 #ifdef LWM2M_BOOTSTRAP_SERVER_MODE
 typedef struct
 {
-    bool        isUri;
     lwm2m_uri_t uri;
     lwm2m_bootstrap_callback_t callback;
     void *      userData;
 } bs_data_t;
 #endif
 
+typedef enum
+{
+    LWM2M_REQUEST_TYPE_UNKNOWN,
+    LWM2M_REQUEST_TYPE_DM,
+    LWM2M_REQUEST_TYPE_REGISTRATION,
+    LWM2M_REQUEST_TYPE_BOOTSTRAP,
+    LWM2M_REQUEST_TYPE_DELETE_ALL
+} lwm2m_request_type_t;
+
 // defined in uri.c
-lwm2m_uri_t * uri_decode(char * altPath, multi_option_t *uriPath);
+lwm2m_request_type_t uri_decode(char * altPath, multi_option_t *uriPath, lwm2m_uri_t *uriP);
 int uri_getNumber(uint8_t * uriString, size_t uriLength);
 int uri_toString(const lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, uri_depth_t * depthP);
 

--- a/core/internals.h
+++ b/core/internals.h
@@ -251,6 +251,7 @@ typedef struct
 
 typedef enum
 {
+    URI_DEPTH_NONE,
     URI_DEPTH_OBJECT,
     URI_DEPTH_OBJECT_INSTANCE,
     URI_DEPTH_RESOURCE,
@@ -270,7 +271,7 @@ typedef struct
 // defined in uri.c
 lwm2m_uri_t * uri_decode(char * altPath, multi_option_t *uriPath);
 int uri_getNumber(uint8_t * uriString, size_t uriLength);
-int uri_toString(lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, uri_depth_t * depthP);
+int uri_toString(const lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, uri_depth_t * depthP);
 
 // defined in objects.c
 uint8_t object_readData(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);

--- a/core/json.c
+++ b/core/json.c
@@ -1391,10 +1391,24 @@ int json_serialize(lwm2m_uri_t * uriP,
     uri_depth_t rootLevel;
     int num;
     lwm2m_data_t * targetP;
+#ifndef LWM2M_VERSION_1_0
+    lwm2m_uri_t uri;
+#endif
 
     LOG_ARG("size: %d", size);
     LOG_URI(uriP);
     if (size != 0 && tlvP == NULL) return -1;
+
+#ifndef LWM2M_VERSION_1_0
+    if (uriP && LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP))
+    {
+        /* The resource instance doesn't get serialized as part of the base URI.
+         * Strip it out. */
+        memcpy(&uri, uriP, sizeof(lwm2m_uri_t));
+        uri.flag &= ~LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID;
+        uriP = &uri;
+    }
+#endif
 
     baseUriLen = uri_toString(uriP, baseUriStr, URI_MAX_STRING_LEN, &rootLevel);
     if (baseUriLen < 0) return -1;

--- a/core/json.c
+++ b/core/json.c
@@ -904,7 +904,7 @@ int json_parse(lwm2m_uri_t * uriP,
         lwm2m_data_t * resultP;
         int size;
 
-        memset(&baseURI, 0, sizeof(lwm2m_uri_t));
+        LWM2M_URI_RESET(&baseURI);
         if (bnFound == false)
         {
             baseUriP = uriP;
@@ -1409,7 +1409,7 @@ int json_serialize(lwm2m_uri_t * uriP,
         /* The resource instance doesn't get serialized as part of the base URI.
          * Strip it out. */
         memcpy(&uri, uriP, sizeof(lwm2m_uri_t));
-        uri.flag &= ~LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID;
+        uri.resourceInstanceId = LWM2M_MAX_ID;
         uriP = &uri;
     }
 #endif

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -260,19 +260,15 @@ void lwm2m_list_free(lwm2m_list_t * head);
 
 #define LWM2M_MAX_ID   ((uint16_t)0xFFFF)
 
-#define LWM2M_URI_FLAG_OBJECT_ID    (uint8_t)0x04
-#define LWM2M_URI_FLAG_INSTANCE_ID  (uint8_t)0x02
-#define LWM2M_URI_FLAG_RESOURCE_ID  (uint8_t)0x01
-#define LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID  (uint8_t)0x08
-
-#define LWM2M_URI_IS_SET_OBJECT(uri) (((uri)->flag & LWM2M_URI_FLAG_OBJECT_ID) != 0)
-#define LWM2M_URI_IS_SET_INSTANCE(uri) (((uri)->flag & LWM2M_URI_FLAG_INSTANCE_ID) != 0)
-#define LWM2M_URI_IS_SET_RESOURCE(uri) (((uri)->flag & LWM2M_URI_FLAG_RESOURCE_ID) != 0)
-#define LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uri) (((uri)->flag & LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID) != 0)
+#define LWM2M_URI_IS_SET_OBJECT(uri) ((uri)->objectId != LWM2M_MAX_ID)
+#define LWM2M_URI_IS_SET_INSTANCE(uri) ((uri)->instanceId != LWM2M_MAX_ID)
+#define LWM2M_URI_IS_SET_RESOURCE(uri) ((uri)->resourceId != LWM2M_MAX_ID)
+#ifndef LWM2M_VERSION_1_0
+#define LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uri) ((uri)->resourceInstanceId != LWM2M_MAX_ID)
+#endif
 
 typedef struct
 {
-    uint8_t     flag;           // indicates which segments are set
     uint16_t    objectId;
     uint16_t    instanceId;
     uint16_t    resourceId;
@@ -281,6 +277,7 @@ typedef struct
 #endif
 } lwm2m_uri_t;
 
+#define LWM2M_URI_RESET(uri) memset((uri), 0xFF, sizeof(lwm2m_uri_t))
 
 #define LWM2M_STRING_ID_MAX_LEN 6
 

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -263,9 +263,12 @@ void lwm2m_list_free(lwm2m_list_t * head);
 #define LWM2M_URI_FLAG_OBJECT_ID    (uint8_t)0x04
 #define LWM2M_URI_FLAG_INSTANCE_ID  (uint8_t)0x02
 #define LWM2M_URI_FLAG_RESOURCE_ID  (uint8_t)0x01
+#define LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID  (uint8_t)0x08
 
+#define LWM2M_URI_IS_SET_OBJECT(uri) (((uri)->flag & LWM2M_URI_FLAG_OBJECT_ID) != 0)
 #define LWM2M_URI_IS_SET_INSTANCE(uri) (((uri)->flag & LWM2M_URI_FLAG_INSTANCE_ID) != 0)
 #define LWM2M_URI_IS_SET_RESOURCE(uri) (((uri)->flag & LWM2M_URI_FLAG_RESOURCE_ID) != 0)
+#define LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uri) (((uri)->flag & LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID) != 0)
 
 typedef struct
 {
@@ -273,6 +276,9 @@ typedef struct
     uint16_t    objectId;
     uint16_t    instanceId;
     uint16_t    resourceId;
+#ifndef LWM2M_VERSION_1_0
+    uint16_t    resourceInstanceId;
+#endif
 } lwm2m_uri_t;
 
 

--- a/core/management.c
+++ b/core/management.c
@@ -276,7 +276,7 @@ uint8_t dm_handleRequest(lwm2m_context_t * contextP,
                     //longest uri is /65535/65535 = 12 + 1 (null) chars
                     char location_path[13] = "";
                     //instanceId expected
-                    if ((uriP->flag & LWM2M_URI_FLAG_INSTANCE_ID) == 0)
+                    if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
                     {
                         result = COAP_500_INTERNAL_SERVER_ERROR;
                         break;
@@ -402,9 +402,17 @@ static void prv_resultCallback(lwm2m_context_t * contextP,
                 lwm2m_free(locationString);
                 return;
             }
+            if (!LWM2M_URI_IS_SET_OBJECT(&locationUri) ||
+                !LWM2M_URI_IS_SET_INSTANCE(&locationUri) ||
+                LWM2M_URI_IS_SET_RESOURCE(&locationUri) ||
+                locationUri.objectId != ((dm_data_t*)transacP->userData)->uri.objectId)
+            {
+                LOG("Error: invalid Location_path option in prv_resultCallback()");
+                lwm2m_free(locationString);
+                return;
+            }
 
-            ((dm_data_t*)transacP->userData)->uri.instanceId = locationUri.instanceId;
-            ((dm_data_t*)transacP->userData)->uri.flag = locationUri.flag;
+            memcpy(&((dm_data_t*)transacP->userData)->uri, &locationUri, sizeof(locationUri));
 
             lwm2m_free(locationString);
         }

--- a/core/objects.c
+++ b/core/objects.c
@@ -86,6 +86,11 @@ uint8_t object_checkReadable(lwm2m_context_t * contextP,
 
     dataP->id = uriP->resourceId;
 
+#ifndef LWM2M_VERSION_1_0
+    // TODO: support resource instance
+    if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP)) return COAP_400_BAD_REQUEST;
+#endif
+
     result = targetP->readFunc(uriP->instanceId, &size, &dataP, targetP);
     if (result == COAP_205_CONTENT)
     {
@@ -131,6 +136,11 @@ uint8_t object_readData(lwm2m_context_t * contextP,
             if (*dataP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
             (*dataP)->id = uriP->resourceId;
+
+#ifndef LWM2M_VERSION_1_0
+            // TODO: support resource instance
+            if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP)) return COAP_400_BAD_REQUEST;
+#endif
         }
 
         result = targetP->readFunc(uriP->instanceId, sizeP, dataP, targetP);
@@ -237,6 +247,10 @@ uint8_t object_write(lwm2m_context_t * contextP,
             result = COAP_406_NOT_ACCEPTABLE;
         }
     }
+#ifndef LWM2M_VERSION_1_0
+    // TODO: support resource instance
+    if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP)) result = COAP_400_BAD_REQUEST;
+#endif
     if (result == NO_ERROR)
     {
         result = targetP->writeFunc(uriP->instanceId, size, dataP, targetP);

--- a/core/objects.c
+++ b/core/objects.c
@@ -323,14 +323,12 @@ uint8_t object_create(lwm2m_context_t * contextP,
         }
         result = targetP->createFunc(dataP[0].id, dataP[0].value.asChildren.count, dataP[0].value.asChildren.array, targetP);
         uriP->instanceId = dataP[0].id;
-        uriP->flag |= LWM2M_URI_FLAG_INSTANCE_ID;
         break;
 
     default:
         if (!LWM2M_URI_IS_SET_INSTANCE(uriP))
         {
             uriP->instanceId = lwm2m_list_newId(targetP->instanceList);
-            uriP->flag |= LWM2M_URI_FLAG_INSTANCE_ID;
         }
         result = targetP->createFunc(uriP->instanceId, size, dataP, targetP);
         break;
@@ -368,19 +366,20 @@ uint8_t object_delete(lwm2m_context_t * contextP,
     else
     {
         lwm2m_list_t * instanceP;
+        lwm2m_uri_t tempUri;
 
+
+        memcpy(&tempUri, uriP, sizeof(tempUri));
         result = COAP_202_DELETED;
         instanceP = objectP->instanceList;
         while (NULL != instanceP
             && result == COAP_202_DELETED)
         {
-            uriP->instanceId = instanceP->id;
             result = objectP->deleteFunc(instanceP->id, objectP);
             if (result == COAP_202_DELETED)
             {
-                uriP->flag |= LWM2M_URI_FLAG_INSTANCE_ID;
-                observe_clear(contextP, uriP);
-                uriP->flag &= ~LWM2M_URI_FLAG_INSTANCE_ID;
+                tempUri.instanceId = instanceP->id;
+                observe_clear(contextP, &tempUri);
             }
             instanceP = objectP->instanceList;
         }

--- a/core/observe.c
+++ b/core/observe.c
@@ -60,8 +60,7 @@ static lwm2m_observed_t * prv_findObserved(lwm2m_context_t * contextP,
 
     targetP = contextP->observedList;
     while (targetP != NULL
-        && (targetP->uri.objectId != uriP->objectId
-         || targetP->uri.flag != uriP->flag
+        && ((LWM2M_URI_IS_SET_OBJECT(uriP) && targetP->uri.objectId != uriP->objectId)
          || (LWM2M_URI_IS_SET_INSTANCE(uriP) && targetP->uri.instanceId != uriP->instanceId)
          || (LWM2M_URI_IS_SET_RESOURCE(uriP) && targetP->uri.resourceId != uriP->resourceId)
 #ifndef LWM2M_VERSION_1_0
@@ -471,16 +470,16 @@ void lwm2m_resource_value_changed(lwm2m_context_t * contextP,
         if (targetP->uri.objectId == uriP->objectId)
         {
             if (!LWM2M_URI_IS_SET_INSTANCE(uriP)
-             || (targetP->uri.flag & LWM2M_URI_FLAG_INSTANCE_ID) == 0
+             || !LWM2M_URI_IS_SET_INSTANCE(&targetP->uri)
              || uriP->instanceId == targetP->uri.instanceId)
             {
                 if (!LWM2M_URI_IS_SET_RESOURCE(uriP)
-                 || (targetP->uri.flag & LWM2M_URI_FLAG_RESOURCE_ID) == 0
+                 || !LWM2M_URI_IS_SET_RESOURCE(&targetP->uri)
                  || uriP->resourceId == targetP->uri.resourceId)
                 {
 #ifndef LWM2M_VERSION_1_0
                     if (!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP)
-                     || (targetP->uri.flag & LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID) == 0
+                     || !LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&targetP->uri)
                      || uriP->resourceInstanceId == targetP->uri.resourceInstanceId)
 #endif
                     {
@@ -861,7 +860,6 @@ static lwm2m_observation_t * prv_findObservationByURI(lwm2m_client_t * clientP,
     while (targetP != NULL)
     {
         if (targetP->uri.objectId == uriP->objectId
-         && targetP->uri.flag == uriP->flag
          && targetP->uri.instanceId == uriP->instanceId
          && targetP->uri.resourceId == uriP->resourceId
 #ifndef LWM2M_VERSION_1_0

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -178,7 +178,7 @@ lwm2m_transaction_t * transaction_new(void * sessionH,
         // TODO: Support multi-segment alternative path
         coap_set_header_uri_path_segment(transacP->message, altPath + 1);
     }
-    if (NULL != uriP)
+    if (NULL != uriP && LWM2M_URI_IS_SET_OBJECT(uriP))
     {
         char stringID[LWM2M_STRING_ID_MAX_LEN];
 
@@ -193,20 +193,22 @@ lwm2m_transaction_t * transaction_new(void * sessionH,
             if (result == 0) goto error;
             stringID[result] = 0;
             coap_set_header_uri_path_segment(transacP->message, stringID);
-        }
-        else
-        {
             if (LWM2M_URI_IS_SET_RESOURCE(uriP))
             {
-                coap_set_header_uri_path_segment(transacP->message, NULL);
+                result = utils_intToText(uriP->resourceId, (uint8_t*)stringID, LWM2M_STRING_ID_MAX_LEN);
+                if (result == 0) goto error;
+                stringID[result] = 0;
+                coap_set_header_uri_path_segment(transacP->message, stringID);
+#ifndef LWM2M_VERSION_1_0
+                if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP))
+                {
+                    result = utils_intToText(uriP->resourceInstanceId, (uint8_t*)stringID, LWM2M_STRING_ID_MAX_LEN);
+                    if (result == 0) goto error;
+                    stringID[result] = 0;
+                    coap_set_header_uri_path_segment(transacP->message, stringID);
+                }
+#endif
             }
-        }
-        if (LWM2M_URI_IS_SET_RESOURCE(uriP))
-        {
-            result = utils_intToText(uriP->resourceId, (uint8_t*)stringID, LWM2M_STRING_ID_MAX_LEN);
-            if (result == 0) goto error;
-            stringID[result] = 0;
-            coap_set_header_uri_path_segment(transacP->message, stringID);
         }
     }
     if (0 < token_len)

--- a/examples/bootstrap_server/bootstrap_info.c
+++ b/examples/bootstrap_server/bootstrap_info.c
@@ -652,22 +652,14 @@ static bs_endpoint_info_t * prv_read_next_endpoint(FILE * fd)
             lwm2m_uri_t uri;
 
 
-            if (lwm2m_stringToUri(value, strlen(value), &uri) == 0)
-            {
-                if (value[0] == '/'
-                 && value[1] == 0)
-                {
-                    uri.flag = 0;
-                }
-                else goto error;
-            }
+            if (lwm2m_stringToUri(value, strlen(value), &uri) == 0) goto error;
 
             cmdP = (bs_command_t *)lwm2m_malloc(sizeof(bs_command_t));
             if (cmdP == NULL) goto error;
             memset(cmdP, 0, sizeof(bs_command_t));
 
             cmdP->operation = BS_DELETE;
-            if (uri.flag != 0)
+            if (LWM2M_URI_IS_SET_OBJECT(&uri))
             {
                 cmdP->uri = (lwm2m_uri_t *)lwm2m_malloc(sizeof(lwm2m_uri_t));
                 if (cmdP->uri == NULL) goto error;

--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -239,7 +239,7 @@ static void prv_send_command(internal_data_t * dataP,
             return;
         }
 
-        uri.flag = LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID;
+        LWM2M_URI_RESET(&uri);
         uri.objectId = LWM2M_SECURITY_OBJECT_ID;
         uri.instanceId = endP->cmdList->serverId;
 
@@ -264,7 +264,7 @@ static void prv_send_command(internal_data_t * dataP,
             return;
         }
 
-        uri.flag = LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID;
+        LWM2M_URI_RESET(&uri);
         uri.objectId = LWM2M_SERVER_OBJECT_ID;
         uri.instanceId = endP->cmdList->serverId;
 

--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -105,7 +105,13 @@ static void prv_print_uri(FILE * fd,
         {
             fprintf(fd, "/%d", uriP->instanceId);
             if (LWM2M_URI_IS_SET_RESOURCE(uriP))
+            {
                 fprintf(fd, "/%d", uriP->resourceId);
+#ifndef LWM2M_VERSION_1_0
+                if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP))
+                    fprintf(fd, "/%d", uriP->resourceInstanceId);
+#endif
+            }
         }
     }
 }

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -478,7 +478,7 @@ static void prv_object_dump(char * buffer,
 
     result = lwm2m_stringToUri(buffer, end - buffer, &uri);
     if (result == 0) goto syntax_error;
-    if (uri.flag & LWM2M_URI_FLAG_RESOURCE_ID) goto syntax_error;
+    if (LWM2M_URI_IS_SET_RESOURCE(&uri)) goto syntax_error;
 
     objectP = (lwm2m_object_t *)LWM2M_LIST_FIND(lwm2mH->objectList, uri.objectId);
     if (objectP == NULL)
@@ -487,7 +487,7 @@ static void prv_object_dump(char * buffer,
         return;
     }
 
-    if (uri.flag & LWM2M_URI_FLAG_INSTANCE_ID)
+    if (LWM2M_URI_IS_SET_INSTANCE(&uri))
     {
         prv_instance_dump(objectP, uri.instanceId);
     }

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -217,6 +217,22 @@ static int prv_read_id(char * buffer,
     return nb;
 }
 
+static void prv_printUri(const lwm2m_uri_t * uriP)
+{
+    fprintf(stdout, "/%d", uriP->objectId);
+    if (LWM2M_URI_IS_SET_INSTANCE(uriP))
+        fprintf(stdout, "/%d", uriP->instanceId);
+    else if (LWM2M_URI_IS_SET_RESOURCE(uriP))
+        fprintf(stdout, "/");
+    if (LWM2M_URI_IS_SET_RESOURCE(uriP))
+            fprintf(stdout, "/%d", uriP->resourceId);
+#ifndef LWM2M_VERSION_1_0
+    else if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP))
+        fprintf(stdout, "/");
+    if (LWM2M_URI_IS_SET_RESOURCE_INSTANCE(uriP))
+            fprintf(stdout, "/%d", uriP->resourceInstanceId);
+#endif
+}
 
 static void prv_result_callback(uint16_t clientID,
                                 lwm2m_uri_t * uriP,
@@ -226,13 +242,8 @@ static void prv_result_callback(uint16_t clientID,
                                 int dataLength,
                                 void * userData)
 {
-    fprintf(stdout, "\r\nClient #%d /%d", clientID, uriP->objectId);
-    if (LWM2M_URI_IS_SET_INSTANCE(uriP))
-        fprintf(stdout, "/%d", uriP->instanceId);
-    else if (LWM2M_URI_IS_SET_RESOURCE(uriP))
-        fprintf(stdout, "/");
-    if (LWM2M_URI_IS_SET_RESOURCE(uriP))
-            fprintf(stdout, "/%d", uriP->resourceId);
+    fprintf(stdout, "\r\nClient #%d ", clientID);
+    prv_printUri(uriP);
     fprintf(stdout, " : ");
     print_status(stdout, status);
     fprintf(stdout, "\r\n");
@@ -251,13 +262,8 @@ static void prv_notify_callback(uint16_t clientID,
                                 int dataLength,
                                 void * userData)
 {
-    fprintf(stdout, "\r\nNotify from client #%d /%d", clientID, uriP->objectId);
-    if (LWM2M_URI_IS_SET_INSTANCE(uriP))
-        fprintf(stdout, "/%d", uriP->instanceId);
-    else if (LWM2M_URI_IS_SET_RESOURCE(uriP))
-        fprintf(stdout, "/");
-    if (LWM2M_URI_IS_SET_RESOURCE(uriP))
-            fprintf(stdout, "/%d", uriP->resourceId);
+    fprintf(stdout, "\r\nNotify from client #%d ", clientID);
+    prv_printUri(uriP);
     fprintf(stdout, " number %d\r\n", count);
 
     output_data(stdout, format, data, dataLength, 1);

--- a/tests/uritests.c
+++ b/tests/uritests.c
@@ -23,7 +23,8 @@
 
 static void test_uri_decode(void)
 {
-    lwm2m_uri_t* uri;
+    lwm2m_uri_t uri;
+    lwm2m_request_type_t requestType;
     multi_option_t extraID = { .next = NULL, .is_static = 1, .len = 3, .data = (uint8_t *) "555" };
 #ifndef LWM2M_VERSION_1_0
     multi_option_t riID = { .next = NULL, .is_static = 1, .len = 2, .data = (uint8_t *) "12" };
@@ -43,84 +44,107 @@ static void test_uri_decode(void)
 #endif
 
     /* "/rd" */
-    uri = uri_decode(NULL, &reg);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_REGISTRATION);
-    lwm2m_free(uri);
+    requestType = uri_decode(NULL, &reg, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_REGISTRATION);
+    CU_ASSERT(!LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+#endif
 
     /* "/rd/5a3f" */
     reg.next = &location;
-    uri = uri_decode(NULL, &reg);
+    requestType = uri_decode(NULL, &reg, &uri);
     /* should not fail, error in uri_parse */
-    /* CU_ASSERT_PTR_NOT_NULL(uri); */
-    lwm2m_free(uri);
+    /* CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_REGISTRATION); */
 
     /* "/rd/5312" */
     reg.next = &locationDecimal;
-    uri = uri_decode(NULL, &reg);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_REGISTRATION | LWM2M_URI_FLAG_OBJECT_ID);
-    CU_ASSERT_EQUAL(uri->objectId, 5312);
-    lwm2m_free(uri);
+    requestType = uri_decode(NULL, &reg, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_REGISTRATION);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+#endif
+    CU_ASSERT_EQUAL(uri.objectId, 5312);
 
     /* "/bs" */
-    uri = uri_decode(NULL, &boot);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_BOOTSTRAP);
-    lwm2m_free(uri);
+    requestType = uri_decode(NULL, &boot, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_BOOTSTRAP);
+    CU_ASSERT(!LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+#endif
 
     /* "/bs/5a3f" */
     boot.next = &location;
-    uri = uri_decode(NULL, &boot);
-    CU_ASSERT_PTR_NULL(uri);
-    lwm2m_free(uri);
-
-    /* "/9050/11/0" */
-    uri = uri_decode(NULL, &oID);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
-#ifdef LWM2M_VERSION_1_0
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID | LWM2M_URI_FLAG_RESOURCE_ID);
-#else
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID | LWM2M_URI_FLAG_RESOURCE_ID | LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID);
-    CU_ASSERT_EQUAL(uri->resourceInstanceId, 12);
+    requestType = uri_decode(NULL, &boot, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_UNKNOWN);
+    CU_ASSERT(!LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
 #endif
-    CU_ASSERT_EQUAL(uri->objectId, 9050);
-    CU_ASSERT_EQUAL(uri->instanceId, 11);
-    CU_ASSERT_EQUAL(uri->resourceId, 0);
-    lwm2m_free(uri);
 
-    /* "/11/0" */
-    uri = uri_decode(NULL, &iID);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
-#ifdef LWM2M_VERSION_1_0
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID);
-#else
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID | LWM2M_URI_FLAG_RESOURCE_ID);
-    CU_ASSERT_EQUAL(uri->resourceId, 12);
+    /* "/9050/11/0" or "/9050/11/0/12" */
+    requestType = uri_decode(NULL, &oID, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_DM);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE(&uri));
+    CU_ASSERT_EQUAL(uri.objectId, 9050);
+    CU_ASSERT_EQUAL(uri.instanceId, 11);
+    CU_ASSERT_EQUAL(uri.resourceId, 0);
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+    CU_ASSERT_EQUAL(uri.resourceInstanceId, 12);
 #endif
-    CU_ASSERT_EQUAL(uri->objectId, 11);
-    CU_ASSERT_EQUAL(uri->instanceId, 0);
-    lwm2m_free(uri);
 
-    /* "/0" */
-    uri = uri_decode(NULL, &rID);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
+    /* "/11/0" or "/11/0/12"*/
+    requestType = uri_decode(NULL, &iID, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_DM);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT_EQUAL(uri.objectId, 11);
+    CU_ASSERT_EQUAL(uri.instanceId, 0);
 #ifdef LWM2M_VERSION_1_0
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
 #else
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID | LWM2M_URI_FLAG_INSTANCE_ID);
-    CU_ASSERT_EQUAL(uri->instanceId, 12);
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+    CU_ASSERT_EQUAL(uri.resourceId, 12);
 #endif
-    CU_ASSERT_EQUAL(uri->objectId, 0);
-    lwm2m_free(uri);
+
+    /* "/0" or "/0/12" */
+    requestType = uri_decode(NULL, &rID, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_DM);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT_EQUAL(uri.objectId, 0);
+#ifdef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#else
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+    CU_ASSERT_EQUAL(uri.instanceId, 12);
+#endif
 
 #ifndef LWM2M_VERSION_1_0
     /* "/12" */
-    uri = uri_decode(NULL, &riID);
-    CU_ASSERT_PTR_NOT_NULL_FATAL(uri);
-    CU_ASSERT_EQUAL(uri->flag, LWM2M_URI_FLAG_DM | LWM2M_URI_FLAG_OBJECT_ID);
-    CU_ASSERT_EQUAL(uri->objectId, 12);
-    lwm2m_free(uri);
+    requestType = uri_decode(NULL, &riID, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_DM);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT_EQUAL(uri.objectId, 12);
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
 #endif
 
     /* "/9050/11/0/555" */
@@ -129,15 +153,25 @@ static void test_uri_decode(void)
 #else
     riID.next = &extraID;
 #endif
-    uri = uri_decode(NULL, &oID);
-    CU_ASSERT_PTR_NULL(uri);
-    lwm2m_free(uri);
+    requestType = uri_decode(NULL, &oID, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_UNKNOWN);
+    CU_ASSERT(!LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+#endif
 
     /* "/0/5a3f" */
     rID.next = &location;
-    uri = uri_decode(NULL, &rID);
-    CU_ASSERT_PTR_NULL(uri);
-    lwm2m_free(uri);
+    requestType = uri_decode(NULL, &rID, &uri);
+    CU_ASSERT_EQUAL(requestType, LWM2M_REQUEST_TYPE_UNKNOWN);
+    CU_ASSERT(!LWM2M_URI_IS_SET_OBJECT(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+#endif
 
     MEMORY_TRACE_AFTER_EQ;
 }
@@ -154,41 +188,47 @@ static void test_string_to_uri(void)
     CU_ASSERT_EQUAL(result, 0);
     result = lwm2m_stringToUri("/1", 2, &uri);
     CU_ASSERT_EQUAL(result, 2);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_OBJECT_ID), LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
     CU_ASSERT_EQUAL(uri.objectId, 1);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_INSTANCE_ID), 0);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_ID), 0);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID), 0);
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+#endif
 
     result = lwm2m_stringToUri("/1/2", 4, &uri);
     CU_ASSERT_EQUAL(result, 4);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_OBJECT_ID), LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
     CU_ASSERT_EQUAL(uri.objectId, 1);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_INSTANCE_ID), LWM2M_URI_FLAG_INSTANCE_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri));
     CU_ASSERT_EQUAL(uri.instanceId, 2);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_ID), 0);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID), 0);
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+#endif
 
     result = lwm2m_stringToUri("/1/2/3", 6, &uri);
     CU_ASSERT_EQUAL(result, 6);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_OBJECT_ID), LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
     CU_ASSERT_EQUAL(uri.objectId, 1);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_INSTANCE_ID), LWM2M_URI_FLAG_INSTANCE_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri));
     CU_ASSERT_EQUAL(uri.instanceId, 2);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_ID), LWM2M_URI_FLAG_RESOURCE_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE(&uri));
     CU_ASSERT_EQUAL(uri.resourceId, 3);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID), 0);
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
+#endif
 
     result = lwm2m_stringToUri("/1/2/3/4", 8, &uri);
 #ifndef LWM2M_VERSION_1_0
     CU_ASSERT_EQUAL(result, 8);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_OBJECT_ID), LWM2M_URI_FLAG_OBJECT_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri));
     CU_ASSERT_EQUAL(uri.objectId, 1);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_INSTANCE_ID), LWM2M_URI_FLAG_INSTANCE_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri));
     CU_ASSERT_EQUAL(uri.instanceId, 2);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_ID), LWM2M_URI_FLAG_RESOURCE_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE(&uri));
     CU_ASSERT_EQUAL(uri.resourceId, 3);
-    CU_ASSERT_EQUAL((uri.flag & LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID), LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID);
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri));
     CU_ASSERT_EQUAL(uri.resourceInstanceId, 4);
 
     result = lwm2m_stringToUri("/1/2/3/4/5", 10, &uri);
@@ -208,72 +248,87 @@ static void test_uri_to_string(void)
 
     MEMORY_TRACE_BEFORE;
 
-    uri.objectId = 1;
-    uri.instanceId = 2;
-    uri.resourceId = 3;
-#ifndef LWM2M_VERSION_1_0
-    uri.resourceInstanceId = 4;
-#endif
-
     result = uri_toString(NULL, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 0);
     CU_ASSERT_EQUAL(depth, URI_DEPTH_NONE);
     CU_ASSERT_EQUAL(lwm2m_stringToUri(buffer, result, &uri2), result);
 
-    uri.flag = 0;
+    LWM2M_URI_RESET(&uri);
     result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 1);
     CU_ASSERT_EQUAL(depth, URI_DEPTH_NONE);
     CU_ASSERT_NSTRING_EQUAL(buffer, "/", result);
     CU_ASSERT_EQUAL(lwm2m_stringToUri(buffer, result, &uri2), result);
-    CU_ASSERT_EQUAL(uri2.flag, uri.flag);
+    CU_ASSERT(!LWM2M_URI_IS_SET_OBJECT(&uri2));
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri2));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri2));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri2));
+#endif
 
-    uri.flag |= LWM2M_URI_FLAG_OBJECT_ID;
+    uri.objectId = 1;
     result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 2);
     CU_ASSERT_EQUAL(depth, URI_DEPTH_OBJECT);
     CU_ASSERT_NSTRING_EQUAL(buffer, "/1", result);
     CU_ASSERT_EQUAL(lwm2m_stringToUri(buffer, result, &uri2), result);
-    CU_ASSERT_EQUAL(uri2.flag, uri.flag);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri2));
+    CU_ASSERT(!LWM2M_URI_IS_SET_INSTANCE(&uri2));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri2));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri2));
+#endif
     CU_ASSERT_EQUAL(uri2.objectId, uri.objectId);
 
-    uri.flag |= LWM2M_URI_FLAG_INSTANCE_ID;
+    uri.instanceId = 2;
     result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 4);
     CU_ASSERT_EQUAL(depth, URI_DEPTH_OBJECT_INSTANCE);
     CU_ASSERT_NSTRING_EQUAL(buffer, "/1/2", result);
     CU_ASSERT_EQUAL(lwm2m_stringToUri(buffer, result, &uri2), result);
-    CU_ASSERT_EQUAL(uri2.flag, uri.flag);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri2));
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri2));
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE(&uri2));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri2));
+#endif
     CU_ASSERT_EQUAL(uri2.objectId, uri.objectId);
     CU_ASSERT_EQUAL(uri2.instanceId, uri.instanceId);
 
-    uri.flag |= LWM2M_URI_FLAG_RESOURCE_ID;
+    uri.resourceId = 3;
     result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 6);
     CU_ASSERT_EQUAL(depth, URI_DEPTH_RESOURCE);
     CU_ASSERT_NSTRING_EQUAL(buffer, "/1/2/3", result);
     CU_ASSERT_EQUAL(lwm2m_stringToUri(buffer, result, &uri2), result);
-    CU_ASSERT_EQUAL(uri2.flag, uri.flag);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri2));
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri2));
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE(&uri2));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(!LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri2));
+#endif
     CU_ASSERT_EQUAL(uri2.objectId, uri.objectId);
     CU_ASSERT_EQUAL(uri2.instanceId, uri.instanceId);
     CU_ASSERT_EQUAL(uri2.resourceId, uri.resourceId);
 
 #ifndef LWM2M_VERSION_1_0
-    uri.flag |= LWM2M_URI_FLAG_RESOURCE_INSTANCE_ID;
+    uri.resourceInstanceId = 4;
     result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(depth, URI_DEPTH_RESOURCE_INSTANCE);
     CU_ASSERT_EQUAL(result, 8);
     CU_ASSERT_NSTRING_EQUAL(buffer, "/1/2/3/4", result);
     CU_ASSERT_EQUAL(lwm2m_stringToUri(buffer, result, &uri2), result);
-    CU_ASSERT_EQUAL(uri2.flag, uri.flag);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri2));
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri2));
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE(&uri2));
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri2));
     CU_ASSERT_EQUAL(uri2.objectId, uri.objectId);
     CU_ASSERT_EQUAL(uri2.instanceId, uri.instanceId);
     CU_ASSERT_EQUAL(uri2.resourceId, uri.resourceId);
     CU_ASSERT_EQUAL(uri2.resourceInstanceId, uri.resourceInstanceId);
 #endif
 
-    memset(&uri, 0xFF, sizeof(uri));
-    uri.flag = LWM2M_URI_MASK_ID;
+    LWM2M_URI_RESET(&uri);
     uri.objectId = LWM2M_MAX_ID - 1;
     uri.instanceId = LWM2M_MAX_ID - 1;
     uri.resourceId = LWM2M_MAX_ID - 1;
@@ -292,7 +347,12 @@ static void test_uri_to_string(void)
     CU_ASSERT_NSTRING_EQUAL(buffer, "/65534/65534/65534/65534", result);
 #endif
     CU_ASSERT_EQUAL(lwm2m_stringToUri(buffer, result, &uri2), result);
-    CU_ASSERT_EQUAL(uri2.flag, uri.flag);
+    CU_ASSERT(LWM2M_URI_IS_SET_OBJECT(&uri2));
+    CU_ASSERT(LWM2M_URI_IS_SET_INSTANCE(&uri2));
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE(&uri2));
+#ifndef LWM2M_VERSION_1_0
+    CU_ASSERT(LWM2M_URI_IS_SET_RESOURCE_INSTANCE(&uri2));
+#endif
     CU_ASSERT_EQUAL(uri2.objectId, uri.objectId);
     CU_ASSERT_EQUAL(uri2.instanceId, uri.instanceId);
     CU_ASSERT_EQUAL(uri2.resourceId, uri.resourceId);


### PR DESCRIPTION
Expand lwm2m_uri_t to have resourceInstanceId. This will be needed for many of the commands in the LWM2M 1.1 Device Managenent and Service Enablement Interface and Information Reporting Interface.

Also makes uri_toString and lwm2m_stringToUri proper inverses.