### PR TITLE
[GH-182] CI: Simplify execution

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-        path: wakaama
 
     - name: Install dependencies from APT repository
       run: sudo apt-get install libcunit1-dev wget unzip
@@ -27,15 +26,10 @@ jobs:
     - name: Install Ninja
       uses: seanmiddleditch/gha-setup-ninja@master
 
-    - name: Build and execute unit tests
+    - name: Build all binaries
       run: |
-        cmake -GNinja -S wakaama/tests -B build-wakaama-tests
-        cmake --build build-wakaama-tests
-        build-wakaama-tests/lwm2munittests
-      working-directory: ${{ github.workspace }}
+        tools/ci/run_ci.sh --build --verbose
 
-    - name: Build examples
+    - name: Execute unit tests
       run: |
-        cmake -GNinja -S wakaama/examples -B build-wakaama-examples
-        cmake --build build-wakaama-examples
-      working-directory: ${{ github.workspace }}
+        tools/ci/run_ci.sh --run-tests

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 GARDENA GmbH
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# and Eclipse Distribution License v1.0 which accompany this distribution.
+#
+# The Eclipse Public License is available at
+#    http://www.eclipse.org/legal/epl-v20.html
+# The Eclipse Distribution License is available at
+#    http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# Contributors:
+#   Reto Schneider, GARDENA GmbH - Please refer to git log
+
+set -eu -o pipefail
+
+readonly REPO_ROOT_DIR="${PWD}"
+readonly SCRIPT_NAME="$(basename "$0")"
+
+CMAKE_ARGS=""
+RUN_CLEAN=0
+RUN_BUILD=0
+RUN_TESTS=0
+OPT_VERBOSE=0
+
+HELP_MSG="usage: ${SCRIPT_NAME} <OPTIONS>...
+Runs build and test steps in CI.
+Select steps to execute with --run- options
+
+Options:
+ -v, --verbose             Verbose output
+ -a, --all                 Run all steps required for a MR
+
+ -h, --help                display this help and exit
+
+Available steps (executed by --all):
+  --clean                  Remove all build artifacts
+  --build                  Build all targets
+  --run-tests              Build and execute tests
+"
+
+function usage() {
+  exit_code=$1
+
+  echo "$HELP_MSG"
+  exit "$exit_code"
+}
+
+function run_clean() {
+  rm -rf build-wakaama-tests
+  rm -rf build-wakaama-examples
+}
+
+function run_build_tests() {
+  cmake -GNinja -S tests -B build-wakaama-tests ${CMAKE_ARGS}
+  cmake --build build-wakaama-tests
+}
+
+function run_build_examples() {
+  cmake -GNinja -S examples -B build-wakaama-examples ${CMAKE_ARGS}
+  cmake --build build-wakaama-examples
+}
+
+function run_build() {
+  run_build_tests
+  run_build_examples
+}
+
+function run_tests() {
+  run_build_tests
+  build-wakaama-tests/lwm2munittests
+}
+
+# Parse Options
+
+ret=0
+getopt --test > /dev/null || ret=$?
+if [[ $ret -ne 4 ]]; then
+  echo "Error: getopt version is not as expected"
+  exit 1
+fi
+
+if ! PARSED_OPTS=$(getopt -o vah \
+                          -l all \
+                          -l build \
+                          -l clean \
+                          -l help \
+                          -l run-tests \
+                          -l verbose \
+                          --name "$SCRIPT_NAME" -- "$@");
+then
+  usage 1
+fi
+
+eval set -- "$PARSED_OPTS"
+
+while true; do
+  case "$1" in
+    --clean)
+      RUN_CLEAN=1
+      shift
+      ;;
+    --build)
+      RUN_BUILD=1
+      shift 1
+      ;;
+    --run-tests)
+      RUN_TESTS=1
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -v|--verbose)
+      OPT_VERBOSE=1
+      shift
+      ;;
+    -a|--all)
+      RUN_CLEAN=1
+      RUN_BUILD=1
+      RUN_TESTS=1
+      shift
+      ;;
+    -h|--help)
+      usage 0
+      ;;
+    *)
+      echo "Error: args parsing failed"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ $# -gt 0 ]]; then
+  echo "too many arguments"
+  usage 1
+fi
+
+if [[ $OPT_VERBOSE != 0 ]]; then
+  CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_VERBOSE_MAKEFILE=ON"
+fi
+
+# Run Steps
+
+if [[ $RUN_CLEAN == 1 ]]; then
+    run_clean
+fi
+
+if [[ $RUN_TESTS == 1 ]]; then
+    run_tests
+fi
+
+if [[ $RUN_BUILD == 1 ]]; then
+    run_build
+fi


### PR DESCRIPTION
Moving the build and test logic into a separate script simplifies
reusing and extending it.

Based on this work, I intend to add more CI related improvements.

Signed-off-by: Reto Schneider <code@reto-schneider.ch>