### PR TITLE
Make TLV format optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Several compilation switches are used:
  - LWM2M_SERVER_MODE to enable LWM2M Server interfaces.
  - LWM2M_BOOTSTRAP_SERVER_MODE to enable LWM2M Bootstrap Server interfaces.
  - LWM2M_BOOTSTRAP to enable LWM2M Bootstrap support in a LWM2M Client.
+ - LWM2M_SUPPORT_TLV to enable TLV payload support (implicit except for LWM2M 1.1 clients)
  - LWM2M_SUPPORT_JSON to enable JSON payload support (implicit when defining LWM2M_SERVER_MODE)
  - LWM2M_SUPPORT_SENML_JSON to enable SenML JSON payload support (implicit for LWM2M 1.1 or greater when defining LWM2M_SERVER_MODE or LWM2M_BOOTSTRAP_SERVER_MODE)
  - LWM2M_OLD_CONTENT_FORMAT_SUPPORT to support the deprecated content format values for TLV and JSON.

--- a/core/internals.h
+++ b/core/internals.h
@@ -279,7 +279,7 @@ int uri_toString(const lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, u
 
 // defined in objects.c
 uint8_t object_readData(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);
-uint8_t object_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t * formatP, uint8_t ** bufferP, size_t * lengthP);
+uint8_t object_read(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, const uint16_t * accept, uint8_t acceptNum, lwm2m_media_type_t * formatP, uint8_t ** bufferP, size_t * lengthP);
 uint8_t object_write(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 uint8_t object_create(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, size_t length);
 uint8_t object_execute(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, uint8_t * buffer, size_t length);
@@ -334,9 +334,11 @@ uint8_t bootstrap_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, 
 void bootstrap_start(lwm2m_context_t * contextP);
 lwm2m_status_t bootstrap_getStatus(lwm2m_context_t * contextP);
 
+#ifdef LWM2M_SUPPORT_TLV
 // defined in tlv.c
 int tlv_parse(const uint8_t * buffer, size_t bufferLen, lwm2m_data_t ** dataP);
 int tlv_serialize(bool isResourceInstance, int size, lwm2m_data_t * dataP, uint8_t ** bufferP);
+#endif
 
 // defined in json.c
 #ifdef LWM2M_SUPPORT_JSON
@@ -379,6 +381,12 @@ lwm2m_data_type_t utils_depthToDatatype(uri_depth_t depth);
 lwm2m_version_t utils_stringToVersion(uint8_t *buffer, size_t length);
 lwm2m_binding_t utils_stringToBinding(uint8_t *buffer, size_t length);
 lwm2m_media_type_t utils_convertMediaType(coap_content_type_t type);
+uint8_t utils_getResponseFormat(uint8_t accept_num,
+                                const uint16_t *accept,
+                                int numData,
+                                const lwm2m_data_t *dataP,
+                                bool singleResource,
+                                lwm2m_media_type_t *format);
 int utils_isAltPathValid(const char * altPath);
 int utils_stringCopy(char * buffer, size_t length, const char * str);
 size_t utils_intToText(int64_t data, uint8_t * string, size_t length);

--- a/core/liblwm2m.h
+++ b/core/liblwm2m.h
@@ -84,6 +84,14 @@ extern "C" {
 #endif
 #endif
 
+#ifndef LWM2M_SUPPORT_TLV
+#if defined(LWM2M_VERSION_1_0) || defined(LWM2M_SERVER_MODE) || defined(LWM2M_BOOTSTRAP_SERVER_MODE)
+/* TLV is mandatory for LWM2M 1.0 client and server. */
+/* TLV is mandatory for LWM2M 1.1 server. */
+#define LWM2M_SUPPORT_TLV
+#endif
+#endif
+
 #if defined(LWM2M_BOOTSTRAP) && defined(LWM2M_BOOTSTRAP_SERVER_MODE)
 #error "LWM2M_BOOTSTRAP and LWM2M_BOOTSTRAP_SERVER_MODE cannot be defined at the same time!"
 #endif
@@ -774,7 +782,7 @@ int lwm2m_dm_discover(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t
 int lwm2m_dm_write(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
 int lwm2m_dm_write_attributes(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_attributes_t * attrP, lwm2m_result_callback_t callback, void * userData);
 int lwm2m_dm_execute(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
-int lwm2m_dm_create(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
+int lwm2m_dm_create(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, int numData, lwm2m_data_t * dataP, lwm2m_result_callback_t callback, void * userData);
 int lwm2m_dm_delete(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_result_callback_t callback, void * userData);
 
 // Information Reporting APIs

--- a/core/management.c
+++ b/core/management.c
@@ -211,27 +211,34 @@ uint8_t dm_handleRequest(lwm2m_context_t * contextP,
                 result = object_readData(contextP, uriP, &size, &dataP);
                 if (COAP_205_CONTENT == result)
                 {
-                    result = observe_handleRequest(contextP, uriP, serverP, size, dataP, message, response);
+                    result = utils_getResponseFormat(message->accept_num,
+                                                     message->accept,
+                                                     size,
+                                                     dataP,
+                                                     LWM2M_URI_IS_SET_RESOURCE(uriP),
+                                                     &format);
                     if (COAP_205_CONTENT == result)
                     {
-                        if (IS_OPTION(message, COAP_OPTION_ACCEPT))
+                        coap_set_header_content_type(response, format);
+                        result = observe_handleRequest(contextP,
+                                                       uriP,
+                                                       serverP,
+                                                       size,
+                                                       dataP,
+                                                       message,
+                                                       response);
+                        if (COAP_205_CONTENT == result)
                         {
-                            format = utils_convertMediaType(message->accept[0]);
-                        }
-                        else
-                        {
-                            format = LWM2M_CONTENT_TLV;
-                        }
-
-                        res = lwm2m_data_serialize(uriP, size, dataP, &format, &buffer);
-                        if (res < 0)
-                        {
-                            result = COAP_500_INTERNAL_SERVER_ERROR;
-                        }
-                        else
-                        {
-                            length = (size_t)res;
-                            LOG_ARG("Observe Request[/%d/%d/%d]: %.*s\n", uriP->objectId, uriP->instanceId, uriP->resourceId, length, buffer);
+                            res = lwm2m_data_serialize(uriP, size, dataP, &format, &buffer);
+                            if (res < 0)
+                            {
+                                result = COAP_500_INTERNAL_SERVER_ERROR;
+                            }
+                            else
+                            {
+                                length = (size_t)res;
+                                LOG_ARG("Observe Request[/%d/%d/%d]: %.*s\n", uriP->objectId, uriP->instanceId, uriP->resourceId, length, buffer);
+                            }
                         }
                     }
                     lwm2m_data_free(size, dataP);
@@ -246,12 +253,13 @@ uint8_t dm_handleRequest(lwm2m_context_t * contextP,
             }
             else
             {
-                if (IS_OPTION(message, COAP_OPTION_ACCEPT))
-                {
-                    format = utils_convertMediaType(message->accept[0]);
-                }
-
-                result = object_read(contextP, uriP, &format, &buffer, &length);
+                result = object_read(contextP,
+                                     uriP,
+                                     message->accept,
+                                     message->accept_num,
+                                     &format,
+                                     &buffer,
+                                     &length);
             }
             if (COAP_205_CONTENT == result)
             {
@@ -560,20 +568,41 @@ int lwm2m_dm_execute(lwm2m_context_t * contextP,
 int lwm2m_dm_create(lwm2m_context_t * contextP,
                     uint16_t clientID,
                     lwm2m_uri_t * uriP,
-                    lwm2m_media_type_t format,
-                    uint8_t * buffer,
-                    int length,
+                    int size,
+                    lwm2m_data_t * dataP,
                     lwm2m_result_callback_t callback,
                     void * userData)
 {
-    LOG_ARG("clientID: %d, format: %s, length: %d", clientID, STR_MEDIA_TYPE(format), length);
+    uint8_t * buffer;
+    int length;
+    lwm2m_client_t * clientP;
+    lwm2m_media_type_t format;
+
+    LOG_ARG("clientID: %d, size: %d", clientID, size);
     LOG_URI(uriP);
 
     if (LWM2M_URI_IS_SET_INSTANCE(uriP)
-     || length == 0)
+     || size == 0)
     {
         return COAP_400_BAD_REQUEST;
     }
+
+    clientP = (lwm2m_client_t *)LWM2M_LIST_FIND(contextP->clientList, clientID);
+    if (clientP == NULL) return COAP_404_NOT_FOUND;
+
+    format = clientP->format;
+#ifdef LWM2M_SUPPORT_TLV
+    /* TODO: JSON formats currently require the object instance to be specified.
+     * Use TLV instead until that is fixed. */
+    if (format != LWM2M_CONTENT_TLV
+     && (size > 1 || dataP[0].type != LWM2M_TYPE_OBJECT_INSTANCE))
+    {
+        format = LWM2M_CONTENT_TLV;
+    }
+#endif
+    length = lwm2m_data_serialize(uriP, size, dataP, &format, &buffer);
+
+    if (length <= 0) return COAP_400_BAD_REQUEST;
 
     return prv_makeOperation(contextP, clientID, uriP,
                               COAP_POST,

--- a/core/objects.c
+++ b/core/objects.c
@@ -187,6 +187,8 @@ uint8_t object_readData(lwm2m_context_t * contextP,
 
 uint8_t object_read(lwm2m_context_t * contextP,
                     lwm2m_uri_t * uriP,
+                    const uint16_t * accept,
+                    uint8_t acceptNum,
                     lwm2m_media_type_t * formatP,
                     uint8_t ** bufferP,
                     size_t * lengthP)
@@ -201,14 +203,26 @@ uint8_t object_read(lwm2m_context_t * contextP,
 
     if (result == COAP_205_CONTENT)
     {
-        res = lwm2m_data_serialize(uriP, size, dataP, formatP, bufferP);
-        if (res < 0)
+        if (acceptNum > 0)
         {
-            result = COAP_500_INTERNAL_SERVER_ERROR;
+            result = utils_getResponseFormat(acceptNum,
+                                             accept,
+                                             size,
+                                             dataP,
+                                             LWM2M_URI_IS_SET_RESOURCE(uriP),
+                                             formatP);
         }
-        else
+        if (result == COAP_205_CONTENT)
         {
-            *lengthP = (size_t)res;
+            res = lwm2m_data_serialize(uriP, size, dataP, formatP, bufferP);
+            if (res < 0)
+            {
+                result = COAP_500_INTERNAL_SERVER_ERROR;
+            }
+            else
+            {
+                *lengthP = (size_t)res;
+            }
         }
     }
     lwm2m_data_free(size, dataP);

--- a/core/observe.c
+++ b/core/observe.c
@@ -190,14 +190,7 @@ uint8_t observe_handleRequest(lwm2m_context_t * contextP,
         watcherP->active = true;
         watcherP->lastTime = lwm2m_gettime();
         watcherP->lastMid = response->mid;
-        if (IS_OPTION(message, COAP_OPTION_ACCEPT))
-        {
-            watcherP->format = utils_convertMediaType(message->accept[0]);
-        }
-        else
-        {
-            watcherP->format = LWM2M_CONTENT_TLV;
-        }
+        watcherP->format = (lwm2m_media_type_t)response->content_type;
 
         if (LWM2M_URI_IS_SET_RESOURCE(uriP))
         {
@@ -775,7 +768,7 @@ void observe_step(lwm2m_context_t * contextP,
                         }
                         else
                         {
-                            if (COAP_205_CONTENT != object_read(contextP, &targetP->uri, &(watcherP->format), &buffer, &length))
+                            if (COAP_205_CONTENT != object_read(contextP, &targetP->uri, NULL, 0, &(watcherP->format), &buffer, &length))
                             {
                                 buffer = NULL;
                                 break;

--- a/core/tlv.c
+++ b/core/tlv.c
@@ -25,6 +25,8 @@
 #include <inttypes.h>
 #include <float.h>
 
+#ifdef LWM2M_SUPPORT_TLV
+
 #ifndef LWM2M_BIG_ENDIAN
 #ifndef LWM2M_LITTLE_ENDIAN
 #error Please define LWM2M_BIG_ENDIAN or LWM2M_LITTLE_ENDIAN
@@ -642,3 +644,4 @@ int tlv_serialize(bool isResourceInstance,
     return length;
 }
 
+#endif

--- a/core/utils.c
+++ b/core/utils.c
@@ -780,6 +780,113 @@ lwm2m_media_type_t utils_convertMediaType(coap_content_type_t type)
     return result;
 }
 
+uint8_t utils_getResponseFormat(uint8_t accept_num,
+                                const uint16_t *accept,
+                                int numData,
+                                const lwm2m_data_t *dataP,
+                                bool singleResource,
+                                lwm2m_media_type_t *format)
+{
+    uint8_t result = COAP_205_CONTENT;
+    bool singular;
+
+    if (numData == 1)
+    {
+        switch (dataP->type)
+        {
+        case LWM2M_TYPE_OBJECT:
+        case LWM2M_TYPE_OBJECT_INSTANCE:
+        case LWM2M_TYPE_MULTIPLE_RESOURCE:
+            singular = false;
+            break;
+        default:
+            singular = singleResource;
+            break;
+        }
+    }
+    else
+    {
+        singular = singleResource;
+    }
+
+    *format = LWM2M_CONTENT_TEXT;
+    if (accept_num > 0)
+    {
+        uint8_t i;
+        bool found = false;
+        for(i = 0; i < accept_num && !found; i++)
+        {
+            switch (accept[i])
+            {
+            case TEXT_PLAIN:
+                if (singular)
+                {
+                    found = true;
+                }
+                break;
+            case APPLICATION_OCTET_STREAM:
+                if (singular)
+                {
+                    *format = LWM2M_CONTENT_OPAQUE;
+                    found = true;
+                }
+                break;
+
+#ifdef LWM2M_SUPPORT_TLV
+#ifdef LWM2M_OLD_CONTENT_FORMAT_SUPPORT
+            case LWM2M_CONTENT_TLV_OLD:
+                *format = LWM2M_CONTENT_TLV_OLD;
+                found = true;
+                break;
+#endif
+            case LWM2M_CONTENT_TLV:
+                *format = LWM2M_CONTENT_TLV;
+                found = true;
+                break;
+#endif
+
+#ifdef LWM2M_SUPPORT_JSON
+#ifdef LWM2M_OLD_CONTENT_FORMAT_SUPPORT
+            case LWM2M_CONTENT_JSON_OLD:
+                *format = LWM2M_CONTENT_JSON_OLD;
+                found = true;
+                break;
+#endif
+            case LWM2M_CONTENT_JSON:
+                *format = LWM2M_CONTENT_JSON;
+                found = true;
+                break;
+#endif
+
+#ifdef LWM2M_SUPPORT_SENML_JSON
+            case LWM2M_CONTENT_SENML_JSON:
+                *format = LWM2M_CONTENT_SENML_JSON;
+                found = true;
+                break;
+#endif
+
+            default:
+                break;
+            }
+        }
+        if (!found) result = COAP_406_NOT_ACCEPTABLE;
+    }
+    else
+    {
+#ifdef LWM2M_SUPPORT_SENML_JSON
+        *format = LWM2M_CONTENT_SENML_JSON;
+#elif defined(LWM2M_SUPPORT_JSON)
+        *format = LWM2M_CONTENT_JSON;
+#elif defined(LWM2M_SUPPORT_TLV)
+        *format = LWM2M_CONTENT_TLV;
+#else
+        result = COAP_500_INTERNAL_SERVER_ERROR;
+#endif
+    }
+
+    return result;
+}
+
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * utils_findServer(lwm2m_context_t * contextP,
                                   void * fromSessionH)

--- a/examples/shared/commandline.c
+++ b/examples/shared/commandline.c
@@ -224,6 +224,7 @@ void output_tlv(FILE * stream,
                 size_t buffer_len,
                 int indent)
 {
+#ifdef LWM2M_SUPPORT_TLV
     lwm2m_data_type_t type;
     uint16_t id;
     size_t dataIndex;
@@ -292,6 +293,14 @@ void output_tlv(FILE * stream,
         print_indent(stream, indent);
         fprintf(stream, "}\r\n");
     }
+#else
+    /* Unused parameters */
+    (void)buffer;
+    (void)buffer_len;
+
+    print_indent(stream, indent);
+    fprintf(stream, "Unsupported.\r\n");
+#endif
 }
 
 void output_data(FILE * stream,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ project (lwm2munittests C)
 include(${CMAKE_CURRENT_LIST_DIR}/../core/wakaama.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../examples/shared/shared.cmake)
 
-add_definitions(-DLWM2M_CLIENT_MODE -DLWM2M_SUPPORT_JSON)
+add_definitions(-DLWM2M_CLIENT_MODE -DLWM2M_SUPPORT_TLV -DLWM2M_SUPPORT_JSON)
 if(LWM2M_VERSION VERSION_GREATER "1.0")
     add_definitions(-DLWM2M_SUPPORT_SENML_JSON)
 endif()


### PR DESCRIPTION
It is always enabled for LWM2M 1.0 clients and servers and LWM2M 1.1
servers, but disabled by default for LWM2M 1.1 clients.

Signed-off-by: Scott Bertin <sbertin@telular.com>