### PR TITLE
Fix potential type size mismatch through pointers

### DIFF
--- a/core/er-coap-13/er-coap-13.c
+++ b/core/er-coap-13/er-coap-13.c
@@ -617,10 +617,10 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
 {
   coap_packet_t *const coap_pkt = (coap_packet_t *) packet;
   uint8_t *current_option;
-  unsigned int option_number = 0;
-  unsigned int option_delta = 0;
-  size_t option_length = 0;
-  unsigned int *x;
+  uint32_t option_number = 0;
+  uint32_t option_delta = 0;
+  uint32_t option_length = 0;
+  uint32_t *x;
 
   /* Initialize packet */
   memset(coap_pkt, 0, sizeof(coap_packet_t));
@@ -696,7 +696,7 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
         ++current_option;
       }
     }
-    while (x!=(unsigned int *)&option_length && (x=(unsigned int *)&option_length));
+    while (x!=&option_length && (x=&option_length));
 
     option_number += option_delta;
 


### PR DESCRIPTION
size_t can be 64-bits while unsigned int is smaller. This causes issues
when option_length is accessed through the pointer x in
coap_parse_message(). The option length and delta are at most a 16-bit
unsigned integer plus 269 according to RFC 7252. Changing
option_number, option_delta, and option_length to uint32_t and x to
uint32_t * fixes #429. This also ensures sufficient size even if used
on a platform with smaller integers.

Signed-off-by: Scott Bertin <sbertin@telular.com>