### PR TITLE
[GH-182] ci: Run Clang Static Analyzer

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -23,7 +23,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install dependencies from APT repository
-      run: sudo apt-get install libcunit1-dev wget unzip
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcunit1-dev wget unzip
 
     - name: Install CMake
       uses: lukka/get-cmake@latest

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -39,6 +39,6 @@ jobs:
 
     - name: Build, execute sanititzed unit tests
       run: |
-        tools/ci/run_ci.sh --run-tests --clean --sanitizer ${{ matrix.sanitizer }}
+        tools/ci/run_ci.sh --run-tests --sanitizer ${{ matrix.sanitizer }}
       env:
         CC:  ${{ matrix.compiler }}

--- a/.github/workflows/clang-static-analyzer.yaml
+++ b/.github/workflows/clang-static-analyzer.yaml
@@ -14,7 +14,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install dependencies from APT repository
-      run: sudo apt-get install clang-tools-10 libcunit1-dev wget unzip
+      run:  |
+        sudo apt-get update
+        sudo apt-get install clang-tools-10 libcunit1-dev wget unzip
 
     - name: Install CMake
       uses: lukka/get-cmake@latest

--- a/.github/workflows/clang-static-analyzer.yaml
+++ b/.github/workflows/clang-static-analyzer.yaml
@@ -1,0 +1,32 @@
+name: Clang Static Analyzer
+
+on: [push, pull_request]
+
+jobs:
+  clang_static_analyzer:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code including full history and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Install dependencies from APT repository
+      run: sudo apt-get install clang-tools-10 libcunit1-dev wget unzip
+
+    - name: Install CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@master
+
+    - name: Run Clang Static Analyzer
+      run: tools/ci/run_ci.sh --build --scan-build scan-build-10
+
+    - name: Upload scan build reports
+      uses: actions/upload-artifact@v1
+      with:
+        name: Clang Static Analyzer Reports
+        path: build-wakaama/clang-static-analyzer

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,4 +33,4 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: Coverage Report (HTML)
-        path: build-wakaama-tests/coverage
+        path: build-wakaama/coverage

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -25,6 +25,7 @@ jobs:
     - name: Collect test coverage data
       run: |
         tools/ci/run_ci.sh --run-tests \
+          --build \
           --clean \
           --test-coverage html
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -14,7 +14,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install dependencies from APT repository
-      run: sudo apt-get install gcovr libcunit1-dev wget unzip
+      run:  |
+        sudo apt-get update
+        sudo apt-get install gcovr libcunit1-dev wget unzip
 
     - name: Install CMake
       uses: lukka/get-cmake@latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required (VERSION 3.13)
+
+project(wakaama C)
+
+# Enable "test" target
+enable_testing()
+add_subdirectory(tests)
+
+add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,5 +4,3 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/bootstrap_server)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/client)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lightclient)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/server)
-
-project(wakaama C)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,5 @@ if(COVERAGE)
     target_link_options(${PROJECT_NAME} PRIVATE --coverage)
 endif()
 
-# Enable "test" target, add our unit tests to it
-enable_testing()
+# Add our unit tests to it "test" target
 add_test(NAME ${PROJECT_NAME}_test COMMAND ${PROJECT_NAME})

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -74,7 +74,6 @@ function run_build() {
 }
 
 function run_tests() {
-  run_build_tests
   build-wakaama-tests/lwm2munittests
 
   mkdir -p "${REPO_ROOT_DIR}/build-wakaama-tests/coverage"
@@ -206,10 +205,10 @@ if [ "${RUN_CLEAN}" -eq 1 ]; then
   run_clean
 fi
 
-if [ "${RUN_TESTS}" -eq 1 ]; then
-  run_tests
-fi
-
 if [ "${RUN_BUILD}" -eq 1 ]; then
   run_build
+fi
+
+if [ "${RUN_TESTS}" -eq 1 ]; then
+  run_tests
 fi

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -203,13 +203,13 @@ fi
 # Run Steps
 
 if [ "${RUN_CLEAN}" -eq 1 ]; then
-    run_clean
+  run_clean
 fi
 
 if [ "${RUN_TESTS}" -eq 1 ]; then
-    run_tests
+  run_tests
 fi
 
 if [ "${RUN_BUILD}" -eq 1 ]; then
-    run_build
+  run_build
 fi

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -54,51 +54,43 @@ function usage() {
 }
 
 function run_clean() {
-  rm -rf build-wakaama-tests
-  rm -rf build-wakaama-examples
-}
-
-function run_build_tests() {
-  cmake -GNinja -S tests -B build-wakaama-tests ${CMAKE_ARGS}
-  cmake --build build-wakaama-tests
-}
-
-function run_build_examples() {
-  cmake -GNinja -S examples -B build-wakaama-examples ${CMAKE_ARGS}
-  cmake --build build-wakaama-examples
+  rm -rf build-wakaama
 }
 
 function run_build() {
-  run_build_tests
-  run_build_examples
+  mkdir build-wakaama
+  pushd build-wakaama
+  cmake -GNinja -S .. ${CMAKE_ARGS}
+  ninja
+  popd
 }
 
 function run_tests() {
-  build-wakaama-tests/lwm2munittests
+  build-wakaama/tests/lwm2munittests
 
-  mkdir -p "${REPO_ROOT_DIR}/build-wakaama-tests/coverage"
+  mkdir -p "${REPO_ROOT_DIR}/build-wakaama/coverage"
 
   if [ -z "${OPT_TEST_COVERAGE_FORMAT}" ]; then
     return 0
   fi
 
   #see https://github.com/koalaman/shellcheck/wiki/SC2089
-  gcovr_opts=(-r "${REPO_ROOT_DIR}" \
-    --exclude "${REPO_ROOT_DIR}"/build-wakaama-tests \
+  gcovr_opts=(-r "${REPO_ROOT_DIR}/build-wakaama" \
+    --exclude "${REPO_ROOT_DIR}"/examples \
     --exclude "${REPO_ROOT_DIR}"/tests)
 
   case "${OPT_TEST_COVERAGE_FORMAT}" in
     xml)
       gcovr_out="--xml"
-      gcovr_file=("${REPO_ROOT_DIR}/build-wakaama-tests/coverage/report.xml")
+      gcovr_file=("${REPO_ROOT_DIR}/build-wakaama/coverage/report.xml")
       ;;
     html)
       gcovr_out="--html --html-details"
-      gcovr_file=("${REPO_ROOT_DIR}/build-wakaama-tests/coverage/report.html")
+      gcovr_file=("${REPO_ROOT_DIR}/build-wakaama/coverage/report.html")
       ;;
     text)
       gcovr_out=""
-      gcovr_file=("${REPO_ROOT_DIR}/build-wakaama-tests/coverage/report.txt")
+      gcovr_file=("${REPO_ROOT_DIR}/build-wakaama/coverage/report.txt")
       ;;
     *)
       echo "Error: Unsupported coverage output format: " \


### PR DESCRIPTION
Findings are available as artifact, but no further actions (e.g. breaking the build) taken.

Currently, 79 bugs are found. Once those got resolved, I intend to prevent merging when the Clang static analyzer findings issues.

When reviewing this PR, please also check if this works properly on your local machine:
```
tools/ci/run_ci.sh --build --run-tests --scan-build scan-build-10
```
And review the results:
```
xdg-open build-wakaama/clang-static-analyzer/*/index.html
```

Please adapt `scan-build-10 ` in case you are not using the Clang 10 or install package `clang-tools-10` (on Debian).