### PR TITLE
Fix reference to Erbium's CoAP engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Developers mailing list: https://dev.eclipse.org/mailman/listinfo/wakaama-dev
 
     -+- core                   (the LWM2M engine)
      |    |
-     |    +- er-coap-13        (Slightly modified Erbium's CoAP engine from
+     |    +- er-coap-13        (Modified Erbium's CoAP engine from
      |                          https://web.archive.org/web/20180316172739/http://people.inf.ethz.ch/mkovatsc/erbium.php)
      |
      +- tests                  (test cases)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Developers mailing list: https://dev.eclipse.org/mailman/listinfo/wakaama-dev
     -+- core                   (the LWM2M engine)
      |    |
      |    +- er-coap-13        (Slightly modified Erbium's CoAP engine from
-     |                          http://people.inf.ethz.ch/mkovatsc/erbium.php
+     |                          https://web.archive.org/web/20180316172739/http://people.inf.ethz.ch/mkovatsc/erbium.php)
      |
      +- tests                  (test cases)
      |


### PR DESCRIPTION
* The original website is no longer available, therefore linking to latest version mirrored on archive.org.
* Even if the changes where just small in the beginning, nowadays there is a big delta. Calling the modifications "slightly" is misleading.