### PR TITLE
ci: Build using C99 and C11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,41 @@
+name: C Standards
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        compiler: ["clang-10", "gcc-10"]
+        c_standard: ["99", "11"]
+        c_extensions: ["ON", "OFF"]
+
+    steps:
+    - name: Checkout code including full history and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Install dependencies from APT repository
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcunit1-dev wget unzip
+
+    - name: Install CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@master
+
+    - name: Build all binaries
+      run: |
+        tools/ci/run_ci.sh \
+          --clean \
+          --build \
+          --c-standard ${{ matrix.c_standard }} \
+          --c-extensions ${{ matrix.c_extensions }}
+      env:
+        CC:  ${{ matrix.compiler }}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 
+add_compile_definitions(_POSIX_C_SOURCE=200809)
+add_compile_options(-pedantic)
+
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/bootstrap_server)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/client)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/lightclient)

--- a/examples/bootstrap_server/bootstrap_info.c
+++ b/examples/bootstrap_server/bootstrap_info.c
@@ -71,7 +71,7 @@ static int prv_find_next_section(FILE * fd,
             if (i < length)
             {
                 line[i] = 0;
-                if (strcasecmp(line + 1, tag) == 0)
+                if (lwm2m_strcasecmp(line + 1, tag) == 0)
                 {
                     found = 1;
                 }
@@ -263,7 +263,7 @@ static read_server_t * prv_read_next_server(FILE * fd)
 
     while((res = prv_read_key_value(fd, &key, &value)) == 1)
     {
-        if (strcasecmp(key, "id") == 0)
+        if (lwm2m_strcasecmp(key, "id") == 0)
         {
             int num;
 
@@ -272,24 +272,24 @@ static read_server_t * prv_read_next_server(FILE * fd)
             readSrvP->id = num;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "uri") == 0)
+        else if (lwm2m_strcasecmp(key, "uri") == 0)
         {
             readSrvP->uri = value;
         }
-        else if (strcasecmp(key, "bootstrap") == 0)
+        else if (lwm2m_strcasecmp(key, "bootstrap") == 0)
         {
-            if (strcasecmp(value, "yes") == 0)
+            if (lwm2m_strcasecmp(value, "yes") == 0)
             {
                 readSrvP->isBootstrap = true;
             }
-            else if (strcasecmp(value, "no") == 0)
+            else if (lwm2m_strcasecmp(value, "no") == 0)
             {
                 readSrvP->isBootstrap = false;
             }
             else goto error;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "lifetime") == 0)
+        else if (lwm2m_strcasecmp(key, "lifetime") == 0)
         {
             int num;
 
@@ -298,47 +298,47 @@ static read_server_t * prv_read_next_server(FILE * fd)
             readSrvP->lifetime = num;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "security") == 0)
+        else if (lwm2m_strcasecmp(key, "security") == 0)
         {
-            if (strcasecmp(value, "nosec") == 0)
+            if (lwm2m_strcasecmp(value, "nosec") == 0)
             {
                 readSrvP->securityMode = LWM2M_SECURITY_MODE_NONE;
             }
-            else if (strcasecmp(value, "PSK") == 0)
+            else if (lwm2m_strcasecmp(value, "PSK") == 0)
             {
                 readSrvP->securityMode = LWM2M_SECURITY_MODE_PRE_SHARED_KEY;
             }
-            else if (strcasecmp(value, "RPK") == 0)
+            else if (lwm2m_strcasecmp(value, "RPK") == 0)
             {
                 readSrvP->securityMode = LWM2M_SECURITY_MODE_RAW_PUBLIC_KEY;
             }
-            else if (strcasecmp(value, "certificate") == 0)
+            else if (lwm2m_strcasecmp(value, "certificate") == 0)
             {
                 readSrvP->securityMode = LWM2M_SECURITY_MODE_CERTIFICATE;
             }
             else goto error;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "public") == 0)
+        else if (lwm2m_strcasecmp(key, "public") == 0)
         {
             readSrvP->publicKeyLen = prv_readSecurityKey(value, &(readSrvP->publicKey));
             if (readSrvP->publicKeyLen == 0) goto error;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "server") == 0)
+        else if (lwm2m_strcasecmp(key, "server") == 0)
         {
             readSrvP->serverKeyLen = prv_readSecurityKey(value, &(readSrvP->serverKey));
             if (readSrvP->serverKeyLen == 0) goto error;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "secret") == 0)
+        else if (lwm2m_strcasecmp(key, "secret") == 0)
         {
             readSrvP->secretKeyLen = prv_readSecurityKey(value, &(readSrvP->secretKey));
             if (readSrvP->secretKeyLen == 0) goto error;
             lwm2m_free(value);
         }
 #ifndef LWM2M_VERSION_1_0
-        else if (strcasecmp(key, "registrationPriorityOrder") == 0)
+        else if (lwm2m_strcasecmp(key, "registrationPriorityOrder") == 0)
         {
             int num;
 
@@ -347,7 +347,7 @@ static read_server_t * prv_read_next_server(FILE * fd)
             readSrvP->registrationPriorityOrder = num;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "initialRegistrationDelay") == 0)
+        else if (lwm2m_strcasecmp(key, "initialRegistrationDelay") == 0)
         {
             int num;
 
@@ -356,33 +356,33 @@ static read_server_t * prv_read_next_server(FILE * fd)
             readSrvP->initialRegistrationDelayTimer = num;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "registrationFailureBlock") == 0)
+        else if (lwm2m_strcasecmp(key, "registrationFailureBlock") == 0)
         {
-            if (strcasecmp(value, "yes") == 0)
+            if (lwm2m_strcasecmp(value, "yes") == 0)
             {
                 readSrvP->registrationFailureBlock = true;
             }
-            else if (strcasecmp(value, "no") == 0)
+            else if (lwm2m_strcasecmp(value, "no") == 0)
             {
                 readSrvP->registrationFailureBlock = false;
             }
             else goto error;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "bootstrapOnRegistrationFailure") == 0)
+        else if (lwm2m_strcasecmp(key, "bootstrapOnRegistrationFailure") == 0)
         {
-            if (strcasecmp(value, "yes") == 0)
+            if (lwm2m_strcasecmp(value, "yes") == 0)
             {
                 readSrvP->bootstrapOnRegistrationFailure = true;
             }
-            else if (strcasecmp(value, "no") == 0)
+            else if (lwm2m_strcasecmp(value, "no") == 0)
             {
                 readSrvP->bootstrapOnRegistrationFailure = false;
             }
             else goto error;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "communicationRetryCount") == 0)
+        else if (lwm2m_strcasecmp(key, "communicationRetryCount") == 0)
         {
             int num;
 
@@ -391,7 +391,7 @@ static read_server_t * prv_read_next_server(FILE * fd)
             readSrvP->communicationRetryCount = num;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "communicationRetryTimer") == 0)
+        else if (lwm2m_strcasecmp(key, "communicationRetryTimer") == 0)
         {
             int num;
 
@@ -400,7 +400,7 @@ static read_server_t * prv_read_next_server(FILE * fd)
             readSrvP->communicationRetryTimer = num;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "communicationSequenceDelayTimer") == 0)
+        else if (lwm2m_strcasecmp(key, "communicationSequenceDelayTimer") == 0)
         {
             int num;
 
@@ -409,7 +409,7 @@ static read_server_t * prv_read_next_server(FILE * fd)
             readSrvP->communicationSequenceDelayTimer = num;
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "communicationSequenceRetryCount") == 0)
+        else if (lwm2m_strcasecmp(key, "communicationSequenceRetryCount") == 0)
         {
             int num;
 
@@ -628,11 +628,11 @@ static bs_endpoint_info_t * prv_read_next_endpoint(FILE * fd)
 
     while((res = prv_read_key_value(fd, &key, &value)) == 1)
     {
-        if (strcasecmp(key, "Name") == 0)
+        if (lwm2m_strcasecmp(key, "Name") == 0)
         {
             endptP->name = value;
         }
-        else if (strcasecmp(key, "Discover") == 0)
+        else if (lwm2m_strcasecmp(key, "Discover") == 0)
         {
             lwm2m_uri_t uri;
 
@@ -652,7 +652,7 @@ static bs_endpoint_info_t * prv_read_next_endpoint(FILE * fd)
 
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "Read") == 0)
+        else if (lwm2m_strcasecmp(key, "Read") == 0)
         {
 #ifndef LWM2M_VERSION_1_0
             lwm2m_uri_t uri;
@@ -673,7 +673,7 @@ static bs_endpoint_info_t * prv_read_next_endpoint(FILE * fd)
 #endif
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "Delete") == 0)
+        else if (lwm2m_strcasecmp(key, "Delete") == 0)
         {
             lwm2m_uri_t uri;
 
@@ -693,7 +693,7 @@ static bs_endpoint_info_t * prv_read_next_endpoint(FILE * fd)
 
             lwm2m_free(value);
         }
-        else if (strcasecmp(key, "Server") == 0)
+        else if (lwm2m_strcasecmp(key, "Server") == 0)
         {
             int num;
 

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -1153,12 +1153,12 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Failed to create Access Control object instance\r\n");
         return -1;
     }
-    else if (acc_ctrl_oi_add_ac_val(objArray[8], instId, 0, 0b000000000001111)==false)
+    else if (acc_ctrl_oi_add_ac_val(objArray[8], instId, 0, 0xF /* == 0b000000000001111 */)==false)
     {
         fprintf(stderr, "Failed to create Access Control ACL default resource\r\n");
         return -1;
     }
-    else if (acc_ctrl_oi_add_ac_val(objArray[8], instId, 999, 0b000000000000001)==false)
+    else if (acc_ctrl_oi_add_ac_val(objArray[8], instId, 999, 0x1 /* == 0b000000000000001 */)==false)
     {
         fprintf(stderr, "Failed to create Access Control ACL resource for serverId: 999\r\n");
         return -1;

--- a/examples/shared/connection.c
+++ b/examples/shared/connection.c
@@ -22,6 +22,10 @@
 #include "connection.h"
 #include "commandline.h"
 
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h>
+
 int create_socket(const char * portStr, int addressFamily)
 {
     int s = -1;

--- a/examples/shared/platform.c
+++ b/examples/shared/platform.c
@@ -17,6 +17,7 @@
 #include <liblwm2m.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <time.h>
@@ -35,7 +36,19 @@ void lwm2m_free(void * p)
 
 char * lwm2m_strdup(const char * str)
 {
-    return strdup(str);
+    if (!str) {
+      return NULL;
+    }
+
+    const int len = strlen(str) + 1;
+    char * const buf = lwm2m_malloc(len);
+
+    if (buf) {
+      memset(buf, 0, len);
+      memcpy(buf, str, len - 1);
+    }
+
+    return buf;
 }
 
 #endif
@@ -45,6 +58,10 @@ int lwm2m_strncmp(const char * s1,
                      size_t n)
 {
     return strncmp(s1, s2, n);
+}
+
+int lwm2m_strcasecmp(const char * str1, const char * str2) {
+    return strcasecmp(str1, str2);
 }
 
 time_t lwm2m_gettime(void)

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -120,6 +120,7 @@ void    lwm2m_trace_free(void * mem, const char * file, const char * function, i
 #endif
 // Compare at most the n first bytes of s1 and s2, return 0 if they match
 int lwm2m_strncmp(const char * s1, const char * s2, size_t n);
+int lwm2m_strcasecmp(const char * str1, const char * str2);
 // This function must return the number of seconds elapsed since origin.
 // The origin (Epoch, system boot, etc...) does not matter as this
 // function is used only to determine the elapsed time since the last
@@ -586,8 +587,6 @@ typedef struct _block_info_t
     int block_size;
     bool block_more;
 } block_info_t;
-
-typedef struct _lwm2m_context_ lwm2m_context_t;
 
 /*
  * LWM2M result callback

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 3.13)
 
 project (lwm2munittests C)
 
+add_compile_definitions(_POSIX_C_SOURCE=200809)
+
 include(${CMAKE_CURRENT_LIST_DIR}/../core/wakaama.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../coap/coap.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../data/data.cmake)

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -23,6 +23,8 @@ CMAKE_ARGS="-DCMAKE_BUILD_TYPE=RelWithDebInfo"
 RUN_CLEAN=0
 RUN_BUILD=0
 RUN_TESTS=0
+OPT_C_EXTENSIONS=""
+OPT_C_STANDARD=""
 OPT_VERBOSE=0
 OPT_SANITIZER=""
 OPT_TEST_COVERAGE_FORMAT=""
@@ -44,6 +46,11 @@ Options:
                            (BINARY: e.g. scan-build-10)
  --test-coverage FORMAT    Create coverage info in given FORMAT
                            (FORMAT: xml html text)
+ --c-standard VERSION      Explicitly specify C VERSION to be used
+                           (VERSION: 99, 11)
+ --c-extensions ENABLE     Whether to allow compiler extensions. Defaults to
+                           ON.
+                           (ENABLE: ON or OFF)
 
 Available steps (executed by --all):
   --clean                  Remove all build artifacts
@@ -120,6 +127,8 @@ fi
 if ! PARSED_OPTS=$(getopt -o vah \
                           -l all \
                           -l build \
+                          -l c-extensions: \
+                          -l c-standard: \
                           -l clean \
                           -l help \
                           -l sanitizer: \
@@ -143,6 +152,14 @@ while true; do
     --build)
       RUN_BUILD=1
       shift 1
+      ;;
+    --c-extensions)
+      OPT_C_EXTENSIONS=$2
+      shift 2
+      ;;
+    --c-standard)
+      OPT_C_STANDARD=$2
+      shift 2
       ;;
     --run-tests)
       RUN_TESTS=1
@@ -192,6 +209,14 @@ fi
 
 if [ "${OPT_VERBOSE}" -ne 0 ]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_VERBOSE_MAKEFILE=ON"
+fi
+
+if [ -n "${OPT_C_EXTENSIONS}" ]; then
+  CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_C_EXTENSIONS=${OPT_C_EXTENSIONS}"
+fi
+
+if [ -n "${OPT_C_STANDARD}" ]; then
+  CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_C_STANDARD=${OPT_C_STANDARD}"
 fi
 
 if [ -n "${OPT_SANITIZER}" ]; then


### PR DESCRIPTION
While the code base is still sprinkled with POSIX dependencies, this PR ensures the following:
* We do not use any GCC specific compiler extensions anymore
* Our code is compatible with C99

When reviewing, this should give you a couple of warnings (same as in master), but otherwise work:

```
tools/ci/run_ci.sh --clean --build --c-standard 11 --c-extensions ON
tools/ci/run_ci.sh --clean --build --c-standard 11 --c-extensions OFF
tools/ci/run_ci.sh --clean --build --c-standard 99 --c-extensions ON
tools/ci/run_ci.sh --clean --build --c-standard 99 --c-extensions OFF
```

Using this new version of run_ci.sh and the code from the current master, all builds with disabled extensions fail and the C99 ones throw additional warnings.