### PR TITLE
Add files via upload

### DIFF
--- a/core/internals.h
+++ b/core/internals.h
@@ -294,7 +294,7 @@ uint8_t object_createInstance(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lw
 uint8_t object_writeInstance(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_data_t * dataP);
 
 // defined in transaction.c
-lwm2m_transaction_t * transaction_new(void * sessionH, coap_method_t method, char * altPath, lwm2m_uri_t * uriP, uint16_t mID, uint8_t token_len, uint8_t* token);
+lwm2m_transaction_t * transaction_new(void * sessionH, uint8_t method, char * altPath, lwm2m_uri_t * uriP, uint16_t mID, uint8_t token_len, uint8_t* token);
 int transaction_send(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);
 void transaction_free(lwm2m_transaction_t * transacP);
 void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transacP);

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -142,7 +142,7 @@ static int prv_checkFinished(lwm2m_transaction_t * transacP,
 }
 
 lwm2m_transaction_t * transaction_new(void * sessionH,
-                                      coap_method_t method,
+                                      uint8_t method,
                                       char * altPath,
                                       lwm2m_uri_t * uriP,
                                       uint16_t mID,


### PR DESCRIPTION
align parameter method's type with coap protocol, it exceeds the define of coap_method_t already. its type should align with coap_init_message(..,.., method,..), 