### PR TITLE
Fix passing NULL pointer to printf as string.

### DIFF
--- a/core/data.c
+++ b/core/data.c
@@ -211,7 +211,7 @@ void lwm2m_data_encode_string(const char * string,
     size_t len;
     int res;
 
-    LOG_ARG("\"%s\"", string);
+    LOG_ARG("\"%s\"", STR_NULL2EMPTY(string));
     if (string == NULL)
     {
         len = 0;
@@ -274,7 +274,7 @@ void lwm2m_data_encode_nstring(const char * string,
                                size_t length,
                                lwm2m_data_t * dataP)
 {
-    LOG_ARG("length: %d, string: \"%.*s\"", length, length, string);
+    LOG_ARG("length: %d, string: \"%.*s\"", length, length, STR_NULL2EMPTY(string));
     lwm2m_data_encode_opaque((uint8_t *)string, length, dataP);
 
     if (dataP->type == LWM2M_TYPE_OPAQUE)
@@ -584,7 +584,7 @@ int lwm2m_data_decode_bool(const lwm2m_data_t * dataP,
 
 void lwm2m_data_encode_corelink(const char * corelink, lwm2m_data_t * dataP)
 {
-    LOG_ARG("\"%s\"", corelink);
+    LOG_ARG("\"%s\"", STR_NULL2EMPTY(corelink));
     lwm2m_data_encode_string(corelink, dataP);
     if (dataP->type == LWM2M_TYPE_STRING)
     {

--- a/core/internals.h
+++ b/core/internals.h
@@ -122,6 +122,7 @@
 ((S) == STATE_REGISTERING ? "STATE_REGISTERING" :      \
 ((S) == STATE_READY ? "STATE_READY" :      \
 "Unknown"))))))
+#define STR_NULL2EMPTY(S) ((const char *)(S) ? (const char *)(S) : "")
 #else
 #define LOG_ARG(FMT, ...)
 #define LOG(STR)

--- a/core/json.c
+++ b/core/json.c
@@ -494,7 +494,7 @@ int json_parse(lwm2m_uri_t * uriP,
     _record_t * recordArray;
     lwm2m_data_t * parsedP;
 
-    LOG_ARG("bufferLen: %d, buffer: \"%s\"", bufferLen, (char *)buffer);
+    LOG_ARG("bufferLen: %d, buffer: \"%s\"", bufferLen, STR_NULL2EMPTY((char *)buffer));
     LOG_URI(uriP);
     *dataP = NULL;
     recordArray = NULL;

--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -261,7 +261,11 @@ int lwm2m_configure(lwm2m_context_t * contextP,
     int i;
     uint8_t found;
 
-    LOG_ARG("endpointName: \"%s\", msisdn: \"%s\", altPath: \"%s\", numObject: %d", endpointName, msisdn, altPath, numObject);
+    LOG_ARG("endpointName: \"%s\", msisdn: \"%s\", altPath: \"%s\", numObject: %d",
+            STR_NULL2EMPTY(endpointName),
+            STR_NULL2EMPTY(msisdn),
+            STR_NULL2EMPTY(altPath),
+            numObject);
     // This API can be called only once for now
     if (contextP->endpointName != NULL || contextP->objectList != NULL) return COAP_400_BAD_REQUEST;
 

--- a/core/management.c
+++ b/core/management.c
@@ -237,7 +237,12 @@ uint8_t dm_handleRequest(lwm2m_context_t * contextP,
                             else
                             {
                                 length = (size_t)res;
-                                LOG_ARG("Observe Request[/%d/%d/%d]: %.*s\n", uriP->objectId, uriP->instanceId, uriP->resourceId, length, buffer);
+                                LOG_ARG("Observe Request[/%d/%d/%d]: %.*s\n",
+                                        uriP->objectId,
+                                        uriP->instanceId,
+                                        uriP->resourceId,
+                                        length,
+                                        STR_NULL2EMPTY(buffer));
                             }
                         }
                     }

--- a/core/packet.c
+++ b/core/packet.c
@@ -113,7 +113,7 @@ static uint8_t handle_request(lwm2m_context_t * contextP,
     uint8_t result = COAP_IGNORE;
 
     LOG("Entering");
-	
+
 #ifdef LWM2M_CLIENT_MODE
     requestType = uri_decode(contextP->altPath, message->uri_path, &uri);
 #else
@@ -213,7 +213,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
     {
         LOG_ARG("Parsed: ver %u, type %u, tkl %u, code %u.%.2u, mid %u, Content type: %d",
                 message->version, message->type, message->token_len, message->code >> 5, message->code & 0x1F, message->mid, message->content_type);
-        LOG_ARG("Payload: %.*s", message->payload_len, message->payload);
+        LOG_ARG("Payload: %.*s", message->payload_len, STR_NULL2EMPTY(message->payload));
         if (message->code >= COAP_GET && message->code <= COAP_DELETE)
         {
             uint32_t block_num = 0;
@@ -400,7 +400,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
 
     if (coap_error_code != NO_ERROR && coap_error_code != COAP_IGNORE)
     {
-        LOG_ARG("ERROR %u: %s", coap_error_code, coap_error_message);
+        LOG_ARG("ERROR %u: %s", coap_error_code, STR_NULL2EMPTY(coap_error_message));
 
         /* Set to sendable error code. */
         if (coap_error_code >= 192)

--- a/core/senml_json.c
+++ b/core/senml_json.c
@@ -611,7 +611,7 @@ int senml_json_parse(const lwm2m_uri_t * uriP,
     time_t baseTime;
     lwm2m_data_t baseValue;
 
-    LOG_ARG("bufferLen: %d, buffer: \"%s\"", bufferLen, (char *)buffer);
+    LOG_ARG("bufferLen: %d, buffer: \"%s\"", bufferLen, STR_NULL2EMPTY((char *)buffer));
     LOG_URI(uriP);
     *dataP = NULL;
     recordArray = NULL;

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -153,7 +153,7 @@ lwm2m_transaction_t * transaction_new(void * sessionH,
     int result;
 
     LOG_ARG("method: %d, altPath: \"%s\", mID: %d, token_len: %d",
-            method, altPath, mID, token_len);
+            method, STR_NULL2EMPTY(altPath), mID, token_len);
     LOG_URI(uriP);
 
     // no transactions without peer
@@ -285,11 +285,11 @@ bool transaction_handleResponse(lwm2m_context_t * contextP,
                 if ((COAP_TYPE_ACK == message->type) || (COAP_TYPE_RST == message->type))
                 {
                     if (transacP->mID == message->mid)
-	                {
-    	                found = true;
-        	            transacP->ack_received = true;
-            	        reset = COAP_TYPE_RST == message->type;
-            	    }
+                    {
+                        found = true;
+                        transacP->ack_received = true;
+                        reset = COAP_TYPE_RST == message->type;
+                    }
                 }
             }
 
@@ -305,14 +305,14 @@ bool transaction_handleResponse(lwm2m_context_t * contextP,
                         coap_init_message(response, COAP_TYPE_ACK, 0, message->mid);
                         message_send(contextP, response, fromSessionH);
                     }
-                
-	                if ((COAP_401_UNAUTHORIZED == message->code) && (COAP_MAX_RETRANSMIT > transacP->retrans_counter))
-    	            {
-        	            transacP->ack_received = false;
-            	        transacP->retrans_time += COAP_RESPONSE_TIMEOUT;
-                	    return true;
-                	}
-				}       
+
+                    if ((COAP_401_UNAUTHORIZED == message->code) && (COAP_MAX_RETRANSMIT > transacP->retrans_counter))
+                    {
+                        transacP->ack_received = false;
+                        transacP->retrans_time += COAP_RESPONSE_TIMEOUT;
+                        return true;
+                    }
+                }
                 if (transacP->callback != NULL)
                 {
                     transacP->callback(contextP, transacP, message);

--- a/core/uri.c
+++ b/core/uri.c
@@ -99,7 +99,7 @@ lwm2m_request_type_t uri_decode(char * altPath,
     int readNum;
     lwm2m_request_type_t requestType = LWM2M_REQUEST_TYPE_DM;
 
-    LOG_ARG("altPath: \"%s\"", altPath);
+    LOG_ARG("altPath: \"%s\"", STR_NULL2EMPTY(altPath));
 
     LWM2M_URI_RESET(uriP);
 
@@ -216,7 +216,7 @@ int lwm2m_stringToUri(const char * buffer,
     size_t head;
     int readNum;
 
-    LOG_ARG("buffer_len: %u, buffer: \"%.*s\"", buffer_len, buffer_len, buffer);
+    LOG_ARG("buffer_len: %u, buffer: \"%.*s\"", buffer_len, buffer_len, STR_NULL2EMPTY(buffer));
 
     if (uriP == NULL) return 0;
 


### PR DESCRIPTION
Doing this is undefined behaviour, and causes crashes with certain
compilers/C libraries. The LOG_ARG macro is defined to function as
printf.

This was causing issues when running wakaama with logs enabled.

I went through all of the LOG_ARG calls, and wrapped any string args
which could be NULL in a helper macro which swaps them for an empty
string.

Signed-off-by: Ciaran Woodward <c.woodward@cascoda.com>