### PR TITLE
Alternate Path while bootstrapping

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -115,7 +115,12 @@ static uint8_t handle_request(lwm2m_context_t * contextP,
     LOG("Entering");
 	
 #ifdef LWM2M_CLIENT_MODE
-    requestType = uri_decode(contextP->altPath, message->uri_path, &uri);
+    if(contextP->state == STATE_BOOTSTRAPPING) {
+        requestType = uri_decode(NULL, message->uri_path, &uri);
+    }
+    else {
+        requestType = uri_decode(contextP->altPath, message->uri_path, &uri);
+    }
 #else
     requestType = uri_decode(NULL, message->uri_path, &uri);
 #endif


### PR DESCRIPTION
According to LWM2M Specification (http://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/OMA-TS-LightweightM2M_Transport-V1_1_1-20190617-A.pdf) Section 6.4.1 CoAP Paths MUST be used. But in wakaama missing alternate paths while bootstrapping will return an error.