### PR TITLE
if the registration_getStatus function (registration status) returns …

### DIFF
--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -442,8 +442,12 @@ next_step:
             break;
 
         case STATE_REG_FAILED:
+#ifdef LWM2M_BOOTSTRAP
             // TODO avoid infinite loop by checking the bootstrap info is different
             contextP->state = STATE_BOOTSTRAP_REQUIRED;
+#else
+            contextP->state = STATE_REGISTER_REQUIRED;
+#endif
             goto next_step;
             break;
 
@@ -458,8 +462,12 @@ next_step:
     case STATE_READY:
         if (registration_getStatus(contextP) == STATE_REG_FAILED)
         {
+#ifdef LWM2M_BOOTSTRAP
             // TODO avoid infinite loop by checking the bootstrap info is different
             contextP->state = STATE_BOOTSTRAP_REQUIRED;
+#else
+            contextP->state = STATE_REGISTER_REQUIRED;
+#endif
             goto next_step;
             break;
         }

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -1225,6 +1225,7 @@ int main(int argc, char *argv[])
             fprintf(stdout, "Unknown...\r\n");
             break;
         }
+#ifdef LWM2M_BOOTSTRAP
         if (result != 0)
         {
             fprintf(stderr, "lwm2m_step() failed: 0x%X\r\n", result);
@@ -1238,7 +1239,6 @@ int main(int argc, char *argv[])
             }
             else return -1;
         }
-#ifdef LWM2M_BOOTSTRAP
         update_bootstrap_info(&previousState, lwm2mH);
 #endif
         /*


### PR DESCRIPTION
If the registration_getStatus function (registration status) returns STATE_REG_FAILED and if bootstrap is not used switch contextP-> state to STATE_REGISTER_REQUIRED, not STATE_BOOTSTRAP_REQUIRED