### PR TITLE
Add context to all callbacks

### DIFF
--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -1102,7 +1102,7 @@ uint8_t bootstrap_handleRequest(lwm2m_context_t * contextP,
     memcpy(name, message->uri_query->data + QUERY_NAME_LEN, message->uri_query->len - QUERY_NAME_LEN);
     name[message->uri_query->len - QUERY_NAME_LEN] = 0;
 
-    result = contextP->bootstrapCallback(fromSessionH, COAP_NO_ERROR, NULL, name, format, message->payload, message->payload_len, contextP->bootstrapUserData);
+    result = contextP->bootstrapCallback(contextP, fromSessionH, COAP_NO_ERROR, NULL, name, format, message->payload, message->payload_len, contextP->bootstrapUserData);
 
     lwm2m_free(name);
 
@@ -1138,7 +1138,8 @@ static void prv_resultCallback(lwm2m_context_t * contextP,
 
     if (message == NULL)
     {
-        dataP->callback(transacP->peerH,
+        dataP->callback(contextP,
+                        transacP->peerH,
                         COAP_503_SERVICE_UNAVAILABLE,
                         uriP,
                         NULL,
@@ -1151,7 +1152,8 @@ static void prv_resultCallback(lwm2m_context_t * contextP,
     {
         coap_packet_t * packet = (coap_packet_t *)message;
 
-        dataP->callback(transacP->peerH,
+        dataP->callback(contextP,
+                        transacP->peerH,
                         packet->code,
                         uriP,
                         NULL,

--- a/core/management.c
+++ b/core/management.c
@@ -421,7 +421,7 @@ static void prv_resultCallback(lwm2m_context_t * contextP,
 
     if (message == NULL)
     {
-        dataP->callback(dataP->clientID,
+        dataP->callback(contextP, dataP->clientID,
                         &dataP->uri, COAP_503_SERVICE_UNAVAILABLE, NULL,
                         LWM2M_CONTENT_TEXT, NULL, 0,
                         dataP->userData);
@@ -477,12 +477,12 @@ static void prv_resultCallback(lwm2m_context_t * contextP,
             block_info.block_num = block_num;
             block_info.block_size = block_size;
             block_info.block_more = block_more;
-            dataP->callback(dataP->clientID,
+            dataP->callback(contextP, dataP->clientID,
                             &dataP->uri, packet->code, &block_info,
                             utils_convertMediaType(packet->content_type), packet->payload, packet->payload_len,
                             dataP->userData);
         } else {
-            dataP->callback(dataP->clientID,
+            dataP->callback(contextP, dataP->clientID,
                             &dataP->uri, packet->code, NULL,
                             utils_convertMediaType(packet->content_type), packet->payload, packet->payload_len,
                             dataP->userData);

--- a/core/objects.c
+++ b/core/objects.c
@@ -59,7 +59,8 @@
 #include <string.h>
 #include <stdio.h>
 
-static int prv_getMandatoryInfo(lwm2m_object_t * objectP,
+static int prv_getMandatoryInfo(lwm2m_context_t *contextP,
+                                lwm2m_object_t * objectP,
                                 uint16_t instanceID,
                                 lwm2m_server_t * targetP)
 {
@@ -73,7 +74,7 @@ static int prv_getMandatoryInfo(lwm2m_object_t * objectP,
     dataP[0].id = LWM2M_SERVER_LIFETIME_ID;
     dataP[1].id = LWM2M_SERVER_BINDING_ID;
 
-    if (objectP->readFunc(instanceID, &size, &dataP, objectP) != COAP_205_CONTENT)
+    if (objectP->readFunc(contextP, instanceID, &size, &dataP, objectP) != COAP_205_CONTENT)
     {
         lwm2m_data_free(size, dataP);
         return -1;
@@ -149,7 +150,7 @@ uint8_t object_checkReadable(lwm2m_context_t * contextP,
     }
 #endif
 
-    result = targetP->readFunc(uriP->instanceId, &size, &dataP, targetP);
+    result = targetP->readFunc(contextP, uriP->instanceId, &size, &dataP, targetP);
     if (result == COAP_205_CONTENT)
     {
         if (attrP->toSet & ATTR_FLAG_NUMERIC)
@@ -212,7 +213,7 @@ uint8_t object_readData(lwm2m_context_t * contextP,
 #endif
         }
 
-        result = targetP->readFunc(uriP->instanceId, sizeP, dataP, targetP);
+        result = targetP->readFunc(contextP, uriP->instanceId, sizeP, dataP, targetP);
     }
     else
     {
@@ -241,7 +242,7 @@ uint8_t object_readData(lwm2m_context_t * contextP,
             i = 0;
             while (instanceP != NULL && result == COAP_205_CONTENT)
             {
-                result = targetP->readFunc(instanceP->id, (int*)&((*dataP)[i].value.asChildren.count), &((*dataP)[i].value.asChildren.array), targetP);
+                result = targetP->readFunc(contextP, instanceP->id, (int*)&((*dataP)[i].value.asChildren.count), &((*dataP)[i].value.asChildren.array), targetP);
                 (*dataP)[i].type = LWM2M_TYPE_OBJECT_INSTANCE;
                 (*dataP)[i].id = instanceP->id;
                 i++;
@@ -309,7 +310,7 @@ uint8_t object_read(lwm2m_context_t * contextP,
 }
 
 // Get the short id from a server object. Valid range 1-65535. Returns 0 if error.
-static uint16_t prv_getServerShortId(lwm2m_object_t *serverObjectP, uint16_t instanceId)
+static uint16_t prv_getServerShortId(lwm2m_context_t *contextP, lwm2m_object_t *serverObjectP, uint16_t instanceId)
 {
     int64_t value;
     lwm2m_data_t * dataP;
@@ -320,7 +321,7 @@ static uint16_t prv_getServerShortId(lwm2m_object_t *serverObjectP, uint16_t ins
     if (dataP == NULL) return 0;
     dataP->id = LWM2M_SERVER_SHORT_ID_ID;
 
-    if (serverObjectP->readFunc(instanceId, &size, &dataP, serverObjectP) != COAP_205_CONTENT)
+    if (serverObjectP->readFunc(contextP, instanceId, &size, &dataP, serverObjectP) != COAP_205_CONTENT)
     {
         lwm2m_data_free(size, dataP);
         return 0;
@@ -343,7 +344,7 @@ static uint16_t prv_getServerShortId(lwm2m_object_t *serverObjectP, uint16_t ins
 // Update the server info of an already in-use server
 static void prv_updateServerInfo(lwm2m_context_t * contextP, lwm2m_object_t *serverObjectP, uint16_t instanceId)
 {
-    uint16_t serverId = prv_getServerShortId(serverObjectP, instanceId);
+    uint16_t serverId = prv_getServerShortId(contextP, serverObjectP, instanceId);
     lwm2m_server_t *serverP = (lwm2m_server_t *)contextP->serverList;
 
     if(serverId == 0)
@@ -355,7 +356,7 @@ static void prv_updateServerInfo(lwm2m_context_t * contextP, lwm2m_object_t *ser
     }
     if(serverP)
     {
-        prv_getMandatoryInfo(serverObjectP, instanceId, serverP);
+        prv_getMandatoryInfo(contextP, serverObjectP, instanceId, serverP);
     }
 }
 
@@ -419,7 +420,7 @@ uint8_t object_write(lwm2m_context_t * contextP,
                 writeType = LWM2M_WRITE_REPLACE_INSTANCE;
             }
         }
-        result = targetP->writeFunc(uriP->instanceId, size, dataP, targetP, writeType);
+        result = targetP->writeFunc(contextP, uriP->instanceId, size, dataP, targetP, writeType);
 
         if(result == COAP_204_CHANGED && targetP->objID == LWM2M_SERVER_OBJECT_ID)
         {
@@ -448,7 +449,7 @@ uint8_t object_execute(lwm2m_context_t * contextP,
     if (NULL == targetP->executeFunc) return COAP_405_METHOD_NOT_ALLOWED;
     if (NULL == lwm2m_list_find(targetP->instanceList, uriP->instanceId)) return COAP_404_NOT_FOUND;
 
-    return targetP->executeFunc(uriP->instanceId, uriP->resourceId, buffer, length, targetP);
+    return targetP->executeFunc(contextP, uriP->instanceId, uriP->resourceId, buffer, length, targetP);
 }
 
 uint8_t object_create(lwm2m_context_t * contextP,
@@ -494,7 +495,7 @@ uint8_t object_create(lwm2m_context_t * contextP,
             result = COAP_406_NOT_ACCEPTABLE;
             goto exit;
         }
-        result = targetP->createFunc(dataP[0].id, dataP[0].value.asChildren.count, dataP[0].value.asChildren.array, targetP);
+        result = targetP->createFunc(contextP, dataP[0].id, dataP[0].value.asChildren.count, dataP[0].value.asChildren.array, targetP);
         uriP->instanceId = dataP[0].id;
         break;
 
@@ -503,7 +504,7 @@ uint8_t object_create(lwm2m_context_t * contextP,
         {
             uriP->instanceId = lwm2m_list_newId(targetP->instanceList);
         }
-        result = targetP->createFunc(uriP->instanceId, size, dataP, targetP);
+        result = targetP->createFunc(contextP, uriP->instanceId, size, dataP, targetP);
         break;
     }
 
@@ -622,7 +623,7 @@ uint8_t object_delete(lwm2m_context_t * contextP,
 
     if (LWM2M_URI_IS_SET_INSTANCE(uriP))
     {
-        result = objectP->deleteFunc(uriP->instanceId, objectP);
+        result = objectP->deleteFunc(contextP, uriP->instanceId, objectP);
         if (result == COAP_202_DELETED)
         {
             observe_clear(contextP, uriP);
@@ -640,7 +641,7 @@ uint8_t object_delete(lwm2m_context_t * contextP,
         while (NULL != instanceP
             && result == COAP_202_DELETED)
         {
-            result = objectP->deleteFunc(instanceP->id, objectP);
+            result = objectP->deleteFunc(contextP, instanceP->id, objectP);
             if (result == COAP_202_DELETED)
             {
                 tempUri.instanceId = instanceP->id;
@@ -685,7 +686,7 @@ uint8_t object_discover(lwm2m_context_t * contextP,
             dataP->id = uriP->resourceId;
         }
 
-        result = targetP->discoverFunc(uriP->instanceId, &size, &dataP, targetP);
+        result = targetP->discoverFunc(contextP, uriP->instanceId, &size, &dataP, targetP);
     }
     else
     {
@@ -710,7 +711,7 @@ uint8_t object_discover(lwm2m_context_t * contextP,
             i = 0;
             while (instanceP != NULL && result == COAP_205_CONTENT)
             {
-                result = targetP->discoverFunc(instanceP->id, (int*)&(dataP[i].value.asChildren.count), &(dataP[i].value.asChildren.array), targetP);
+                result = targetP->discoverFunc(contextP, instanceP->id, (int*)&(dataP[i].value.asChildren.count), &(dataP[i].value.asChildren.array), targetP);
                 dataP[i].type = LWM2M_TYPE_OBJECT_INSTANCE;
                 dataP[i].id = instanceP->id;
                 i++;
@@ -990,7 +991,8 @@ int object_getRegisterPayload(lwm2m_context_t * contextP,
     return index;
 }
 
-static lwm2m_list_t * prv_findServerInstance(lwm2m_object_t * objectP,
+static lwm2m_list_t * prv_findServerInstance(lwm2m_context_t *contextP,
+                                             lwm2m_object_t * objectP,
                                              uint16_t shortID)
 {
     lwm2m_list_t * instanceP;
@@ -1007,7 +1009,7 @@ static lwm2m_list_t * prv_findServerInstance(lwm2m_object_t * objectP,
         if (dataP == NULL) return NULL;
         dataP->id = LWM2M_SERVER_SHORT_ID_ID;
 
-        if (objectP->readFunc(instanceP->id, &size, &dataP, objectP) != COAP_205_CONTENT)
+        if (objectP->readFunc(contextP, instanceP->id, &size, &dataP, objectP) != COAP_205_CONTENT)
         {
             lwm2m_data_free(size, dataP);
             return NULL;
@@ -1070,7 +1072,7 @@ int object_getServers(lwm2m_context_t * contextP, bool checkOnly)
             if (dataP == NULL) return -1;
             dataP[0].id = LWM2M_SECURITY_BOOTSTRAP_ID;
 
-            if (securityObjP->readFunc(securityInstP->id, &size, &dataP, securityObjP) != COAP_205_CONTENT)
+            if (securityObjP->readFunc(contextP, securityInstP->id, &size, &dataP, securityObjP) != COAP_205_CONTENT)
             {
                 lwm2m_data_free(size, dataP);
                 return -1;
@@ -1107,7 +1109,7 @@ int object_getServers(lwm2m_context_t * contextP, bool checkOnly)
                     return -1;
                 }
                 dataP[0].id = LWM2M_SECURITY_HOLD_OFF_ID;
-                if (securityObjP->readFunc(securityInstP->id, &size, &dataP, securityObjP) != COAP_205_CONTENT)
+                if (securityObjP->readFunc(contextP, securityInstP->id, &size, &dataP, securityObjP) != COAP_205_CONTENT)
                 {
                     lwm2m_free(targetP);
                     lwm2m_data_free(size, dataP);
@@ -1145,7 +1147,7 @@ int object_getServers(lwm2m_context_t * contextP, bool checkOnly)
                     return -1;
                 }
                 dataP[0].id = LWM2M_SECURITY_SHORT_SERVER_ID;
-                if (securityObjP->readFunc(securityInstP->id, &size, &dataP, securityObjP) != COAP_205_CONTENT)
+                if (securityObjP->readFunc(contextP, securityInstP->id, &size, &dataP, securityObjP) != COAP_205_CONTENT)
                 {
                     lwm2m_free(targetP);
                     lwm2m_data_free(size, dataP);
@@ -1160,7 +1162,7 @@ int object_getServers(lwm2m_context_t * contextP, bool checkOnly)
                 }
                 targetP->shortID = value;
 
-                serverInstP = prv_findServerInstance(serverObjP, targetP->shortID);
+                serverInstP = prv_findServerInstance(contextP, serverObjP, targetP->shortID);
                 if (serverInstP == NULL)
                 {
                     lwm2m_free(targetP);
@@ -1170,7 +1172,7 @@ int object_getServers(lwm2m_context_t * contextP, bool checkOnly)
 #ifndef LWM2M_VERSION_1_0
                     targetP->servObjInstID = serverInstP->id;
 #endif
-                    if (0 != prv_getMandatoryInfo(serverObjP, serverInstP->id, targetP))
+                    if (0 != prv_getMandatoryInfo(contextP, serverObjP, serverInstP->id, targetP))
                     {
                         lwm2m_free(targetP);
                         lwm2m_data_free(size, dataP);
@@ -1210,7 +1212,7 @@ uint8_t object_createInstance(lwm2m_context_t * contextP,
         return COAP_405_METHOD_NOT_ALLOWED;
     }
 
-    return targetP->createFunc(lwm2m_list_newId(targetP->instanceList), dataP->value.asChildren.count, dataP->value.asChildren.array, targetP);
+    return targetP->createFunc(contextP, lwm2m_list_newId(targetP->instanceList), dataP->value.asChildren.count, dataP->value.asChildren.array, targetP);
 }
 
 uint8_t object_writeInstance(lwm2m_context_t * contextP,
@@ -1228,7 +1230,7 @@ uint8_t object_writeInstance(lwm2m_context_t * contextP,
         return COAP_405_METHOD_NOT_ALLOWED;
     }
 
-    return targetP->writeFunc(dataP->id, dataP->value.asChildren.count, dataP->value.asChildren.array, targetP, LWM2M_WRITE_REPLACE_INSTANCE);
+    return targetP->writeFunc(contextP, dataP->id, dataP->value.asChildren.count, dataP->value.asChildren.array, targetP, LWM2M_WRITE_REPLACE_INSTANCE);
 }
 
 #endif

--- a/core/observe.c
+++ b/core/observe.c
@@ -917,7 +917,8 @@ static void prv_obsRequestCallback(lwm2m_context_t * contextP,
         if (has_block2)
         {
             // Do we need a block transfer here?
-            observationData->callback(observationData->client,
+            observationData->callback(contextP,
+                                      observationData->client,
                                       &observationData->uri,
                                       COAP_500_INTERNAL_SERVER_ERROR,  //?
                                       &block_info,
@@ -926,7 +927,8 @@ static void prv_obsRequestCallback(lwm2m_context_t * contextP,
         }
         else
         {
-            observationData->callback(observationData->client,
+            observationData->callback(contextP,
+                                      observationData->client,
                                       &observationData->uri,
                                       COAP_500_INTERNAL_SERVER_ERROR,  //?
                                       NULL,
@@ -960,7 +962,8 @@ static void prv_obsRequestCallback(lwm2m_context_t * contextP,
 
     if (code != COAP_205_CONTENT || (IS_OPTION(packet, COAP_OPTION_BLOCK2) && packet->block2_more))
     {
-        observationData->callback(observationData->client,
+        observationData->callback(contextP,
+                                  observationData->client,
                                   &observationData->uri,
                                   code,  //?
                                   NULL,
@@ -983,7 +986,8 @@ static void prv_obsRequestCallback(lwm2m_context_t * contextP,
 
             // give the user chance to free previous observation userData
             // indicator: COAP_202_DELETED and (Length ==0)
-            observationData->callback(observationData->client,
+            observationData->callback(contextP,
+                                      observationData->client,
                                       &observationData->uri,
                                       COAP_202_DELETED,
                                       NULL,
@@ -1004,7 +1008,8 @@ static void prv_obsRequestCallback(lwm2m_context_t * contextP,
         const int status = 0;
 
         if (has_block2) {
-            observationData->callback(observationData->client,
+            observationData->callback(contextP,
+                                      observationData->client,
                                       &observationData->uri,
                                       status,
                                       &block_info,
@@ -1013,7 +1018,8 @@ static void prv_obsRequestCallback(lwm2m_context_t * contextP,
                                       packet->payload_len,
                                       observationData->userData);
         } else {
-            observationData->callback(observationData->client,
+            observationData->callback(contextP,
+                                      observationData->client,
                                       &observationData->uri,
                                       status,
                                       NULL,
@@ -1054,7 +1060,8 @@ static void prv_obsCancelRequestCallback(lwm2m_context_t * contextP,
     {
         if (has_block2)
         {
-            cancelP->callbackP(cancelP->client,
+            cancelP->callbackP(contextP,
+                               cancelP->client,
                                &cancelP->uri,
                                COAP_500_INTERNAL_SERVER_ERROR,  //?
                                &block_info,
@@ -1065,7 +1072,8 @@ static void prv_obsCancelRequestCallback(lwm2m_context_t * contextP,
         }
         else
         {
-            cancelP->callbackP(cancelP->client,
+            cancelP->callbackP(contextP,
+                               cancelP->client,
                                &cancelP->uri,
                                COAP_500_INTERNAL_SERVER_ERROR,  //?
                                NULL,
@@ -1092,7 +1100,8 @@ static void prv_obsCancelRequestCallback(lwm2m_context_t * contextP,
     {
         if (has_block2)
         {
-            cancelP->callbackP(cancelP->client,
+            cancelP->callbackP(contextP,
+                               cancelP->client,
                                &cancelP->uri,
                                code,  //?
                                &block_info,
@@ -1103,7 +1112,8 @@ static void prv_obsCancelRequestCallback(lwm2m_context_t * contextP,
         }
         else
         {
-            cancelP->callbackP(cancelP->client,
+            cancelP->callbackP(contextP,
+                               cancelP->client,
                                &cancelP->uri,
                                code,  //?
                                NULL,
@@ -1118,7 +1128,8 @@ static void prv_obsCancelRequestCallback(lwm2m_context_t * contextP,
         const int status = 0;
         if (has_block2)
         {
-            cancelP->callbackP(cancelP->client,
+            cancelP->callbackP(contextP,
+                               cancelP->client,
                                &cancelP->uri,
                                status,  //?
                                &block_info,
@@ -1129,7 +1140,8 @@ static void prv_obsCancelRequestCallback(lwm2m_context_t * contextP,
         }
         else
         {
-            cancelP->callbackP(cancelP->client,
+            cancelP->callbackP(contextP,
+                               cancelP->client,
                                &cancelP->uri,
                                status,  //?
                                NULL,
@@ -1386,14 +1398,16 @@ bool observe_handleNotify(lwm2m_context_t * contextP,
             block_info.block_num = block_num;
             block_info.block_size = block_size;
             block_info.block_more = block_more;
-            observationP->callback(clientID,
+            observationP->callback(contextP,
+                                   clientID,
                                    &observationP->uri,
                                    (int)count,
                                    &block_info,
                                    utils_convertMediaType(message->content_type), message->payload, message->payload_len,
                                    observationP->userData);
         } else {
-            observationP->callback(clientID,
+            observationP->callback(contextP,
+                                   clientID,
                                    &observationP->uri,
                                    (int)count,
                                    NULL,

--- a/core/registration.c
+++ b/core/registration.c
@@ -253,7 +253,8 @@ static int prv_getRegistrationQuery(lwm2m_context_t * contextP,
 }
 
 #ifndef LWM2M_VERSION_1_0
-static uint8_t prv_readUint(lwm2m_object_t *objP,
+static uint8_t prv_readUint(lwm2m_context_t *contextP,
+                            lwm2m_object_t *objP,
                             uint16_t instanceId,
                             uint16_t resourceId,
                             uint64_t *valueP)
@@ -266,7 +267,7 @@ static uint8_t prv_readUint(lwm2m_object_t *objP,
         return COAP_500_INTERNAL_SERVER_ERROR;
     }
     dataP[0].id = resourceId;
-    result = objP->readFunc(instanceId, &size, &dataP, objP);
+    result = objP->readFunc(contextP, instanceId, &size, &dataP, objP);
     if (result == COAP_205_CONTENT)
     {
         if (lwm2m_data_decode_uint(dataP, valueP))
@@ -282,7 +283,8 @@ static uint8_t prv_readUint(lwm2m_object_t *objP,
     return result;
 }
 
-static uint8_t prv_readBoolean(lwm2m_object_t *objP,
+static uint8_t prv_readBoolean(lwm2m_context_t *contextP,
+                               lwm2m_object_t *objP,
                                uint16_t instanceId,
                                uint16_t resourceId,
                                bool *valueP)
@@ -295,7 +297,7 @@ static uint8_t prv_readBoolean(lwm2m_object_t *objP,
         return COAP_500_INTERNAL_SERVER_ERROR;
     }
     dataP[0].id = resourceId;
-    result = objP->readFunc(instanceId, &size, &dataP, objP);
+    result = objP->readFunc(contextP, instanceId, &size, &dataP, objP);
     if (result == COAP_205_CONTENT)
     {
         if (lwm2m_data_decode_bool(dataP, valueP))
@@ -311,13 +313,15 @@ static uint8_t prv_readBoolean(lwm2m_object_t *objP,
     return result;
 }
 
-static uint8_t prv_getRegistrationOrder(lwm2m_server_t *targetP,
+static uint8_t prv_getRegistrationOrder(lwm2m_context_t *contextP,
+                                        lwm2m_server_t *targetP,
                                         lwm2m_object_t *serverObjP,
                                         bool *orderedP,
                                         uint64_t *orderP)
 {
     uint64_t order;
-    uint8_t result = prv_readUint(serverObjP,
+    uint8_t result = prv_readUint(contextP,
+                                  serverObjP,
                                   targetP->servObjInstID,
                                   LWM2M_SERVER_REG_ORDER_ID,
                                   &order);
@@ -343,12 +347,14 @@ static uint8_t prv_getRegistrationOrder(lwm2m_server_t *targetP,
     return result;
 }
 
-static uint8_t prv_getRegistrationFailureBlocking(lwm2m_server_t *targetP,
+static uint8_t prv_getRegistrationFailureBlocking(lwm2m_context_t *contextP,
+                                                  lwm2m_server_t *targetP,
                                                   lwm2m_object_t *serverObjP,
                                                   bool *blockingP)
 {
     bool blocking;
-    uint8_t result = prv_readBoolean(serverObjP,
+    uint8_t result = prv_readBoolean(contextP,
+                                     serverObjP,
                                      targetP->servObjInstID,
                                      LWM2M_SERVER_REG_FAIL_BLOCK_ID,
                                      &blocking);
@@ -370,14 +376,16 @@ static uint8_t prv_getRegistrationFailureBlocking(lwm2m_server_t *targetP,
     return result;
 }
 
-static uint8_t prv_getRegistrationAttemptLimit(lwm2m_server_t *targetP,
+static uint8_t prv_getRegistrationAttemptLimit(lwm2m_context_t *contextP,
+                                               lwm2m_server_t *targetP,
                                                lwm2m_object_t *serverObjP,
                                                uint8_t *attemptLimitP,
                                                uint64_t *attemptDelayP)
 {
     uint64_t attemptLimit;
     uint64_t attemptDelay;
-    uint8_t result = prv_readUint(serverObjP,
+    uint8_t result = prv_readUint(contextP,
+                                  serverObjP,
                                   targetP->servObjInstID,
                                   LWM2M_SERVER_COMM_RETRY_COUNT_ID,
                                   &attemptLimit);
@@ -388,7 +396,8 @@ static uint8_t prv_getRegistrationAttemptLimit(lwm2m_server_t *targetP,
     }
     if (result == COAP_NO_ERROR)
     {
-        result = prv_readUint(serverObjP,
+        result = prv_readUint(contextP,
+                              serverObjP,
                               targetP->servObjInstID,
                               LWM2M_SERVER_COMM_RETRY_TIMER_ID,
                               &attemptDelay);
@@ -416,14 +425,16 @@ static uint8_t prv_getRegistrationAttemptLimit(lwm2m_server_t *targetP,
     return result;
 }
 
-static uint8_t prv_getRegistrationSequenceLimit(lwm2m_server_t *targetP,
+static uint8_t prv_getRegistrationSequenceLimit(lwm2m_context_t *contextP,
+                                                lwm2m_server_t *targetP,
                                                 lwm2m_object_t *serverObjP,
                                                 uint8_t *sequenceLimitP,
                                                 uint64_t *sequenceDelayP)
 {
     uint64_t sequenceLimit;
     uint64_t sequenceDelay;
-    uint8_t result = prv_readUint(serverObjP,
+    uint8_t result = prv_readUint(contextP,
+                                  serverObjP,
                                   targetP->servObjInstID,
                                   LWM2M_SERVER_SEQ_RETRY_COUNT_ID,
                                   &sequenceLimit);
@@ -434,7 +445,8 @@ static uint8_t prv_getRegistrationSequenceLimit(lwm2m_server_t *targetP,
     }
     if (result == COAP_NO_ERROR)
     {
-        result = prv_readUint(serverObjP,
+        result = prv_readUint(contextP,
+                              serverObjP,
                               targetP->servObjInstID,
                               LWM2M_SERVER_SEQ_DELAY_TIMER_ID,
                               &sequenceDelay);
@@ -462,12 +474,14 @@ static uint8_t prv_getRegistrationSequenceLimit(lwm2m_server_t *targetP,
     return result;
 }
 
-static uint8_t prv_getBootstrapOnRegistrationFailure(lwm2m_server_t *targetP,
+static uint8_t prv_getBootstrapOnRegistrationFailure(lwm2m_context_t *contextP,
+                                                     lwm2m_server_t *targetP,
                                                      lwm2m_object_t *serverObjP,
                                                      bool *bootstrapP)
 {
     bool bootstrap;
-    uint8_t result = prv_readBoolean(serverObjP,
+    uint8_t result = prv_readBoolean(contextP,
+                                     serverObjP,
                                      targetP->servObjInstID,
                                      LWM2M_SERVER_REG_FAIL_BOOTSTRAP_ID,
                                      &bootstrap);
@@ -489,11 +503,13 @@ static uint8_t prv_getBootstrapOnRegistrationFailure(lwm2m_server_t *targetP,
     return result;
 }
 
-static uint8_t prv_startRegistration(lwm2m_server_t* targetP,
+static uint8_t prv_startRegistration(lwm2m_context_t *contextP,
+                                     lwm2m_server_t* targetP,
                                      lwm2m_object_t* serverObjP)
 {
     uint64_t delay;
-    uint8_t result = prv_readUint(serverObjP,
+    uint8_t result = prv_readUint(contextP,
+                                  serverObjP,
                                   targetP->servObjInstID,
                                   LWM2M_SERVER_INITIAL_REG_DELAY_ID,
                                   &delay);
@@ -517,10 +533,10 @@ static void prv_handleRegistrationSequenceFailure(lwm2m_context_t *contextP, lwm
     bool blocking = false;
     uint8_t sequenceLimit;
     uint64_t sequenceDelay;
-    uint8_t result = prv_getRegistrationOrder(targetP, serverObjP, &ordered, NULL);
+    uint8_t result = prv_getRegistrationOrder(contextP, targetP, serverObjP, &ordered, NULL);
     if (result == COAP_NO_ERROR && ordered)
     {
-        result = prv_getRegistrationFailureBlocking(targetP, serverObjP, &blocking);
+        result = prv_getRegistrationFailureBlocking(contextP, targetP, serverObjP, &blocking);
         if (result == COAP_NO_ERROR && !blocking && targetP->sequence == 1)
         {
             /* Find the next ordered registration to start */
@@ -528,7 +544,7 @@ static void prv_handleRegistrationSequenceFailure(lwm2m_context_t *contextP, lwm
         }
     }
 
-    result = prv_getRegistrationSequenceLimit(targetP, serverObjP, &sequenceLimit, &sequenceDelay);
+    result = prv_getRegistrationSequenceLimit(contextP, targetP, serverObjP, &sequenceLimit, &sequenceDelay);
     if (result == COAP_NO_ERROR)
     {
         if (targetP->sequence >= sequenceLimit)
@@ -537,7 +553,7 @@ static void prv_handleRegistrationSequenceFailure(lwm2m_context_t *contextP, lwm
             targetP->status = STATE_REG_FAILED;
             LOG_ARG("%d Registration failed", targetP->shortID);
 
-            result = prv_getBootstrapOnRegistrationFailure(targetP, serverObjP, &bootstrap);
+            result = prv_getBootstrapOnRegistrationFailure(contextP, targetP, serverObjP, &bootstrap);
             if (result != COAP_NO_ERROR || bootstrap)
             {
                 contextP->state = STATE_BOOTSTRAP_REQUIRED;
@@ -549,7 +565,7 @@ static void prv_handleRegistrationSequenceFailure(lwm2m_context_t *contextP, lwm
                 {
                     if (targetP->status == STATE_DEREGISTERED)
                     {
-                        if (prv_getRegistrationOrder(targetP, serverObjP, &ordered, NULL) == COAP_NO_ERROR
+                        if (prv_getRegistrationOrder(contextP, targetP, serverObjP, &ordered, NULL) == COAP_NO_ERROR
                             && ordered)
                         {
                             targetP->status = STATE_REG_FAILED;
@@ -584,7 +600,7 @@ static void prv_handleRegistrationAttemptFailure(lwm2m_context_t *contextP, lwm2
         uint64_t attemptDelay;
         uint8_t result;
 
-        result = prv_getRegistrationAttemptLimit(targetP, serverObjP, &attemptLimit, &attemptDelay);
+        result = prv_getRegistrationAttemptLimit(contextP, targetP, serverObjP, &attemptLimit, &attemptDelay);
         if (result == COAP_NO_ERROR)
         {
             if (targetP->attempt >= attemptLimit)
@@ -662,7 +678,7 @@ static void prv_handleRegistrationReply(lwm2m_context_t * contextP,
                     bool ordered;
                     uint8_t result;
 
-                    result = prv_getRegistrationOrder(dataP->server, serverObjP, &ordered, NULL);
+                    result = prv_getRegistrationOrder(contextP, dataP->server, serverObjP, &ordered, NULL);
                     if (result == COAP_NO_ERROR && ordered)
                     {
                         bool blocking;
@@ -674,7 +690,7 @@ static void prv_handleRegistrationReply(lwm2m_context_t * contextP,
                         }
                         else
                         {
-                            result = prv_getRegistrationFailureBlocking(dataP->server, serverObjP, &blocking);
+                            result = prv_getRegistrationFailureBlocking(contextP, dataP->server, serverObjP, &blocking);
                             if (result == COAP_NO_ERROR && !blocking)
                             {
                                 /* Find the next ordered registration to start */
@@ -1019,7 +1035,7 @@ uint8_t registration_start(lwm2m_context_t * contextP, bool restartFailed)
 
             targetP->attempt = 0;
             targetP->sequence = 0;
-            result = prv_getRegistrationOrder(targetP, serverObjP, &ordered, &order);
+            result = prv_getRegistrationOrder(contextP, targetP, serverObjP, &ordered, &order);
             if (result == COAP_NO_ERROR)
             {
                 if (ordered)
@@ -1032,7 +1048,7 @@ uint8_t registration_start(lwm2m_context_t * contextP, bool restartFailed)
                 }
                 else
                 {
-                    result = prv_startRegistration(targetP, serverObjP);
+                    result = prv_startRegistration(contextP, targetP, serverObjP);
                 }
             }
 #else
@@ -1045,7 +1061,7 @@ uint8_t registration_start(lwm2m_context_t * contextP, bool restartFailed)
 #ifndef LWM2M_VERSION_1_0
     if (firstOrdered)
     {
-        result = prv_startRegistration(firstOrdered, serverObjP);
+        result = prv_startRegistration(contextP, firstOrdered, serverObjP);
     }
 #endif
 
@@ -1881,7 +1897,7 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
 
             if (contextP->monitorCallback != NULL)
             {
-                contextP->monitorCallback(clientP->internalID, NULL, COAP_201_CREATED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+                contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_201_CREATED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
             }
             result = COAP_201_CREATED;
         }
@@ -1933,8 +1949,14 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
                     objP = (lwm2m_client_object_t *)lwm2m_list_find((lwm2m_list_t *)objects, observationP->uri.objectId);
                     if (objP == NULL)
                     {
-                        observationP->callback(observationP->clientP->internalID, &observationP->uri,
-                                               COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0,
+                        observationP->callback(contextP,
+                        		               observationP->clientP->internalID,
+											   &observationP->uri,
+                                               COAP_202_DELETED,
+											   NULL,
+											   LWM2M_CONTENT_TEXT,
+											   NULL,
+											   0,
                                                observationP->userData);
                         observe_remove(observationP);
                     }
@@ -1944,8 +1966,14 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
                         {
                             if (lwm2m_list_find((lwm2m_list_t *)objP->instanceList, observationP->uri.instanceId) == NULL)
                             {
-                                observationP->callback(observationP->clientP->internalID, &observationP->uri,
-                                                       COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0,
+                                observationP->callback(contextP,
+                                		               observationP->clientP->internalID,
+													   &observationP->uri,
+                                                       COAP_202_DELETED,
+													   NULL,
+													   LWM2M_CONTENT_TEXT,
+													   NULL,
+													   0,
                                                        observationP->userData);
                                 observe_remove(observationP);
                             }
@@ -1963,7 +1991,7 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
 
             if (contextP->monitorCallback != NULL)
             {
-                contextP->monitorCallback(clientP->internalID, NULL, COAP_204_CHANGED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+                contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_204_CHANGED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
             }
             result = COAP_204_CHANGED;
         }
@@ -1981,7 +2009,7 @@ uint8_t  registration_handleRequest(lwm2m_context_t * contextP,
         if (clientP == NULL) return COAP_400_BAD_REQUEST;
         if (contextP->monitorCallback != NULL)
         {
-            contextP->monitorCallback(clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+            contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
         }
         registration_freeClient(clientP);
         result = COAP_202_DELETED;
@@ -2101,7 +2129,7 @@ void registration_step(lwm2m_context_t * contextP,
             contextP->clientList = (lwm2m_client_t *)LWM2M_LIST_RM(contextP->clientList, clientP->internalID, NULL);
             if (contextP->monitorCallback != NULL)
             {
-                contextP->monitorCallback(clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
+                contextP->monitorCallback(contextP, clientP->internalID, NULL, COAP_202_DELETED, NULL, LWM2M_CONTENT_TEXT, NULL, 0, contextP->monitorUserData);
             }
             registration_freeClient(clientP);
         }

--- a/examples/client/object_connectivity_moni.c
+++ b/examples/client/object_connectivity_moni.c
@@ -254,13 +254,17 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
     }
 }
 
-static uint8_t prv_read(uint16_t instanceId,
+static uint8_t prv_read(lwm2m_context_t *contextP,
+                        uint16_t instanceId,
                         int * numDataP,
                         lwm2m_data_t ** dataArrayP,
                         lwm2m_object_t * objectP)
 {
     uint8_t result;
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     // this is a single instance object
     if (instanceId != 0)

--- a/examples/client/object_connectivity_stat.c
+++ b/examples/client/object_connectivity_stat.c
@@ -91,10 +91,17 @@ static uint8_t prv_set_tlv(lwm2m_data_t * dataP, conn_s_data_t * connStDataP)
     }
 }
 
-static uint8_t prv_read(uint16_t instanceId, int * numDataP, lwm2m_data_t** dataArrayP, lwm2m_object_t * objectP)
+static uint8_t prv_read(lwm2m_context_t *contextP,
+                        uint16_t instanceId,
+                        int * numDataP,
+                        lwm2m_data_t** dataArrayP,
+                        lwm2m_object_t * objectP)
 {
     uint8_t result;
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     // this is a single instance object
     if (instanceId != 0)
@@ -155,9 +162,16 @@ static void prv_resetCounter(lwm2m_object_t* objectP, bool start)
     myData->collectDataStarted  = start;
 }
 
-static uint8_t prv_exec(uint16_t instanceId, uint16_t resourceId,
-                        uint8_t * buffer, int length, lwm2m_object_t * objectP)
+static uint8_t prv_exec(lwm2m_context_t *contextP,
+                        uint16_t instanceId,
+                        uint16_t resourceId,
+                        uint8_t * buffer,
+                        int length,
+                        lwm2m_object_t * objectP)
 {
+    /* unused parameter */
+    (void)contextP;
+
     // this is a single instance object
     if (instanceId != 0)
     {

--- a/examples/client/object_device.c
+++ b/examples/client/object_device.c
@@ -363,13 +363,17 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP,
     }
 }
 
-static uint8_t prv_device_read(uint16_t instanceId,
+static uint8_t prv_device_read(lwm2m_context_t *contextP,
+                               uint16_t instanceId,
                                int * numDataP,
                                lwm2m_data_t ** dataArrayP,
                                lwm2m_object_t * objectP)
 {
     uint8_t result;
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     // this is a single instance object
     if (instanceId != 0)
@@ -420,13 +424,17 @@ static uint8_t prv_device_read(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_device_discover(uint16_t instanceId,
+static uint8_t prv_device_discover(lwm2m_context_t *contextP,
+                                   uint16_t instanceId,
                                    int * numDataP,
                                    lwm2m_data_t ** dataArrayP,
                                    lwm2m_object_t * objectP)
 {
     uint8_t result;
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     // this is a single instance object
     if (instanceId != 0)
@@ -501,7 +509,8 @@ static uint8_t prv_device_discover(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_device_write(uint16_t instanceId,
+static uint8_t prv_device_write(lwm2m_context_t *contextP,
+                                uint16_t instanceId,
                                 int numData,
                                 lwm2m_data_t * dataArray,
                                 lwm2m_object_t * objectP,
@@ -509,6 +518,9 @@ static uint8_t prv_device_write(uint16_t instanceId,
 {
     int i;
     uint8_t result;
+
+    /* unused parameter */
+    (void)contextP;
 
     // All write types are treated the same here
     (void)writeType;
@@ -572,12 +584,16 @@ static uint8_t prv_device_write(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_device_execute(uint16_t instanceId,
+static uint8_t prv_device_execute(lwm2m_context_t *contextP,
+                                  uint16_t instanceId,
                                   uint16_t resourceId,
                                   uint8_t * buffer,
                                   int length,
                                   lwm2m_object_t * objectP)
 {
+    /* unused parameter */
+    (void)contextP;
+
     // this is a single instance object
     if (instanceId != 0)
     {

--- a/examples/client/object_firmware.c
+++ b/examples/client/object_firmware.c
@@ -71,7 +71,8 @@ typedef struct
     uint8_t delivery_method;
 } firmware_data_t;
 
-static uint8_t prv_firmware_read(uint16_t instanceId,
+static uint8_t prv_firmware_read(lwm2m_context_t *contextP,
+                                 uint16_t instanceId,
                                  int * numDataP,
                                  lwm2m_data_t ** dataArrayP,
                                  lwm2m_object_t * objectP)
@@ -79,6 +80,9 @@ static uint8_t prv_firmware_read(uint16_t instanceId,
     int i;
     uint8_t result;
     firmware_data_t * data = (firmware_data_t*)(objectP->userData);
+
+    /* unused parameter */
+    (void)contextP;
 
     // this is a single instance object
     if (instanceId != 0)
@@ -199,7 +203,8 @@ static uint8_t prv_firmware_read(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_firmware_write(uint16_t instanceId,
+static uint8_t prv_firmware_write(lwm2m_context_t *contextP,
+                                  uint16_t instanceId,
                                   int numData,
                                   lwm2m_data_t * dataArray,
                                   lwm2m_object_t * objectP,
@@ -207,6 +212,9 @@ static uint8_t prv_firmware_write(uint16_t instanceId,
 {
     int i;
     uint8_t result;
+
+    /* unused parameter */
+    (void)contextP;
 
     // All write types are treated the same here
     (void)writeType;
@@ -250,13 +258,17 @@ static uint8_t prv_firmware_write(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_firmware_execute(uint16_t instanceId,
+static uint8_t prv_firmware_execute(lwm2m_context_t *contextP,
+                                    uint16_t instanceId,
                                     uint16_t resourceId,
                                     uint8_t * buffer,
                                     int length,
                                     lwm2m_object_t * objectP)
 {
     firmware_data_t * data = (firmware_data_t*)(objectP->userData);
+
+    /* unused parameter */
+    (void)contextP;
 
     // this is a single instance object
     if (instanceId != 0)

--- a/examples/client/object_location.c
+++ b/examples/client/object_location.c
@@ -160,13 +160,15 @@ static uint8_t prv_res2tlv(lwm2m_data_t* dataP,
   * object, single resources or a sequence of resources
   * see 3GPP TS 23.032 V11.0.0(2012-09) page 23,24.
   * implemented for: HORIZONTAL_VELOCITY_WITH_UNCERTAINT
+  * @param contextP     in,     unused pointer to LWM2M context
   * @param objInstId    in,     instances ID of the location object to read
   * @param numDataP     in/out, pointer to the number of resource to read. 0 is the
   *                             exception for all readable resource of object instance
   * @param tlvArrayP    in/out, TLV data sequence with initialized resource ID to read
   * @param objectP      in,     private location data structure
   */
-static uint8_t prv_location_read(uint16_t objInstId,
+static uint8_t prv_location_read(lwm2m_context_t *contextP,
+                                 uint16_t objInstId,
                                  int*  numDataP,
                                  lwm2m_data_t** tlvArrayP,
                                  lwm2m_object_t*  objectP)
@@ -175,6 +177,9 @@ static uint8_t prv_location_read(uint16_t objInstId,
     int     i;
     uint8_t result = COAP_500_INTERNAL_SERVER_ERROR;
     location_data_t* locDataP = (location_data_t*)(objectP->userData);
+
+    /* unused parameter */
+    (void)contextP;
 
     // defined as single instance object!
     if (objInstId != 0) return COAP_404_NOT_FOUND;

--- a/examples/client/object_security.c
+++ b/examples/client/object_security.c
@@ -134,7 +134,8 @@ static uint8_t prv_get_value(lwm2m_data_t * dataP,
     }
 }
 
-static uint8_t prv_security_read(uint16_t instanceId,
+static uint8_t prv_security_read(lwm2m_context_t *contextP,
+                                 uint16_t instanceId,
                                  int * numDataP,
                                  lwm2m_data_t ** dataArrayP,
                                  lwm2m_object_t * objectP)
@@ -142,6 +143,9 @@ static uint8_t prv_security_read(uint16_t instanceId,
     security_instance_t * targetP;
     uint8_t result;
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     targetP = (security_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -192,7 +196,8 @@ static uint8_t prv_security_read(uint16_t instanceId,
 
 #ifdef LWM2M_BOOTSTRAP
 
-static uint8_t prv_security_write(uint16_t instanceId,
+static uint8_t prv_security_write(lwm2m_context_t *contextP,
+                                  uint16_t instanceId,
                                   int numData,
                                   lwm2m_data_t * dataArray,
                                   lwm2m_object_t * objectP,
@@ -201,6 +206,9 @@ static uint8_t prv_security_write(uint16_t instanceId,
     security_instance_t * targetP;
     int i;
     uint8_t result = COAP_204_CHANGED;
+
+    /* unused parameter */
+    (void)contextP;
 
     /* All write types are ignored. They don't apply during bootstrap. */
     (void)writeType;
@@ -416,10 +424,14 @@ static uint8_t prv_security_write(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_security_delete(uint16_t id,
+static uint8_t prv_security_delete(lwm2m_context_t *contextP,
+                                   uint16_t id,
                                    lwm2m_object_t * objectP)
 {
     security_instance_t * targetP;
+
+    /* unused parameter */
+    (void)contextP;
 
     objectP->instanceList = lwm2m_list_remove(objectP->instanceList, id, (lwm2m_list_t **)&targetP);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -433,7 +445,8 @@ static uint8_t prv_security_delete(uint16_t id,
     return COAP_202_DELETED;
 }
 
-static uint8_t prv_security_create(uint16_t instanceId,
+static uint8_t prv_security_create(lwm2m_context_t *contextP,
+                                   uint16_t instanceId,
                                    int numData,
                                    lwm2m_data_t * dataArray,
                                    lwm2m_object_t * objectP)
@@ -448,11 +461,11 @@ static uint8_t prv_security_create(uint16_t instanceId,
     targetP->instanceId = instanceId;
     objectP->instanceList = LWM2M_LIST_ADD(objectP->instanceList, targetP);
 
-    result = prv_security_write(instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
+    result = prv_security_write(contextP, instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
 
     if (result != COAP_204_CHANGED)
     {
-        (void)prv_security_delete(instanceId, objectP);
+        (void)prv_security_delete(contextP, instanceId, objectP);
     }
     else
     {

--- a/examples/client/object_server.c
+++ b/examples/client/object_server.c
@@ -75,9 +75,11 @@ typedef struct _server_instance_
 #endif
 } server_instance_t;
 
-static uint8_t prv_server_delete(uint16_t id,
+static uint8_t prv_server_delete(lwm2m_context_t *contextP,
+                                 uint16_t id,
                                  lwm2m_object_t * objectP);
-static uint8_t prv_server_create(uint16_t instanceId,
+static uint8_t prv_server_create(lwm2m_context_t *contextP,
+                                 uint16_t instanceId,
                                  int numData,
                                  lwm2m_data_t * dataArray,
                                  lwm2m_object_t * objectP);
@@ -217,7 +219,8 @@ static uint8_t prv_get_value(lwm2m_data_t * dataP,
     }
 }
 
-static uint8_t prv_server_read(uint16_t instanceId,
+static uint8_t prv_server_read(lwm2m_context_t *contextP,
+                               uint16_t instanceId,
                                int * numDataP,
                                lwm2m_data_t ** dataArrayP,
                                lwm2m_object_t * objectP)
@@ -225,6 +228,9 @@ static uint8_t prv_server_read(uint16_t instanceId,
     server_instance_t * targetP;
     uint8_t result;
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     targetP = (server_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -379,7 +385,8 @@ static uint8_t prv_server_read(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_server_discover(uint16_t instanceId,
+static uint8_t prv_server_discover(lwm2m_context_t *contextP,
+                                   uint16_t instanceId,
                                    int * numDataP,
                                    lwm2m_data_t ** dataArrayP,
                                    lwm2m_object_t * objectP)
@@ -387,6 +394,9 @@ static uint8_t prv_server_discover(uint16_t instanceId,
     server_instance_t * targetP;
     uint8_t result;
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     result = COAP_205_CONTENT;
 
@@ -634,7 +644,8 @@ static uint8_t prv_set_int_value(lwm2m_data_t * dataArray, uint32_t * data) {
     return result;
 }
 
-static uint8_t prv_server_write(uint16_t instanceId,
+static uint8_t prv_server_write(lwm2m_context_t *contextP,
+                                uint16_t instanceId,
                                 int numData,
                                 lwm2m_data_t * dataArray,
                                 lwm2m_object_t * objectP,
@@ -652,10 +663,10 @@ static uint8_t prv_server_write(uint16_t instanceId,
 
     if (writeType == LWM2M_WRITE_REPLACE_INSTANCE)
     {
-        result = prv_server_delete(instanceId, objectP);
+        result = prv_server_delete(contextP, instanceId, objectP);
         if (result == COAP_202_DELETED)
         {
-            result = prv_server_create(instanceId, numData, dataArray, objectP);
+            result = prv_server_create(contextP, instanceId, numData, dataArray, objectP);
             if (result == COAP_201_CREATED)
             {
                 result = COAP_204_CHANGED;
@@ -929,7 +940,8 @@ static uint8_t prv_server_write(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_server_execute(uint16_t instanceId,
+static uint8_t prv_server_execute(lwm2m_context_t *contextP,
+                                  uint16_t instanceId,
                                   uint16_t resourceId,
                                   uint8_t * buffer,
                                   int length,
@@ -937,6 +949,9 @@ static uint8_t prv_server_execute(uint16_t instanceId,
 
 {
     server_instance_t * targetP;
+
+    /* unused parameter */
+    (void)contextP;
 
     targetP = (server_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -955,10 +970,14 @@ static uint8_t prv_server_execute(uint16_t instanceId,
     }
 }
 
-static uint8_t prv_server_delete(uint16_t id,
+static uint8_t prv_server_delete(lwm2m_context_t *contextP,
+                                 uint16_t id,
                                  lwm2m_object_t * objectP)
 {
     server_instance_t * serverInstance;
+
+    /* unused parameter */
+    (void)contextP;
 
     objectP->instanceList = lwm2m_list_remove(objectP->instanceList, id, (lwm2m_list_t **)&serverInstance);
     if (NULL == serverInstance) return COAP_404_NOT_FOUND;
@@ -968,7 +987,8 @@ static uint8_t prv_server_delete(uint16_t id,
     return COAP_202_DELETED;
 }
 
-static uint8_t prv_server_create(uint16_t instanceId,
+static uint8_t prv_server_create(lwm2m_context_t *contextP,
+                                 uint16_t instanceId,
                                  int numData,
                                  lwm2m_data_t * dataArray,
                                  lwm2m_object_t * objectP)
@@ -993,11 +1013,11 @@ static uint8_t prv_server_create(uint16_t instanceId,
 #endif
     objectP->instanceList = LWM2M_LIST_ADD(objectP->instanceList, serverInstance);
 
-    result = prv_server_write(instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
+    result = prv_server_write(contextP, instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
 
     if (result != COAP_204_CHANGED)
     {
-        (void)prv_server_delete(instanceId, objectP);
+        (void)prv_server_delete(contextP, instanceId, objectP);
     }
     else
     {

--- a/examples/client/object_test.c
+++ b/examples/client/object_test.c
@@ -102,9 +102,11 @@ typedef struct _prv_instance_
 #endif
 } prv_instance_t;
 
-static uint8_t prv_delete(uint16_t id,
+static uint8_t prv_delete(lwm2m_context_t *contextP,
+                          uint16_t id,
                           lwm2m_object_t * objectP);
-static uint8_t prv_create(uint16_t instanceId,
+static uint8_t prv_create(lwm2m_context_t *contextP,
+                          uint16_t instanceId,
                           int numData,
                           lwm2m_data_t * dataArray,
                           lwm2m_object_t * objectP);
@@ -146,13 +148,17 @@ static void prv_output_buffer(uint8_t * buffer,
     }
 }
 
-static uint8_t prv_read(uint16_t instanceId,
+static uint8_t prv_read(lwm2m_context_t *contextP,
+                        uint16_t instanceId,
                         int * numDataP,
                         lwm2m_data_t ** dataArrayP,
                         lwm2m_object_t * objectP)
 {
     prv_instance_t * targetP;
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     targetP = (prv_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -195,12 +201,16 @@ static uint8_t prv_read(uint16_t instanceId,
     return COAP_205_CONTENT;
 }
 
-static uint8_t prv_discover(uint16_t instanceId,
+static uint8_t prv_discover(lwm2m_context_t *contextP,
+                            uint16_t instanceId,
                             int * numDataP,
                             lwm2m_data_t ** dataArrayP,
                             lwm2m_object_t * objectP)
 {
     int i;
+
+    /* unused parameter */
+    (void)contextP;
 
     // is the server asking for the full object ?
     if (*numDataP == 0)
@@ -233,7 +243,8 @@ static uint8_t prv_discover(uint16_t instanceId,
     return COAP_205_CONTENT;
 }
 
-static uint8_t prv_write(uint16_t instanceId,
+static uint8_t prv_write(lwm2m_context_t *contextP,
+                         uint16_t instanceId,
                          int numData,
                          lwm2m_data_t * dataArray,
                          lwm2m_object_t * objectP,
@@ -248,10 +259,10 @@ static uint8_t prv_write(uint16_t instanceId,
 
     if (writeType == LWM2M_WRITE_REPLACE_INSTANCE)
     {
-        uint8_t result = prv_delete(instanceId, objectP);
+        uint8_t result = prv_delete(contextP, instanceId, objectP);
         if (result == COAP_202_DELETED)
         {
-            result = prv_create(instanceId, numData, dataArray, objectP);
+            result = prv_create(contextP, instanceId, numData, dataArray, objectP);
             if (result == COAP_201_CREATED)
             {
                 result = COAP_204_CHANGED;
@@ -320,7 +331,8 @@ static void prv_block_buffer_free(prv_instance_t * targetP)
     }
 }
 
-static uint8_t prv_raw_block1_write(lwm2m_uri_t * uriP,
+static uint8_t prv_raw_block1_write(lwm2m_context_t *contextP,
+                                lwm2m_uri_t * uriP,
                                 lwm2m_media_type_t format,
                                 uint8_t * payload,
                                 int length,
@@ -420,10 +432,14 @@ static uint8_t prv_raw_block1_write(lwm2m_uri_t * uriP,
 }
 #endif
 
-static uint8_t prv_delete(uint16_t id,
+static uint8_t prv_delete(lwm2m_context_t *contextP,
+                          uint16_t id,
                           lwm2m_object_t * objectP)
 {
     prv_instance_t * targetP;
+
+    /* unused parameter */
+    (void)contextP;
 
     objectP->instanceList = lwm2m_list_remove(objectP->instanceList, id, (lwm2m_list_t **)&targetP);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -439,7 +455,8 @@ static uint8_t prv_delete(uint16_t id,
     return COAP_202_DELETED;
 }
 
-static uint8_t prv_create(uint16_t instanceId,
+static uint8_t prv_create(lwm2m_context_t *contextP,
+                          uint16_t instanceId,
                           int numData,
                           lwm2m_data_t * dataArray,
                           lwm2m_object_t * objectP)
@@ -455,11 +472,11 @@ static uint8_t prv_create(uint16_t instanceId,
     targetP->shortID = instanceId;
     objectP->instanceList = LWM2M_LIST_ADD(objectP->instanceList, targetP);
 
-    result = prv_write(instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
+    result = prv_write(contextP, instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
 
     if (result != COAP_204_CHANGED)
     {
-        (void)prv_delete(instanceId, objectP);
+        (void)prv_delete(contextP, instanceId, objectP);
     }
     else
     {
@@ -469,12 +486,15 @@ static uint8_t prv_create(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_exec(uint16_t instanceId,
+static uint8_t prv_exec(lwm2m_context_t *contextP,
+                        uint16_t instanceId,
                         uint16_t resourceId,
                         uint8_t * buffer,
                         int length,
                         lwm2m_object_t * objectP)
 {
+    /* unused parameter */
+    (void)contextP;
 
     if (NULL == lwm2m_list_find(objectP->instanceList, instanceId)) return COAP_404_NOT_FOUND;
 

--- a/examples/lightclient/object_device.c
+++ b/examples/lightclient/object_device.c
@@ -122,13 +122,17 @@ static uint8_t prv_set_value(lwm2m_data_t * dataP)
     }
 }
 
-static uint8_t prv_device_read(uint16_t instanceId,
+static uint8_t prv_device_read(lwm2m_context_t * contextP,
+                               uint16_t instanceId,
                                int * numDataP,
                                lwm2m_data_t ** dataArrayP,
                                lwm2m_object_t * objectP)
 {
     uint8_t result;
     int i;
+
+    /* Unused parameter */
+    (void)contextP;
 
     // this is a single instance object
     if (instanceId != 0)
@@ -172,13 +176,17 @@ static uint8_t prv_device_read(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_device_discover(uint16_t instanceId,
+static uint8_t prv_device_discover(lwm2m_context_t * contextP,
+                                   uint16_t instanceId,
                                    int * numDataP,
                                    lwm2m_data_t ** dataArrayP,
                                    lwm2m_object_t * objectP)
 {
     uint8_t result;
     int i;
+
+    /* Unused parameter */
+    (void)contextP;
 
     // this is a single instance object
     if (instanceId != 0)
@@ -227,12 +235,16 @@ static uint8_t prv_device_discover(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_device_execute(uint16_t instanceId,
+static uint8_t prv_device_execute(lwm2m_context_t * contextP,
+                                  uint16_t instanceId,
                                   uint16_t resourceId,
                                   uint8_t * buffer,
                                   int length,
                                   lwm2m_object_t * objectP)
 {
+    /* Unused parameter */
+    (void)contextP;
+
     // this is a single instance object
     if (instanceId != 0)
     {

--- a/examples/lightclient/object_security.c
+++ b/examples/lightclient/object_security.c
@@ -140,7 +140,8 @@ static uint8_t prv_get_value(lwm2m_data_t * dataP,
     }
 }
 
-static uint8_t prv_security_read(uint16_t instanceId,
+static uint8_t prv_security_read(lwm2m_context_t * contextP,
+                                 uint16_t instanceId,
                                  int * numDataP,
                                  lwm2m_data_t ** dataArrayP,
                                  lwm2m_object_t * objectP)
@@ -148,6 +149,9 @@ static uint8_t prv_security_read(uint16_t instanceId,
     security_instance_t * targetP;
     uint8_t result;
     int i;
+
+    /* Unused parameter */
+    (void)contextP;
 
     targetP = (security_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;

--- a/examples/lightclient/object_server.c
+++ b/examples/lightclient/object_server.c
@@ -51,9 +51,11 @@ typedef struct _server_instance_
     char        binding[4];
 } server_instance_t;
 
-static uint8_t prv_server_delete(uint16_t id,
+static uint8_t prv_server_delete(lwm2m_context_t * contextP,
+                                 uint16_t id,
                                  lwm2m_object_t * objectP);
-static uint8_t prv_server_create(uint16_t instanceId,
+static uint8_t prv_server_create(lwm2m_context_t * contextP,
+                                 uint16_t instanceId,
                                  int numData,
                                  lwm2m_data_t * dataArray,
                                  lwm2m_object_t * objectP);
@@ -90,7 +92,8 @@ static uint8_t prv_get_value(lwm2m_data_t * dataP,
     }
 }
 
-static uint8_t prv_server_read(uint16_t instanceId,
+static uint8_t prv_server_read(lwm2m_context_t * contextP,
+                               uint16_t instanceId,
                                int * numDataP,
                                lwm2m_data_t ** dataArrayP,
                                lwm2m_object_t * objectP)
@@ -98,6 +101,9 @@ static uint8_t prv_server_read(uint16_t instanceId,
     server_instance_t * targetP;
     uint8_t result;
     int i;
+
+    /* Unused parameter */
+    (void)contextP;
 
     targetP = (server_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -139,13 +145,17 @@ static uint8_t prv_server_read(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_server_discover(uint16_t instanceId,
+static uint8_t prv_server_discover(lwm2m_context_t * contextP,
+                                   uint16_t instanceId,
                                    int * numDataP,
                                    lwm2m_data_t ** dataArrayP,
                                    lwm2m_object_t * objectP)
 {
     uint8_t result;
     int i;
+
+    /* Unused parameter */
+    (void)contextP;
 
     result = COAP_205_CONTENT;
 
@@ -223,7 +233,8 @@ static uint8_t prv_set_int_value(lwm2m_data_t * dataArray,
     return result;
 }
 
-static uint8_t prv_server_write(uint16_t instanceId,
+static uint8_t prv_server_write(lwm2m_context_t * contextP,
+                                uint16_t instanceId,
                                 int numData,
                                 lwm2m_data_t * dataArray,
                                 lwm2m_object_t * objectP,
@@ -241,10 +252,10 @@ static uint8_t prv_server_write(uint16_t instanceId,
 
     if (writeType == LWM2M_WRITE_REPLACE_INSTANCE)
     {
-        result = prv_server_delete(instanceId, objectP);
+        result = prv_server_delete(contextP, instanceId, objectP);
         if (result == COAP_202_DELETED)
         {
-            result = prv_server_create(instanceId, numData, dataArray, objectP);
+            result = prv_server_create(contextP, instanceId, numData, dataArray, objectP);
             if (result == COAP_201_CREATED)
             {
                 result = COAP_204_CHANGED;
@@ -343,7 +354,8 @@ static uint8_t prv_server_write(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_server_execute(uint16_t instanceId,
+static uint8_t prv_server_execute(lwm2m_context_t * contextP,
+                                  uint16_t instanceId,
                                   uint16_t resourceId,
                                   uint8_t * buffer,
                                   int length,
@@ -351,6 +363,9 @@ static uint8_t prv_server_execute(uint16_t instanceId,
 
 {
     server_instance_t * targetP;
+
+    /* Unused parameter */
+    (void)contextP;
 
     targetP = (server_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -370,10 +385,14 @@ static uint8_t prv_server_execute(uint16_t instanceId,
     }
 }
 
-static uint8_t prv_server_delete(uint16_t id,
+static uint8_t prv_server_delete(lwm2m_context_t * contextP,
+                                 uint16_t id,
                                  lwm2m_object_t * objectP)
 {
     server_instance_t * serverInstance;
+
+    /* Unused parameter */
+    (void)contextP;
 
     objectP->instanceList = lwm2m_list_remove(objectP->instanceList, id, (lwm2m_list_t **)&serverInstance);
     if (NULL == serverInstance) return COAP_404_NOT_FOUND;
@@ -383,7 +402,8 @@ static uint8_t prv_server_delete(uint16_t id,
     return COAP_202_DELETED;
 }
 
-static uint8_t prv_server_create(uint16_t instanceId,
+static uint8_t prv_server_create(lwm2m_context_t * contextP,
+                                 uint16_t instanceId,
                                  int numData,
                                  lwm2m_data_t * dataArray,
                                  lwm2m_object_t * objectP)
@@ -398,11 +418,11 @@ static uint8_t prv_server_create(uint16_t instanceId,
     serverInstance->instanceId = instanceId;
     objectP->instanceList = LWM2M_LIST_ADD(objectP->instanceList, serverInstance);
 
-    result = prv_server_write(instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
+    result = prv_server_write(contextP, instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
 
     if (result != COAP_204_CHANGED)
     {
-        (void)prv_server_delete(instanceId, objectP);
+        (void)prv_server_delete(contextP, instanceId, objectP);
     }
     else
     {

--- a/examples/lightclient/object_test.c
+++ b/examples/lightclient/object_test.c
@@ -77,9 +77,11 @@
 #include <ctype.h>
 #include <limits.h>
 
-static uint8_t prv_delete(uint16_t id,
+static uint8_t prv_delete(lwm2m_context_t * contextP,
+                          uint16_t id,
                           lwm2m_object_t * objectP);
-static uint8_t prv_create(uint16_t instanceId,
+static uint8_t prv_create(lwm2m_context_t * contextP,
+                          uint16_t instanceId,
                           int numData,
                           lwm2m_data_t * dataArray,
                           lwm2m_object_t * objectP);
@@ -139,13 +141,17 @@ typedef struct _prv_instance_
     int16_t  sig;
 } prv_instance_t;
 
-static uint8_t prv_read(uint16_t instanceId,
+static uint8_t prv_read(lwm2m_context_t * contextP,
+                        uint16_t instanceId,
                         int * numDataP,
                         lwm2m_data_t ** dataArrayP,
                         lwm2m_object_t * objectP)
 {
     prv_instance_t * targetP;
     int i;
+
+    /* Unused parameter */
+    (void)contextP;
 
     targetP = (prv_instance_t *)lwm2m_list_find(objectP->instanceList, instanceId);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -188,12 +194,16 @@ static uint8_t prv_read(uint16_t instanceId,
     return COAP_205_CONTENT;
 }
 
-static uint8_t prv_discover(uint16_t instanceId,
+static uint8_t prv_discover(lwm2m_context_t * contextP,
+                            uint16_t instanceId,
                             int * numDataP,
                             lwm2m_data_t ** dataArrayP,
                             lwm2m_object_t * objectP)
 {
     int i;
+
+    /* Unused parameter */
+    (void)contextP;
 
     // is the server asking for the full object ?
     if (*numDataP == 0)
@@ -225,7 +235,8 @@ static uint8_t prv_discover(uint16_t instanceId,
     return COAP_205_CONTENT;
 }
 
-static uint8_t prv_write(uint16_t instanceId,
+static uint8_t prv_write(lwm2m_context_t * contextP,
+                         uint16_t instanceId,
                          int numData,
                          lwm2m_data_t * dataArray,
                          lwm2m_object_t * objectP,
@@ -239,10 +250,10 @@ static uint8_t prv_write(uint16_t instanceId,
 
     if (writeType == LWM2M_WRITE_REPLACE_INSTANCE)
     {
-        uint8_t result = prv_delete(instanceId, objectP);
+        uint8_t result = prv_delete(contextP, instanceId, objectP);
         if (result == COAP_202_DELETED)
         {
-            result = prv_create(instanceId, numData, dataArray, objectP);
+            result = prv_create(contextP, instanceId, numData, dataArray, objectP);
             if (result == COAP_201_CREATED)
             {
                 result = COAP_204_CHANGED;
@@ -296,10 +307,14 @@ static uint8_t prv_write(uint16_t instanceId,
     return COAP_204_CHANGED;
 }
 
-static uint8_t prv_delete(uint16_t id,
+static uint8_t prv_delete(lwm2m_context_t * contextP,
+                          uint16_t id,
                           lwm2m_object_t * objectP)
 {
     prv_instance_t * targetP;
+
+    /* Unused parameter */
+    (void)contextP;
 
     objectP->instanceList = lwm2m_list_remove(objectP->instanceList, id, (lwm2m_list_t **)&targetP);
     if (NULL == targetP) return COAP_404_NOT_FOUND;
@@ -309,7 +324,8 @@ static uint8_t prv_delete(uint16_t id,
     return COAP_202_DELETED;
 }
 
-static uint8_t prv_create(uint16_t instanceId,
+static uint8_t prv_create(lwm2m_context_t * contextP,
+                          uint16_t instanceId,
                           int numData,
                           lwm2m_data_t * dataArray,
                           lwm2m_object_t * objectP)
@@ -325,11 +341,11 @@ static uint8_t prv_create(uint16_t instanceId,
     targetP->shortID = instanceId;
     objectP->instanceList = LWM2M_LIST_ADD(objectP->instanceList, targetP);
 
-    result = prv_write(instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
+    result = prv_write(contextP, instanceId, numData, dataArray, objectP, LWM2M_WRITE_REPLACE_RESOURCES);
 
     if (result != COAP_204_CHANGED)
     {
-        (void)prv_delete(instanceId, objectP);
+        (void)prv_delete(contextP, instanceId, objectP);
     }
     else
     {
@@ -339,12 +355,15 @@ static uint8_t prv_create(uint16_t instanceId,
     return result;
 }
 
-static uint8_t prv_exec(uint16_t instanceId,
+static uint8_t prv_exec(lwm2m_context_t * contextP,
+                        uint16_t instanceId,
                         uint16_t resourceId,
                         uint8_t * buffer,
                         int length,
                         lwm2m_object_t * objectP)
 {
+    /* Unused parameter */
+    (void)contextP;
 
     if (NULL == lwm2m_list_find(objectP->instanceList, instanceId)) return COAP_404_NOT_FOUND;
 

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -187,11 +187,14 @@ static void prv_dump_client(lwm2m_client_t * targetP)
     fprintf(stdout, "\r\n");
 }
 
-static void prv_output_clients(char * buffer,
+static void prv_output_clients(lwm2m_context_t *lwm2mH,
+                               char * buffer,
                                void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     lwm2m_client_t * targetP;
+
+    /* unused parameter */
+    (void)user_data;
 
     targetP = lwm2mH->clientList;
 
@@ -246,7 +249,8 @@ static void prv_printUri(const lwm2m_uri_t * uriP)
 #endif
 }
 
-static void prv_result_callback(uint16_t clientID,
+static void prv_result_callback(lwm2m_context_t *contextP,
+                                uint16_t clientID,
                                 lwm2m_uri_t * uriP,
                                 int status,
                                 block_info_t * block_info,
@@ -255,6 +259,10 @@ static void prv_result_callback(uint16_t clientID,
                                 int dataLength,
                                 void * userData)
 {
+    /* unused parameters */
+    (void)contextP;
+    (void)userData;
+
     fprintf(stdout, "\r\nClient #%d ", clientID);
     prv_printUri(uriP);
     fprintf(stdout, " : ");
@@ -267,7 +275,8 @@ static void prv_result_callback(uint16_t clientID,
     fflush(stdout);
 }
 
-static void prv_notify_callback(uint16_t clientID,
+static void prv_notify_callback(lwm2m_context_t *contextP,
+                                uint16_t clientID,
                                 lwm2m_uri_t * uriP,
                                 int count,
                                 block_info_t * block_info,
@@ -276,6 +285,10 @@ static void prv_notify_callback(uint16_t clientID,
                                 int dataLength,
                                 void * userData)
 {
+    /* unused parameters */
+    (void)contextP;
+    (void)userData;
+
     fprintf(stdout, "\r\nNotify from client #%d ", clientID);
     prv_printUri(uriP);
     fprintf(stdout, " number %d\r\n", count);
@@ -286,14 +299,17 @@ static void prv_notify_callback(uint16_t clientID,
     fflush(stdout);
 }
 
-static void prv_read_client(char * buffer,
+static void prv_read_client(lwm2m_context_t * lwm2mH,
+                            char * buffer,
                             void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char* end = NULL;
     int result;
+
+    /* unused parameters */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -322,14 +338,17 @@ syntax_error:
     fprintf(stdout, "Syntax error !");
 }
 
-static void prv_discover_client(char * buffer,
+static void prv_discover_client(lwm2m_context_t * lwm2mH,
+                                char * buffer,
                                 void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char* end = NULL;
     int result;
+
+    /* unused parameter */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -359,10 +378,9 @@ syntax_error:
 }
 
 static void prv_do_write_client(char * buffer,
-                                void * user_data,
+                                lwm2m_context_t * lwm2mH,
                                 bool partialUpdate)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     lwm2m_data_t * dataP = NULL;
@@ -464,22 +482,30 @@ syntax_error:
     fprintf(stdout, "Syntax error !");
 }
 
-static void prv_write_client(char * buffer,
+static void prv_write_client(lwm2m_context_t * lwm2mH,
+                             char * buffer,
                              void * user_data)
 {
-    prv_do_write_client(buffer, user_data, false);
+    /* unused parameter */
+    (void)user_data;
+
+    prv_do_write_client(buffer, lwm2mH, false);
 }
 
-static void prv_update_client(char * buffer,
+static void prv_update_client(lwm2m_context_t * lwm2mH,
+                              char * buffer,
                               void * user_data)
 {
-    prv_do_write_client(buffer, user_data, true);
+    /* unused parameter */
+    (void)user_data;
+
+    prv_do_write_client(buffer, lwm2mH, true);
 }
 
-static void prv_time_client(char * buffer,
+static void prv_time_client(lwm2m_context_t * lwm2mH,
+                            char * buffer,
                             void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char * end = NULL;
@@ -487,6 +513,9 @@ static void prv_time_client(char * buffer,
     lwm2m_attributes_t attr;
     int nb;
     int value;
+
+    /* unused parameter */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -535,10 +564,10 @@ syntax_error:
 }
 
 
-static void prv_attr_client(char * buffer,
+static void prv_attr_client(lwm2m_context_t *lwm2mH,
+                            char * buffer,
                             void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char * end = NULL;
@@ -546,6 +575,9 @@ static void prv_attr_client(char * buffer,
     lwm2m_attributes_t attr;
     int nb;
     float value;
+
+    /* unused parameter */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -602,15 +634,18 @@ syntax_error:
 }
 
 
-static void prv_clear_client(char * buffer,
+static void prv_clear_client(lwm2m_context_t *lwm2mH,
+                             char * buffer,
                              void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char * end = NULL;
     int result;
     lwm2m_attributes_t attr;
+
+    /* unused parameter */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -644,14 +679,17 @@ syntax_error:
 }
 
 
-static void prv_exec_client(char * buffer,
+static void prv_exec_client(lwm2m_context_t *lwm2mH,
+                            char * buffer,
                             void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char * end = NULL;
     int result;
+
+    /* unused parameter */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -690,10 +728,10 @@ syntax_error:
     fprintf(stdout, "Syntax error !");
 }
 
-static void prv_create_client(char * buffer,
+static void prv_create_client(lwm2m_context_t *lwm2mH,
+                              char * buffer,
                               void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char * end = NULL;
@@ -701,6 +739,9 @@ static void prv_create_client(char * buffer,
     int64_t value;
     lwm2m_data_t * dataP = NULL;
     int size = 0;
+
+    /* unused parameter */
+    (void)user_data;
 
     //Get Client ID
     result = prv_read_id(buffer, &clientId);
@@ -806,14 +847,17 @@ syntax_error:
     fprintf(stdout, "Syntax error !");
 }
 
-static void prv_delete_client(char * buffer,
+static void prv_delete_client(lwm2m_context_t *lwm2mH,
+                              char * buffer,
                               void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char* end = NULL;
     int result;
+
+    /* unused parameter */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -842,14 +886,17 @@ syntax_error:
     fprintf(stdout, "Syntax error !");
 }
 
-static void prv_observe_client(char * buffer,
+static void prv_observe_client(lwm2m_context_t *lwm2mH,
+                               char * buffer,
                                void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char* end = NULL;
     int result;
+
+    /* unused parameter */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -878,14 +925,17 @@ syntax_error:
     fprintf(stdout, "Syntax error !");
 }
 
-static void prv_cancel_client(char * buffer,
+static void prv_cancel_client(lwm2m_context_t *lwm2mH,
+                              char * buffer,
                               void * user_data)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) user_data;
     uint16_t clientId;
     lwm2m_uri_t uri;
     char* end = NULL;
     int result;
+
+    /* unused parameter */
+    (void)user_data;
 
     result = prv_read_id(buffer, &clientId);
     if (result != 1) goto syntax_error;
@@ -914,7 +964,8 @@ syntax_error:
     fprintf(stdout, "Syntax error !");
 }
 
-static void prv_monitor_callback(uint16_t clientID,
+static void prv_monitor_callback(lwm2m_context_t *lwm2mH,
+                                 uint16_t clientID,
                                  lwm2m_uri_t * uriP,
                                  int status,
                                  block_info_t * block_info,
@@ -923,8 +974,10 @@ static void prv_monitor_callback(uint16_t clientID,
                                  int dataLength,
                                  void * userData)
 {
-    lwm2m_context_t * lwm2mH = (lwm2m_context_t *) userData;
     lwm2m_client_t * targetP;
+
+    /* unused parameter */
+    (void)userData;
 
     switch (status)
     {
@@ -958,9 +1011,14 @@ static void prv_monitor_callback(uint16_t clientID,
 }
 
 
-static void prv_quit(char * buffer,
+static void prv_quit(lwm2m_context_t *lwm2mH,
+                     char * buffer,
                      void * user_data)
 {
+    /* unused parameters */
+    (void)lwm2mH;
+    (void)user_data;
+
     g_quit = 1;
 }
 
@@ -987,7 +1045,6 @@ int main(int argc, char *argv[])
     struct timeval tv;
     int result;
     lwm2m_context_t * lwm2mH = NULL;
-    int i;
     connection_t * connList = NULL;
     int addressFamily = AF_INET6;
     int opt;
@@ -1105,13 +1162,9 @@ int main(int argc, char *argv[])
 
     signal(SIGINT, handle_sigint);
 
-    for (i = 0 ; commands[i].name != NULL ; i++)
-    {
-        commands[i].userData = (void *)lwm2mH;
-    }
     fprintf(stdout, "> "); fflush(stdout);
 
-    lwm2m_set_monitoring_callback(lwm2mH, prv_monitor_callback, lwm2mH);
+    lwm2m_set_monitoring_callback(lwm2mH, prv_monitor_callback, NULL);
 
     while (0 == g_quit)
     {
@@ -1204,7 +1257,7 @@ int main(int argc, char *argv[])
                 if (numBytes > 1)
                 {
                     buffer[numBytes] = 0;
-                    handle_command(commands, (char*)buffer);
+                    handle_command(lwm2mH, commands, (char*)buffer);
                     fprintf(stdout, "\r\n");
                 }
                 if (g_quit == 0)

--- a/examples/shared/commandline.c
+++ b/examples/shared/commandline.c
@@ -88,7 +88,8 @@ static void prv_displayHelp(command_desc_t * commandArray,
 }
 
 
-void handle_command(command_desc_t * commandArray,
+void handle_command(lwm2m_context_t *lwm2mH,
+                    command_desc_t * commandArray,
                     char * buffer)
 {
     command_desc_t * cmdP;
@@ -104,7 +105,7 @@ void handle_command(command_desc_t * commandArray,
     {
         while (buffer[length] != 0 && isspace(buffer[length]&0xFF))
             length++;
-        cmdP->callback(buffer + length, cmdP->userData);
+        cmdP->callback(lwm2mH, buffer + length, cmdP->userData);
     }
     else
     {

--- a/examples/shared/commandline.h
+++ b/examples/shared/commandline.h
@@ -19,7 +19,7 @@
 
 #define COMMAND_END_LIST {NULL, NULL, NULL, NULL, NULL}
 
-typedef void (*command_handler_t) (char * args, void * user_data);
+typedef void (*command_handler_t) (lwm2m_context_t *lwm2mH, char * args, void * user_data);
 
 typedef struct
 {
@@ -31,7 +31,7 @@ typedef struct
 } command_desc_t;
 
 
-void handle_command(command_desc_t * commandArray, char * buffer);
+void handle_command(lwm2m_context_t *lwm2mH, command_desc_t * commandArray, char * buffer);
 char* get_end_of_arg(char* buffer);
 char * get_next_arg(char * buffer, char **end);
 int check_end_of_args(char* buffer);

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -28,13 +28,21 @@
 
 dtls_context_t * dtlsContext;
 
+typedef struct _dtls_app_context_
+{
+    lwm2m_context_t * lwm2mH;
+    dtls_connection_t * connList;
+} dtls_app_context_t;
+
+dtls_app_context_t appContext;
+
 /********************* Security Obj Helpers **********************/
-char * security_get_uri(lwm2m_object_t * obj, int instanceId, char * uriBuffer, int bufferSize){
+char * security_get_uri(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, char * uriBuffer, int bufferSize){
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 0; // security server uri
 
-    obj->readFunc(instanceId, &size, &dataP, obj);
+    obj->readFunc(lwm2mH, instanceId, &size, &dataP, obj);
     if (dataP != NULL &&
             dataP->type == LWM2M_TYPE_STRING &&
             dataP->value.asBuffer.length > 0)
@@ -50,13 +58,13 @@ char * security_get_uri(lwm2m_object_t * obj, int instanceId, char * uriBuffer, 
     return NULL;
 }
 
-int64_t security_get_mode(lwm2m_object_t * obj, int instanceId){
+int64_t security_get_mode(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId){
     int64_t mode;
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 2; // security mode
 
-    obj->readFunc(instanceId, &size, &dataP, obj);
+    obj->readFunc(lwm2mH, instanceId, &size, &dataP, obj);
     if (0 != lwm2m_data_decode_int(dataP,&mode))
     {
         lwm2m_data_free(size, dataP);
@@ -68,12 +76,12 @@ int64_t security_get_mode(lwm2m_object_t * obj, int instanceId){
     return LWM2M_SECURITY_MODE_NONE;
 }
 
-char * security_get_public_id(lwm2m_object_t * obj, int instanceId, int * length){
+char * security_get_public_id(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, int * length){
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 3; // public key or id
 
-    obj->readFunc(instanceId, &size, &dataP, obj);
+    obj->readFunc(lwm2mH, instanceId, &size, &dataP, obj);
     if (dataP != NULL &&
         dataP->type == LWM2M_TYPE_OPAQUE)
     {
@@ -94,12 +102,12 @@ char * security_get_public_id(lwm2m_object_t * obj, int instanceId, int * length
 }
 
 
-char * security_get_secret_key(lwm2m_object_t * obj, int instanceId, int * length){
+char * security_get_secret_key(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, int * length){
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 5; // secret key
 
-    obj->readFunc(instanceId, &size, &dataP, obj);
+    obj->readFunc(lwm2mH, instanceId, &size, &dataP, obj);
     if (dataP != NULL &&
         dataP->type == LWM2M_TYPE_OPAQUE)
     {
@@ -175,8 +183,10 @@ static int get_psk_info(struct dtls_context_t *ctx,
         const unsigned char *id, size_t id_len,
         unsigned char *result, size_t result_length) {
 
+    dtls_app_context_t *appContext = (dtls_app_context_t *)ctx->app;
+
     // find connection
-    dtls_connection_t* cnx = connection_find((dtls_connection_t *) ctx->app, &(session->addr.st),session->size);
+    dtls_connection_t* cnx = connection_find(appContext->connList, &(session->addr.st),session->size);
     if (cnx == NULL)
     {
         printf("GET PSK session not found\n");
@@ -188,7 +198,7 @@ static int get_psk_info(struct dtls_context_t *ctx,
         {
             int idLen;
             char * id;
-            id = security_get_public_id(cnx->securityObj, cnx->securityInstId, &idLen);
+            id = security_get_public_id(appContext->lwm2mH, cnx->securityObj, cnx->securityInstId, &idLen);
             if (result_length < idLen)
             {
                 printf("cannot set psk_identity -- buffer too small\n");
@@ -203,7 +213,7 @@ static int get_psk_info(struct dtls_context_t *ctx,
         {
             int keyLen;
             char * key;
-            key = security_get_secret_key(cnx->securityObj, cnx->securityInstId, &keyLen);
+            key = security_get_secret_key(appContext->lwm2mH, cnx->securityObj, cnx->securityInstId, &keyLen);
 
             if (result_length < keyLen)
             {
@@ -233,8 +243,10 @@ static int get_psk_info(struct dtls_context_t *ctx,
 static int send_to_peer(struct dtls_context_t *ctx,
         session_t *session, uint8 *data, size_t len) {
 
+    dtls_app_context_t *appContext = (dtls_app_context_t *)ctx->app;
+
     // find connection
-    dtls_connection_t* cnx = connection_find((dtls_connection_t *) ctx->app, &(session->addr.st),session->size);
+    dtls_connection_t* cnx = connection_find(appContext->connList, &(session->addr.st),session->size);
     if (cnx != NULL)
     {
         // send data to peer
@@ -253,11 +265,13 @@ static int send_to_peer(struct dtls_context_t *ctx,
 static int read_from_peer(struct dtls_context_t *ctx,
           session_t *session, uint8 *data, size_t len) {
 
+    dtls_app_context_t *appContext = (dtls_app_context_t *)ctx->app;
+
     // find connection
-    dtls_connection_t* cnx = connection_find((dtls_connection_t *) ctx->app, &(session->addr.st),session->size);
+    dtls_connection_t* cnx = connection_find(appContext->connList, &(session->addr.st),session->size);
     if (cnx != NULL)
     {
-        lwm2m_handle_packet(cnx->lwm2mH, (uint8_t*)data, len, (void*)cnx);
+        lwm2m_handle_packet(appContext->lwm2mH, (uint8_t*)data, len, (void*)cnx);
         return 0;
     }
     return -1;
@@ -277,15 +291,15 @@ static dtls_handler_t cb = {
 //#endif /* DTLS_ECC */
 };
 
-dtls_context_t * get_dtls_context(dtls_connection_t * connList) {
+dtls_context_t * get_dtls_context(lwm2m_context_t * lwm2mH, dtls_connection_t * connList) {
+    appContext.lwm2mH = lwm2mH;
+    appContext.connList = connList;
     if (dtlsContext == NULL) {
         dtls_init();
-        dtlsContext = dtls_new_context(connList);
+        dtlsContext = dtls_new_context(&appContext);
         if (dtlsContext == NULL)
             fprintf(stderr, "Failed to create the DTLS context\r\n");
         dtls_set_handler(dtlsContext, &cb);
-    }else{
-        dtlsContext->app = connList;
     }
     return dtlsContext;
 }
@@ -444,7 +458,7 @@ dtls_connection_t * connection_create(dtls_connection_t * connList,
     hints.ai_family = addressFamily;
     hints.ai_socktype = SOCK_DGRAM;
 
-    uri = security_get_uri(securityObj, instanceId, uriBuf, URI_LENGTH);
+    uri = security_get_uri(lwm2mH, securityObj, instanceId, uriBuf, URI_LENGTH);
     if (uri == NULL) return NULL;
 
     // parse uri in the form "coaps://[host]:[port]"
@@ -518,10 +532,10 @@ dtls_connection_t * connection_create(dtls_connection_t * connList,
             connP->securityInstId = instanceId;
             connP->lwm2mH = lwm2mH;
 
-            if (security_get_mode(connP->securityObj,connP->securityInstId)
+            if (security_get_mode(lwm2mH, connP->securityObj,connP->securityInstId)
                      != LWM2M_SECURITY_MODE_NONE)
             {
-                connP->dtlsContext = get_dtls_context(connP);
+                connP->dtlsContext = get_dtls_context(lwm2mH, connP);
             }
             else
             {


### PR DESCRIPTION
Some activities require knowing the LWM2M context and may be triggered
by callbacks. Examples of this are server object execute resources to
trigger a registration update or bootstrap. Before this change it is
necessary to have a means outside Wakaama to get that context. This
provides the context to all callbacks so that there is uniform access to
the context.

Signed-off-by: Scott Bertin <sbertin@telular.com>