### PR TITLE
Enable SENML_JSON support in lightclient

### DIFF
--- a/examples/lightclient/CMakeLists.txt
+++ b/examples/lightclient/CMakeLists.txt
@@ -10,6 +10,10 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../core/wakaama.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/shared.cmake)
 
 add_definitions(-DLWM2M_CLIENT_MODE)
+if(LWM2M_VERSION VERSION_GREATER "1.0")
+    add_definitions(-DLWM2M_SUPPORT_SENML_JSON)
+endif()
+
 add_definitions(${SHARED_DEFINITIONS} ${WAKAAMA_DEFINITIONS})
 
 include_directories (${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})


### PR DESCRIPTION
Lightclient example now works out-of-the-box with wakaama server example.

Signed-off-by: Leif Sandstrom <leif.sandstrom@husqvarnagroup.com>

Wakaama client / server examples should work together after a "vanilla build" to provide a good user experience.