### PR TITLE
fix dataArray size of client example's firware

### DIFF
--- a/examples/client/object_firmware.c
+++ b/examples/client/object_firmware.c
@@ -88,7 +88,7 @@ static uint8_t prv_firmware_read(uint16_t instanceId,
     // is the server asking for the full object ?
     if (*numDataP == 0)
     {
-        *dataArrayP = lwm2m_data_new(3);
+        *dataArrayP = lwm2m_data_new(6);
         if (*dataArrayP == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
         *numDataP = 6;
         (*dataArrayP)[0].id = 3;


### PR DESCRIPTION
Encountered when running the example on ARM, looks like the dataArray size is off by three in the client's firmware object, causing the client to segfault when one attempts to read the whole object.
Funnily enough, does not occur on x86.