### PR TITLE
Add received message size check

### DIFF
--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -624,6 +624,10 @@ int main(int argc, char *argv[])
                 {
                     fprintf(stderr, "Error in recvfrom(): %d\r\n", errno);
                 }
+                else if (numBytes >= MAX_PACKET_SIZE) 
+                {
+                    fprintf(stderr, "Received packet >= MAX_PACKET_SIZE\r\n");
+                } 
                 else
                 {
                     char s[INET6_ADDRSTRLEN];

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -80,7 +80,7 @@
 #include <errno.h>
 #include <signal.h>
 
-#define MAX_PACKET_SIZE 1024
+#define MAX_PACKET_SIZE 2048
 #define DEFAULT_SERVER_IPV6 "[::1]"
 #define DEFAULT_SERVER_IPV4 "127.0.0.1"
 
@@ -1297,6 +1297,10 @@ int main(int argc, char *argv[])
                 {
                     fprintf(stderr, "Error in recvfrom(): %d %s\r\n", errno, strerror(errno));
                 }
+                else if (numBytes >= MAX_PACKET_SIZE) 
+                {
+                    fprintf(stderr, "Received packet >= MAX_PACKET_SIZE\r\n");
+                } 
                 else if (0 < numBytes)
                 {
                     char s[INET6_ADDRSTRLEN];

--- a/examples/lightclient/lightclient.c
+++ b/examples/lightclient/lightclient.c
@@ -83,7 +83,7 @@ extern char * get_server_uri(lwm2m_object_t * objectP, uint16_t secObjInstID);
 extern lwm2m_object_t * get_test_object(void);
 extern void free_test_object(lwm2m_object_t * object);
 
-#define MAX_PACKET_SIZE 1024
+#define MAX_PACKET_SIZE 2048
 
 int g_reboot = 0;
 static int g_quit = 0;
@@ -514,6 +514,10 @@ int main(int argc, char *argv[])
                 {
                     fprintf(stderr, "Error in recvfrom(): %d %s\r\n", errno, strerror(errno));
                 }
+                else if (numBytes >= MAX_PACKET_SIZE) 
+                {
+                    fprintf(stderr, "Received packet >= MAX_PACKET_SIZE\r\n");
+                } 
                 else if (0 < numBytes)
                 {
                     connection_t * connP;

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -74,7 +74,7 @@
 #include "commandline.h"
 #include "connection.h"
 
-#define MAX_PACKET_SIZE 1024
+#define MAX_PACKET_SIZE 2048
 
 static int g_quit = 0;
 
@@ -1140,6 +1140,10 @@ int main(int argc, char *argv[])
                 {
                     fprintf(stderr, "Error in recvfrom(): %d\r\n", errno);
                 }
+                else if (numBytes >= MAX_PACKET_SIZE) 
+                {
+                    fprintf(stderr, "Received packet >= MAX_PACKET_SIZE\r\n");
+                } 
                 else
                 {
                     char s[INET6_ADDRSTRLEN];


### PR DESCRIPTION
Received packets >= MAX_PACKET_SIZE are dropped. MAX_PACKET_SIZE increased to 2048

Signed-off-by: Leif Sandstrom <leif.sandstrom@husqvarnagroup.com>

Resolves #509 