### PR TITLE
Add example client support for full UTC offset range

### DIFF
--- a/examples/client/object_device.c
+++ b/examples/client/object_device.c
@@ -136,7 +136,7 @@ static int prv_check_time_offset(char * buffer,
         if (buffer[2] < '0' || buffer[2] > '9') return 0;
         break;
     case '1':
-        if (buffer[2] < '0' || buffer[2] > '2') return 0;
+        if (buffer[2] < '0' || (buffer[0] == '-' && buffer[2] > '2') || (buffer[0] == '+' && buffer[2] > '4')) return 0;
         break;
     default:
         return 0;


### PR DESCRIPTION
Extending range to include UTC+13, UTC+14

Signed-off-by: Leif Sandstrom <leif.sandstrom@husqvarnagroup.com>

Bugfix for #452. Wakaama example client now proudly support UTC+13, UTC+14 [Line_Islands](https://en.wikipedia.org/wiki/Line_Islands)