### PR TITLE
examples/client: Fix access control object read

### DIFF
--- a/examples/client/object_access_control.c
+++ b/examples/client/object_access_control.c
@@ -95,7 +95,7 @@ static uint8_t prv_set_tlv(lwm2m_data_t* dataP, acc_ctrl_oi_t* accCtrlOiP)
                 subTlvP[ri].id = accCtrlRiP->resInstId;
                 lwm2m_data_encode_int(accCtrlRiP->accCtrlValue, &subTlvP[ri]);
             }
-            lwm2m_data_encode_instances(subTlvP, 2, dataP);
+            lwm2m_data_encode_instances(subTlvP, ri, dataP);
             return COAP_205_CONTENT;
         }
     }   break;


### PR DESCRIPTION
### Description
In the Access Control object implementation of the Client example when the `prv_set_tlv` function is called the data is encoded into the data pointer using the helping function for encoding instances. The amount of instances being encoded was hardcoded and didn't work if a different number of items were present in the access control list. This fixes this.

### Test procedure
Run the example before and after applying this PR with a number different to 2 in the access control list.