### PR TITLE
Improve portability

### DIFF
--- a/core/block1.c
+++ b/core/block1.c
@@ -71,12 +71,12 @@ uint8_t coap_block1_handler(lwm2m_block1_data_t ** pBlock1Data,
        }
        else
        {
-           block1Data = lwm2m_malloc(sizeof(lwm2m_block1_data_t));
+           block1Data = (lwm2m_block1_data_t*) lwm2m_malloc(sizeof(lwm2m_block1_data_t));
            *pBlock1Data = block1Data;
            if (NULL == block1Data) return COAP_500_INTERNAL_SERVER_ERROR;
        }
 
-       block1Data->block1buffer = lwm2m_malloc(length);
+       block1Data->block1buffer = (uint8_t*) lwm2m_malloc(length);
        block1Data->block1bufferSize = length;
 
        // write new block in buffer
@@ -112,7 +112,7 @@ uint8_t coap_block1_handler(lwm2m_block1_data_t ** pBlock1Data,
           }
           // re-alloc new buffer
           block1Data->block1bufferSize = oldSize+length;
-          block1Data->block1buffer = lwm2m_malloc(block1Data->block1bufferSize);
+          block1Data->block1buffer = (uint8_t*) lwm2m_malloc(block1Data->block1bufferSize);
           if (NULL == block1Data->block1buffer) return COAP_500_INTERNAL_SERVER_ERROR;
           memcpy(block1Data->block1buffer, oldBuffer, oldSize);
           lwm2m_free(oldBuffer);

--- a/core/er-coap-13/er-coap-13.c
+++ b/core/er-coap-13/er-coap-13.c
@@ -322,7 +322,7 @@ char * coap_get_multi_option_as_string(multi_option_t * option)
        len += opt->len + 1;     // for separator
     }
 
-    output = lwm2m_malloc(len + 1); // for String terminator
+    output = (char*) lwm2m_malloc(len + 1); // for String terminator
     if (output != NULL)
     {
         size_t i = 0;
@@ -630,7 +630,7 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
 
   /* parse header fields */
   coap_pkt->version = (COAP_HEADER_VERSION_MASK & coap_pkt->buffer[0])>>COAP_HEADER_VERSION_POSITION;
-  coap_pkt->type = (COAP_HEADER_TYPE_MASK & coap_pkt->buffer[0])>>COAP_HEADER_TYPE_POSITION;
+  coap_pkt->type = (coap_message_type_t) ((COAP_HEADER_TYPE_MASK & coap_pkt->buffer[0])>>COAP_HEADER_TYPE_POSITION);
   coap_pkt->token_len = MIN(COAP_TOKEN_LEN, (COAP_HEADER_TOKEN_LEN_MASK & coap_pkt->buffer[0])>>COAP_HEADER_TOKEN_LEN_POSITION);
   coap_pkt->code = coap_pkt->buffer[1];
   coap_pkt->mid = coap_pkt->buffer[2]<<8 | coap_pkt->buffer[3];
@@ -716,7 +716,7 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
     switch (option_number)
     {
       case COAP_OPTION_CONTENT_TYPE:
-        coap_pkt->content_type = coap_parse_int_option(current_option, option_length);
+        coap_pkt->content_type = (coap_content_type_t) coap_parse_int_option(current_option, option_length);
         PRINTF("Content-Format [%u]\n", coap_pkt->content_type);
         break;
       case COAP_OPTION_MAX_AGE:

--- a/core/registration.c
+++ b/core/registration.c
@@ -697,7 +697,7 @@ static uint8_t prv_register(lwm2m_context_t * contextP,
 
     payload_length = object_getRegisterPayloadBufferLength(contextP);
     if(payload_length == 0) return COAP_500_INTERNAL_SERVER_ERROR;
-    payload = lwm2m_malloc(payload_length);
+    payload = (uint8_t*) lwm2m_malloc(payload_length);
     if(!payload) return COAP_500_INTERNAL_SERVER_ERROR;
     payload_length = object_getRegisterPayload(contextP, payload, payload_length);
     if(payload_length == 0)
@@ -712,7 +712,7 @@ static uint8_t prv_register(lwm2m_context_t * contextP,
         lwm2m_free(payload);
         return COAP_500_INTERNAL_SERVER_ERROR;
     }
-    query = lwm2m_malloc(query_length);
+    query = (char*) lwm2m_malloc(query_length);
     if(!query)
     {
         lwm2m_free(payload);
@@ -826,7 +826,7 @@ static int prv_updateRegistration(lwm2m_context_t * contextP,
             return COAP_500_INTERNAL_SERVER_ERROR;
         }
 
-        payload = lwm2m_malloc(payload_length);
+        payload = (uint8_t*) lwm2m_malloc(payload_length);
         if(!payload)
         {
             transaction_free(transaction);

--- a/core/senml_json.c
+++ b/core/senml_json.c
@@ -474,7 +474,7 @@ static bool prv_convertValue(const _record_t * recordP,
             uint8_t *data;
             dataLength = utils_base64GetDecodedSize((const char *)recordP->value.value.asBuffer.buffer,
                                                     recordP->value.value.asBuffer.length);
-            data = lwm2m_malloc(dataLength);
+            data = (uint8_t*) lwm2m_malloc(dataLength);
             if (!data) return false;
             dataLength = utils_base64Decode((const char *)recordP->value.value.asBuffer.buffer,
                                    recordP->value.value.asBuffer.length,

--- a/core/transaction.c
+++ b/core/transaction.c
@@ -119,7 +119,7 @@ static int prv_checkFinished(lwm2m_transaction_t * transacP,
 {
     int len;
     uint8_t* token;
-    coap_packet_t * transactionMessage = transacP->message;
+    coap_packet_t * transactionMessage = (coap_packet_t *) transacP->message;
 
     if (COAP_DELETE < transactionMessage->code)
     {


### PR DESCRIPTION
Make explicit typecasts to avoid compiler errors/warnings.

Signed-off-by: Leif Sandstrom <leif.sandstrom@husqvarnagroup.com>

Encountered during porting effort (suppressing by supplying compiler flag(s) was not possible in the intended use case)