### PR TITLE
Point the tinydtls submodule at the new location.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,7 @@ jobs:
       uses: lukka/get-cmake@latest
 
     - name: Install Ninja
-      uses: ashutoshvarma/setup-ninja@master
-      with:
-        version: 1.10.0
+      uses: seanmiddleditch/gha-setup-ninja@master
 
     - name: Build and execute unit tests
       run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "platforms/Linux/tinydtls"]
 	path = examples/shared/tinydtls
-	url = https://git.eclipse.org/r/tinydtls/org.eclipse.tinydtls
+	url = https://github.com/eclipse/tinydtls.git


### PR DESCRIPTION
The old location https://git.eclipse.org/r/tinydtls/org.eclipse.tinydtls
is no longer accessable. It has been moved to
https://github.com/eclipse/tinydtls.git.

Signed-off-by: Scott Bertin <sbertin@telular.com>