### PR TITLE
Fix block2 response to a response bug

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -763,6 +763,7 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
                         {
                             prv_send_get_next_block2(contextP, fromSessionH, peerP->blockData, message->mid, block2_num, block2_size);
                             transaction_handleResponse(contextP, fromSessionH, message, NULL);
+                            coap_error_code = NO_ERROR;
                         }
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Leif Sandstrom <leif.sandstrom@husqvarnagroup.com>

There is a general (not only bootstrap server related) issue with handling of block2 responses. Prefer to have this merged separately while working on a solution for the bootstrap server specific issue(s).

Without this fix a GET resulting in a block2 ACK will be answered with a 2.31 continue ACK...