### PR TITLE
Fix for issue #440: Crash with client in DTLS when "quit" is usedInco…

### DIFF
--- a/core/management.c
+++ b/core/management.c
@@ -183,7 +183,7 @@ uint8_t dm_handleRequest(lwm2m_context_t * contextP,
 
     if (uriP->objectId == LWM2M_SECURITY_OBJECT_ID)
     {
-        return COAP_404_NOT_FOUND;
+        return COAP_401_UNAUTHORIZED;
     }
 
     if (serverP->status != STATE_REGISTERED


### PR DESCRIPTION
…rrect CoAP result on security object action made by the DM server

Signed-off-by: Frederic DUR <fdur@sierrawireless.com>

Fix for issue #440 by Frederic DUR (all credits intact)