### PR TITLE
Fix DTLS connection_send in example code

### DIFF
--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -554,7 +554,7 @@ void connection_free(dtls_connection_t * connList)
 int connection_send(dtls_connection_t *connP, uint8_t * buffer, size_t length){
     if (connP->dtlsSession == NULL) {
         // no security
-        if ( 0 != send_data(connP, buffer, length)) {
+        if (0 >= send_data(connP, buffer, length)) {
             return -1 ;
         }
     } else {


### PR DESCRIPTION
The number of bytes sent returned from send_data was interpreted as
error.

Signed-off-by: Tobias Gustafsson <tobias.gustafsson@inux.se>