### PR TITLE
Resolving base64 decoding bug

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -765,7 +765,7 @@ size_t utils_base64Decode(const char * dataP, size_t dataLen, uint8_t * bufferP,
                     {
                         v4 = prv_base64Value(dataP[dataIndex++]);
                         if (v4 >= 64) return 0;
-                        bufferP[bufferIndex++] = (v2 << 6) + v4;
+                        bufferP[bufferIndex++] = (v3 << 6) + v4;
                     }
                     else
                     {


### PR DESCRIPTION
Base64 decoding requires that adjacent variables from the encoded string are combined to generate the final correct binary data stream. The current implementation will result in every 3rd byte decoded into junk, this fix resolves the issue.