### PR TITLE
Fix debug step-timeout-print for 32-bit platforms

### DIFF
--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -378,7 +378,7 @@ int lwm2m_step(lwm2m_context_t * contextP,
 {
     time_t tv_sec;
 
-    LOG_ARG("timeoutP: %" PRId64, *timeoutP);
+    LOG_ARG("timeoutP: %d", (int) *timeoutP);
     tv_sec = lwm2m_gettime();
     if (tv_sec < 0) return COAP_500_INTERNAL_SERVER_ERROR;
 
@@ -488,7 +488,7 @@ next_step:
     registration_step(contextP, tv_sec, timeoutP);
     transaction_step(contextP, tv_sec, timeoutP);
 
-    LOG_ARG("Final timeoutP: %" PRId64, *timeoutP);
+    LOG_ARG("Final timeoutP: %d", (int) *timeoutP);
 #ifdef LWM2M_CLIENT_MODE
     LOG_ARG("Final state: %s", STR_STATE(contextP->state));
 #endif


### PR DESCRIPTION
Current debug prints of timeout between lwm2m steps assume _time_t_ to be
64-bit. However, on MIPS and ARM this is not always given. This fix will decide
at build time whether a 32-bit or 64-bit print format is needed.

This was tested on:
 * Linux x86_64 (64-bit)
 * Linux armv5e (32-bit)
 * Linux mips32r2el-24kc-nf (32-bit)

Signed-off-by: Marc Lasch <marc.lasch@husqvarnagroup.com>