### PR TITLE
Fix memory leak with bad options.

### DIFF
--- a/core/er-coap-13/er-coap-13.c
+++ b/core/er-coap-13/er-coap-13.c
@@ -703,6 +703,7 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
     if (current_option + option_length > data + data_len)
     {
         PRINTF("OPTION %u (delta %u, len %u) has invalid length.\n", option_number, option_delta, option_length);
+        coap_free_header(coap_pkt);
         return BAD_REQUEST_4_00;
     }
     else
@@ -835,6 +836,7 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
         if (option_number & 1)
         {
           coap_error_message = "Unsupported critical option";
+          coap_free_header(coap_pkt);
           return BAD_OPTION_4_02;
         }
     }


### PR DESCRIPTION
Option processing can allocate memory. Encountering a bad option was
returning and error without freeing that memory. This adds the necessary
calls to free the memory to fix #425.

Signed-off-by: Scott Bertin <sbertin@telular.com>