### PR TITLE
Remove incomplete error state in transaction_new

### DIFF
--- a/coap/transaction.c
+++ b/coap/transaction.c
@@ -240,6 +240,11 @@ lwm2m_transaction_t * transaction_new(void * sessionH,
 
 error:
     LOG("Exiting on failure");
+    if(transacP->message)
+    {
+        coap_free_header(transacP->message);
+        lwm2m_free(transacP->message);
+    }
     lwm2m_free(transacP);
     return NULL;
 }


### PR DESCRIPTION
Discovered what looked like a potential memory leak in the 'error' state of transaction_new. However it wasn't actually possible to hit this state without a programmer error (utils_intToText will never fail with a length 6 buffer and a uint16_t int)... but the state did exist and didn't properly clear up. One option was to correct it, so that it cleaned up properly:

```C
error:
    LOG("Exiting on failure");
    if(transacP->message) 
    {
        coap_free_header(transacP->message);
        lwm2m_free(transacP->message);
    }
    lwm2m_free(transacP);
    return NULL;
```

But I figured it was cleaner to just remove the unused & incomplete code.
