### PR TITLE
Improve floating point conversions.

### DIFF
--- a/core/data.c
+++ b/core/data.c
@@ -72,7 +72,7 @@ static int prv_textSerialize(lwm2m_data_t * dataP,
     {
         uint8_t floatString[_PRV_STR_LENGTH * 2];
 
-        res = utils_floatToText(dataP->value.asFloat, floatString, _PRV_STR_LENGTH * 2);
+        res = utils_floatToText(dataP->value.asFloat, floatString, _PRV_STR_LENGTH * 2, false);
         if (res == 0) return -1;
 
         *bufferP = (uint8_t *)lwm2m_malloc(res);
@@ -477,7 +477,7 @@ int lwm2m_data_decode_float(const lwm2m_data_t * dataP,
         break;
 
     case LWM2M_TYPE_STRING:
-        result = utils_textToFloat(dataP->value.asBuffer.buffer, dataP->value.asBuffer.length, valueP);
+        result = utils_textToFloat(dataP->value.asBuffer.buffer, dataP->value.asBuffer.length, valueP, false);
         break;
 
     case LWM2M_TYPE_OPAQUE:

--- a/core/discover.c
+++ b/core/discover.c
@@ -123,7 +123,7 @@ static int prv_serializeAttributes(lwm2m_context_t * contextP,
             PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
             PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_GREATER_THAN_STR, ATTR_GREATER_THAN_LEN);
 
-            res = utils_floatToText(paramP->greaterThan, buffer + head, bufferLen - head);
+            res = utils_floatToText(paramP->greaterThan, buffer + head, bufferLen - head, false);
             if (res <= 0) return -1;
             head += res;
         }
@@ -132,7 +132,7 @@ static int prv_serializeAttributes(lwm2m_context_t * contextP,
             PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
             PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_LESS_THAN_STR, ATTR_LESS_THAN_LEN);
 
-            res = utils_floatToText(paramP->lessThan, buffer + head, bufferLen - head);
+            res = utils_floatToText(paramP->lessThan, buffer + head, bufferLen - head, false);
             if (res <= 0) return -1;
             head += res;
         }
@@ -141,7 +141,7 @@ static int prv_serializeAttributes(lwm2m_context_t * contextP,
             PRV_CONCAT_STR(buffer, bufferLen, head, LINK_ATTR_SEPARATOR, LINK_ATTR_SEPARATOR_SIZE);
             PRV_CONCAT_STR(buffer, bufferLen, head, ATTR_STEP_STR, ATTR_STEP_LEN);
 
-            res = utils_floatToText(paramP->step, buffer + head, bufferLen - head);
+            res = utils_floatToText(paramP->step, buffer + head, bufferLen - head, false);
             if (res <= 0) return -1;
             head += res;
         }

--- a/core/internals.h
+++ b/core/internals.h
@@ -383,14 +383,14 @@ int utils_isAltPathValid(const char * altPath);
 int utils_stringCopy(char * buffer, size_t length, const char * str);
 size_t utils_intToText(int64_t data, uint8_t * string, size_t length);
 size_t utils_uintToText(uint64_t data, uint8_t * string, size_t length);
-size_t utils_floatToText(double data, uint8_t * string, size_t length);
+size_t utils_floatToText(double data, uint8_t * string, size_t length, bool allowExponential);
 size_t utils_objLinkToText(uint16_t objectId,
                            uint16_t objectInstanceId,
                            uint8_t * string,
                            size_t length);
 int utils_textToInt(const uint8_t * buffer, int length, int64_t * dataP);
 int utils_textToUInt(const uint8_t * buffer, int length, uint64_t * dataP);
-int utils_textToFloat(const uint8_t * buffer, int length, double * dataP);
+int utils_textToFloat(const uint8_t * buffer, int length, double * dataP, bool allowExponential);
 int utils_textToObjLink(const uint8_t * buffer,
                         int length,
                         uint16_t * objectId,

--- a/core/json.c
+++ b/core/json.c
@@ -18,6 +18,7 @@
 
 
 #include "internals.h"
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -758,8 +759,8 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
                               uint8_t * buffer,
                               size_t bufferLen)
 {
-    int res;
-    int head;
+    size_t res;
+    size_t head;
 
     switch (tlvP->type)
     {
@@ -793,7 +794,7 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
         head = JSON_ITEM_NUM_SIZE;
 
         res = utils_intToText(value, buffer + head, bufferLen - head);
-        if (res <= 0) return -1;
+        if (!res) return -1;
         head += res;
 
         if (bufferLen - head < JSON_ITEM_NUM_END_SIZE) return -1;
@@ -813,7 +814,7 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
         head = JSON_ITEM_NUM_SIZE;
 
         res = utils_uintToText(value, buffer + head, bufferLen - head);
-        if (res <= 0) return -1;
+        if (!res) return -1;
         head += res;
 
         if (bufferLen - head < JSON_ITEM_NUM_END_SIZE) return -1;
@@ -832,8 +833,11 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
         memcpy(buffer, JSON_ITEM_NUM, JSON_ITEM_NUM_SIZE);
         head = JSON_ITEM_NUM_SIZE;
 
-        res = utils_floatToText(value, buffer + head, bufferLen - head);
-        if (res <= 0) return -1;
+        res = utils_floatToText(value, buffer + head, bufferLen - head, true);
+        if (!res) return -1;
+        /* Error if inf or nan */
+        if (buffer[head] != '-' && !isdigit(buffer[head])) return -1;
+        if (res > 1 && buffer[head] == '-' && !isdigit(buffer[head+1])) return -1;
         head += res;
 
         if (bufferLen - head < JSON_ITEM_NUM_END_SIZE) return -1;
@@ -886,7 +890,7 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
                                   tlvP->value.asObjLink.objectInstanceId,
                                   buffer + head,
                                   bufferLen - head);
-        if (res <= 0) return -1;
+        if (!res) return -1;
         head += res;
 
         if (bufferLen - head < JSON_ITEM_OBJECT_LINK_END_SIZE) return -1;
@@ -898,7 +902,7 @@ static int prv_serializeValue(lwm2m_data_t * tlvP,
         return -1;
     }
 
-    return head;
+    return (int)head;
 }
 
 static int prv_serializeData(lwm2m_data_t * tlvP,

--- a/core/json_common.c
+++ b/core/json_common.c
@@ -18,6 +18,7 @@
 
 
 #include "internals.h"
+#include <float.h>
 
 #if defined(LWM2M_SUPPORT_JSON) || defined(LWM2M_SUPPORT_SENML_JSON)
 
@@ -320,7 +321,7 @@ int json_convertNumeric(const uint8_t *value,
     {
         double val;
 
-        result = utils_textToFloat(value, valueLen, &val);
+        result = utils_textToFloat(value, valueLen, &val, true);
         if (result)
         {
             lwm2m_data_encode_float(val, targetP);

--- a/core/management.c
+++ b/core/management.c
@@ -104,7 +104,7 @@ static int prv_readAttributes(multi_option_t * query,
             if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_GREATER_THAN)) return -1;
             if (query->len == ATTR_GREATER_THAN_LEN) return -1;
 
-            if (1 != utils_textToFloat(query->data + ATTR_GREATER_THAN_LEN, query->len - ATTR_GREATER_THAN_LEN, &floatValue)) return -1;
+            if (1 != utils_textToFloat(query->data + ATTR_GREATER_THAN_LEN, query->len - ATTR_GREATER_THAN_LEN, &floatValue, false)) return -1;
 
             attrP->toSet |= LWM2M_ATTR_FLAG_GREATER_THAN;
             attrP->greaterThan = floatValue;
@@ -121,7 +121,7 @@ static int prv_readAttributes(multi_option_t * query,
             if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_LESS_THAN)) return -1;
             if (query->len == ATTR_LESS_THAN_LEN) return -1;
 
-            if (1 != utils_textToFloat(query->data + ATTR_LESS_THAN_LEN, query->len - ATTR_LESS_THAN_LEN, &floatValue)) return -1;
+            if (1 != utils_textToFloat(query->data + ATTR_LESS_THAN_LEN, query->len - ATTR_LESS_THAN_LEN, &floatValue, false)) return -1;
 
             attrP->toSet |= LWM2M_ATTR_FLAG_LESS_THAN;
             attrP->lessThan = floatValue;
@@ -138,7 +138,7 @@ static int prv_readAttributes(multi_option_t * query,
             if (0 != ((attrP->toSet | attrP->toClear) & LWM2M_ATTR_FLAG_STEP)) return -1;
             if (query->len == ATTR_STEP_LEN) return -1;
 
-            if (1 != utils_textToFloat(query->data + ATTR_STEP_LEN, query->len - ATTR_STEP_LEN, &floatValue)) return -1;
+            if (1 != utils_textToFloat(query->data + ATTR_STEP_LEN, query->len - ATTR_STEP_LEN, &floatValue, false)) return -1;
             if (floatValue < 0) return -1;
 
             attrP->toSet |= LWM2M_ATTR_FLAG_STEP;
@@ -678,7 +678,7 @@ int lwm2m_dm_write_attributes(lwm2m_context_t * contextP,
     if (attrP->toSet & LWM2M_ATTR_FLAG_GREATER_THAN)
     {
         memcpy(buffer, ATTR_GREATER_THAN_STR, ATTR_GREATER_THAN_LEN);
-        length = utils_floatToText(attrP->greaterThan, buffer + ATTR_GREATER_THAN_LEN, _PRV_BUFFER_SIZE - ATTR_GREATER_THAN_LEN);
+        length = utils_floatToText(attrP->greaterThan, buffer + ATTR_GREATER_THAN_LEN, _PRV_BUFFER_SIZE - ATTR_GREATER_THAN_LEN, false);
         if (length == 0)
         {
             transaction_free(transaction);
@@ -690,7 +690,7 @@ int lwm2m_dm_write_attributes(lwm2m_context_t * contextP,
     if (attrP->toSet & LWM2M_ATTR_FLAG_LESS_THAN)
     {
         memcpy(buffer, ATTR_LESS_THAN_STR, ATTR_LESS_THAN_LEN);
-        length = utils_floatToText(attrP->lessThan, buffer + ATTR_LESS_THAN_LEN, _PRV_BUFFER_SIZE - ATTR_LESS_THAN_LEN);
+        length = utils_floatToText(attrP->lessThan, buffer + ATTR_LESS_THAN_LEN, _PRV_BUFFER_SIZE - ATTR_LESS_THAN_LEN, false);
         if (length == 0)
         {
             transaction_free(transaction);
@@ -702,7 +702,7 @@ int lwm2m_dm_write_attributes(lwm2m_context_t * contextP,
     if (attrP->toSet & LWM2M_ATTR_FLAG_STEP)
     {
         memcpy(buffer, ATTR_STEP_STR, ATTR_STEP_LEN);
-        length = utils_floatToText(attrP->step, buffer + ATTR_STEP_LEN, _PRV_BUFFER_SIZE - ATTR_STEP_LEN);
+        length = utils_floatToText(attrP->step, buffer + ATTR_STEP_LEN, _PRV_BUFFER_SIZE - ATTR_STEP_LEN, false);
         if (length == 0)
         {
             transaction_free(transaction);

--- a/core/senml_json.c
+++ b/core/senml_json.c
@@ -18,6 +18,7 @@
 
 
 #include "internals.h"
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -855,8 +856,11 @@ static int prv_serializeValue(const lwm2m_data_t * tlvP,
         memcpy(buffer, JSON_ITEM_NUM, JSON_ITEM_NUM_SIZE);
         head = JSON_ITEM_NUM_SIZE;
 
-        res = utils_floatToText(value, buffer + head, bufferLen - head);
+        res = utils_floatToText(value, buffer + head, bufferLen - head, true);
         if (!res) return -1;
+        /* Error if inf or nan */
+        if (buffer[head] != '-' && !isdigit(buffer[head])) return -1;
+        if (res > 1 && buffer[head] == '-' && !isdigit(buffer[head+1])) return -1;
         head += res;
     }
     break;

--- a/tests/convert_numbers_test.c
+++ b/tests/convert_numbers_test.c
@@ -28,12 +28,13 @@
 #include <inttypes.h>
 #include <float.h>
 
-int64_t ints[]={12, -114 , 1 , 134 , 43243 , 0, -215025, INT64_MIN, INT64_MAX};
-const char* ints_text[] = {"12","-114","1", "134", "43243","0","-215025", "-9223372036854775808", "9223372036854775807"};
-uint64_t uints[]={12, 1 , 134 , 43243 , 0, UINT64_MAX};
-const char* uints_text[] = {"12","1", "134", "43243","0","18446744073709551615"};
-double floats[]={12, -114 , -30 , 1.02 , 134.000235 , 0.43243 , 0, -21.5025, -0.0925, 0.98765, 6.667e-11, FLT_MIN, FLT_MAX, DBL_MIN, DBL_MAX};
-const char* floats_text[] = {"12.0","-114.0","-30.0", "1.02", "134.000235","0.43243","0.0","-21.5025","-0.0925","0.98765", "0.00000000006667", "0.00000000000000000000000000000000000001175494", "340282346638528859811704183484516925440.0", "0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002225073858", "179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.0"};
+static const int64_t ints[]={12, -114 , 1 , 134 , 43243 , 0, -215025, INT64_MIN, INT64_MAX};
+static const char* ints_text[] = {"12","-114","1", "134", "43243","0","-215025", "-9223372036854775808", "9223372036854775807"};
+static const uint64_t uints[]={12, 1 , 134 , 43243 , 0, UINT64_MAX};
+static const char* uints_text[] = {"12","1", "134", "43243","0","18446744073709551615"};
+static const double floats[]={12, -114 , -30 , 1.02 , 134.000235 , 0.43243 , 0, -21.5025, -0.0925, 0.98765, 6.667e-11, 56.789, -52.0006, FLT_MIN, FLT_MAX, DBL_MIN, DBL_MAX};
+static const char* floats_text[] = {"12.0","-114.0","-30.0", "1.02", "134.000235","0.43243","0.0","-21.5025","-0.0925","0.98765", "0.00000000006667", "56.789", "-52.0006", "0.00000000000000000000000000000000000001175494", "340282346638528859811704183484516925440.0", "0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002225073858", "179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.0"};
+static const char* floats_exponential[] = {"12.0","-114.0","-30.0", "1.02", "134.000235","0.43243","0.0","-21.5025","-0.0925","0.98765", "6.667e-11", "56.789", "-52.0006", "1.17549435082229e-38", "3.40282346638529e38", "2.2250738585072e-308", "1.7976931348623e308"};
 
 static void test_utils_textToInt(void)
 {
@@ -44,7 +45,7 @@ static void test_utils_textToInt(void)
         int64_t res;
         int converted;
 
-        converted = utils_textToInt((uint8_t*)ints_text[i], strlen(ints_text[i]), &res);
+        converted = utils_textToInt((const uint8_t*)ints_text[i], strlen(ints_text[i]), &res);
 
         CU_ASSERT(converted);
         if (converted)
@@ -69,7 +70,7 @@ static void test_utils_textToUInt(void)
         uint64_t res;
         int converted;
 
-        converted = utils_textToUInt((uint8_t*)uints_text[i], strlen(uints_text[i]), &res);
+        converted = utils_textToUInt((const uint8_t*)uints_text[i], strlen(uints_text[i]), &res);
 
         CU_ASSERT(converted);
         if (converted)
@@ -94,7 +95,7 @@ static void test_utils_textToFloat(void)
         double res;
         int converted;
 
-        converted = utils_textToFloat((uint8_t*)floats_text[i], strlen(floats_text[i]), &res);
+        converted = utils_textToFloat((const uint8_t*)floats_text[i], strlen(floats_text[i]), &res, false);
 
         CU_ASSERT(converted);
         if (converted)
@@ -110,26 +111,55 @@ static void test_utils_textToFloat(void)
     }
 }
 
+static void test_utils_textToFloatExponential(void)
+{
+    size_t i;
+
+    for (i = 0 ; i < sizeof(floats)/sizeof(floats[0]) ; i++)
+    {
+        double res;
+        int converted;
+
+        converted = utils_textToFloat((const uint8_t*)floats_exponential[i], strlen(floats_exponential[i]), &res, true);
+
+        CU_ASSERT(converted);
+        if (converted)
+        {
+            /* Using a granularity of the value divided by 1000000 allows
+             * checking the first 6 significant digits. Some of the values in
+             * floats_exponential don't have enough significant digits to pass
+             * if checked to greater precision. */
+            CU_ASSERT_DOUBLE_EQUAL(res, floats[i], floats[i]/1000000.0);
+            if(fabs(res - floats[i]) > fabs(floats[i]/1000000.0))
+                printf("%zu \"%s\" -> fail (%f)\n", i, floats_exponential[i], res);
+        }
+        else
+        {
+            printf("%zu \"%s\" -> fail\n", i, floats_exponential[i]);
+        }
+    }
+}
+
 static void test_utils_textToObjLink(void)
 {
     uint16_t objectId;
     uint16_t objectInstanceId;
     CU_ASSERT_EQUAL(utils_textToObjLink(NULL, 0, &objectId, &objectInstanceId), 0);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)"", 0, &objectId, &objectInstanceId), 0);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)":", 1, &objectId, &objectInstanceId), 0);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)"0:", 2, &objectId, &objectInstanceId), 0);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)":0", 2, &objectId, &objectInstanceId), 0);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)"0:0", 3, &objectId, &objectInstanceId), 1);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)"", 0, &objectId, &objectInstanceId), 0);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)":", 1, &objectId, &objectInstanceId), 0);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)"0:", 2, &objectId, &objectInstanceId), 0);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)":0", 2, &objectId, &objectInstanceId), 0);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)"0:0", 3, &objectId, &objectInstanceId), 1);
     CU_ASSERT_EQUAL(objectId, 0);
     CU_ASSERT_EQUAL(objectInstanceId, 0);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)"1:2", 3, &objectId, &objectInstanceId), 1);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)"1:2", 3, &objectId, &objectInstanceId), 1);
     CU_ASSERT_EQUAL(objectId, 1);
     CU_ASSERT_EQUAL(objectInstanceId, 2);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)"65535:65535", 11, &objectId, &objectInstanceId), 1);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)"65535:65535", 11, &objectId, &objectInstanceId), 1);
     CU_ASSERT_EQUAL(objectId, 65535);
     CU_ASSERT_EQUAL(objectInstanceId, 65535);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)"65536:65535", 11, &objectId, &objectInstanceId), 0);
-    CU_ASSERT_EQUAL(utils_textToObjLink((uint8_t*)"65535:65536", 11, &objectId, &objectInstanceId), 0);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)"65536:65535", 11, &objectId, &objectInstanceId), 0);
+    CU_ASSERT_EQUAL(utils_textToObjLink((const uint8_t*)"65535:65536", 11, &objectId, &objectInstanceId), 0);
 }
 
 static void test_utils_intToText(void)
@@ -181,18 +211,23 @@ static void test_utils_floatToText(void)
 
     for (i = 0 ; i < sizeof(floats)/sizeof(floats[0]); i++)
     {
-        len = utils_floatToText(floats[i], (uint8_t*)res, sizeof(res));
+        len = utils_floatToText(floats[i], (uint8_t*)res, sizeof(res), false);
 
         CU_ASSERT(len);
         if (len)
         {
             compareLen = (int)strlen(floats_text[i]);
-            if (compareLen > DBL_DIG
+            /* Limit the comparison length of very large numbers to the maximum
+             * number of significant digits in a double, excluding the last to
+             * allow difference in rounding. The decimal point must be in the
+             * same place in both the converted number and the one being
+             * compared. */
+            if (compareLen > DBL_DIG - 1
                 && floats_text[i][compareLen-2] == '.'
                 && len > compareLen - 2
                 && res[compareLen-2] == '.')
             {
-                compareLen = DBL_DIG;
+                compareLen = DBL_DIG - 1;
             }
             CU_ASSERT_NSTRING_EQUAL(res, floats_text[i], compareLen);
             if (strncmp(res, floats_text[i], compareLen))
@@ -206,12 +241,12 @@ static void test_utils_floatToText(void)
 
     /* Test when no significant digits fit */
     double val = 1e-9;
-    len = utils_floatToText(val, (uint8_t*)res, 6);
-    CU_ASSERT(len);
+    len = utils_floatToText(val, (uint8_t*)res, 6, false);
+    CU_ASSERT(len == 3);
     if(len)
     {
-        CU_ASSERT_NSTRING_EQUAL(res, "0.0000", len);
-        if (strncmp(res, "0.0000", len))
+        CU_ASSERT_NSTRING_EQUAL(res, "0.0", len);
+        if (strncmp(res, "0.0", len))
             printf("%zu \"%g\" -> fail (%*s)\n", i, val, len, res);
     }
     else
@@ -222,13 +257,101 @@ static void test_utils_floatToText(void)
 
     /* Test when only some significant digits fit */
     val = 0.11111111111111111;
-    len = utils_floatToText(val, (uint8_t*)res, 6);
+    len = utils_floatToText(val, (uint8_t*)res, 6, false);
     CU_ASSERT(len);
     if(len)
     {
         CU_ASSERT_NSTRING_EQUAL(res, "0.1111", len);
         if (strncmp(res, "0.1111", len))
             printf("%zu \"%g\" -> fail (%*s)\n", i, val, len, res);
+    }
+    else
+    {
+        printf("%zu \"%g\" -> fail\n", i, val);
+    }
+}
+
+static void test_utils_floatToTextExponential(void)
+{
+    size_t i;
+    char res[24];
+    int len;
+    int compareLen;
+
+    for (i = 0 ; i < sizeof(floats)/sizeof(floats[0]); i++)
+    {
+        compareLen = (int)strlen(floats_exponential[i]);
+        len = utils_floatToText(floats[i], (uint8_t*)res, sizeof(res), true);
+
+        CU_ASSERT(len >= compareLen);
+        if (len)
+        {
+            CU_ASSERT_NSTRING_EQUAL(res, floats_exponential[i], compareLen);
+            if (strncmp(res, floats_exponential[i], compareLen))
+                printf("%zu \"%g\" -> fail (%*s)\n", i, floats[i], len, res);
+        }
+        else
+        {
+            printf("%zu \"%g\" -> fail\n", i, floats[i]);
+        }
+    }
+
+    /* Test when no significant digits */
+    double val = DBL_MIN/FLT_RADIX;
+    CU_ASSERT_NOT_EQUAL(val, 0);
+    len = utils_floatToText(val, (uint8_t*)res, 6, true);
+    CU_ASSERT(len == 3);
+    if(len)
+    {
+        CU_ASSERT_NSTRING_EQUAL(res, "0.0", 3);
+        if (strncmp(res, "0.0", 3))
+            printf("%zu \"%g\" -> fail (%.*s)\n", i, val, len, res);
+    }
+    else
+    {
+        printf("%zu \"%g\" -> fail\n", i, val);
+    }
+    i++;
+
+    /* Tests when only some significant digits fit */
+    val = 0.11111111111111111;
+    len = utils_floatToText(val, (uint8_t*)res, 6, true);
+    CU_ASSERT(len == 6);
+    if(len)
+    {
+        CU_ASSERT_NSTRING_EQUAL(res, "0.1111", 6);
+        if (strncmp(res, "0.1111", 6))
+            printf("%zu \"%g\" -> fail (%.*s)\n", i, val, len, res);
+    }
+    else
+    {
+        printf("%zu \"%g\" -> fail\n", i, val);
+    }
+    i++;
+
+    val = 1.1111111111111111e-6;
+    len = utils_floatToText(val, (uint8_t*)res, 6, true);
+    CU_ASSERT(len == 6);
+    if(len)
+    {
+        CU_ASSERT_NSTRING_EQUAL(res, "1.1e-6", 6);
+        if (strncmp(res, "1.1e-6", 6))
+            printf("%zu \"%g\" -> fail (%.*s)\n", i, val, len, res);
+    }
+    else
+    {
+        printf("%zu \"%g\" -> fail\n", i, val);
+    }
+    i++;
+
+    val = 1.99e-6;
+    len = utils_floatToText(val, (uint8_t*)res, 6, true);
+    CU_ASSERT(len == 6);
+    if(len)
+    {
+        CU_ASSERT_NSTRING_EQUAL(res, "2.0e-6", 6);
+        if (strncmp(res, "2.0e-6", 6))
+            printf("%zu \"%g\" -> fail (%.*s)\n", i, val, len, res);
     }
     else
     {
@@ -284,10 +407,12 @@ static struct TestTable table[] = {
         { "test of utils_textToInt()", test_utils_textToInt },
         { "test of utils_textToUInt()", test_utils_textToUInt },
         { "test of utils_textToFloat()", test_utils_textToFloat },
+        { "test of utils_textToFloat(exponential)", test_utils_textToFloatExponential },
         { "test of utils_textToObjLink()", test_utils_textToObjLink },
         { "test of utils_intToText()", test_utils_intToText },
         { "test of utils_uintToText()", test_utils_uintToText },
         { "test of utils_floatToText()", test_utils_floatToText },
+        { "test of utils_floatToText(exponential)", test_utils_floatToTextExponential },
         { "test of utils_objLinkToText()", test_utils_objLinkToText },
         { "test of base64 functions", test_utils_base64 },
         { NULL, NULL },


### PR DESCRIPTION
Provides an improved range of conversions and handles scientific
notation.

Updates the tests.

Ignores warning about comparing floating point numbers for equality.
This is intentionally used to detect a NaN.

Signed-off-by: Scott Bertin <sbertin@telular.com>