### PR TITLE
Implement lwm2m_gettime() using time().

### DIFF
--- a/examples/shared/platform.c
+++ b/examples/shared/platform.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include <sys/time.h>
+#include <time.h>
 
 #ifndef LWM2M_MEMORY_TRACE
 
@@ -49,14 +49,7 @@ int lwm2m_strncmp(const char * s1,
 
 time_t lwm2m_gettime(void)
 {
-    struct timeval tv;
-
-    if (0 != gettimeofday(&tv, NULL))
-    {
-        return -1;
-    }
-
-    return tv.tv_sec;
+    return time(NULL);
 }
 
 void lwm2m_printf(const char * format, ...)


### PR DESCRIPTION
Currently lwm2m_gettime() is implemented using POSIX's gettimeofday(). This creates a number of issues:

1. gettimeofday() gives the "time of day", meaning it overflows each 24 hours. This runs contrary to the specification in liblwm2m.h,    an may result in wring behaviour.
2. gettimeofday() is marked obsolete in POSIX 2008.
3. time is standard in C89/C99, not only POSIX.
4. Using time() is more straightforward.

I understand that gettimeofday() used only in the examples and it not part of the waakama library. The examples, however, are what people wanting use waakama will look at first and probably copy, so they should be correct. Using gettimeofday() creates confusion as to whether the absolute time or the time since 0AM should be used.

#### Point 1

The first issue is the most important. Looking at the code, there is no evidence that the 24-hour overflow is being taken into account. So, by default we must assime that an overflowing time value may break waakama.

For example, in core/transaction.c:389 we find:
```c
transacP->retrans_time = tv_sec + COAP_RESPONSE_TIMEOUT;
```

and later in core/transaction.c:443 :
```c
if (transacP->retrans_time <= currentTime)
```

If tv_sec is acquired via gettimeofday() it has a range from 0 to 3600*24, and the first line may put `transacP->retrans_time` outside that range. If that happens, the comparison in line 443 will always be false.

#### Point 3

Point (3) is relevant for those trying to use waakama in embedded system where the full POSIX API is not available. Using time() makes it clear that waakama does not need POSIX time functions. Now, I'm not very familiar with this code, but it seems to me that the library itself does not need POSIX _at all_.

#### Points 2, 4

Point (2) and (4) are easy to verify.

#### Testing

I haven't tested this, apart from checking that it stil compiles. I do not know how to test waakama.
