### PR TITLE
ci: Break build on unit test error

### DIFF
--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -79,6 +79,14 @@ int main()
 
    CU_basic_set_mode(CU_BRM_VERBOSE);
    CU_basic_run_tests();
+   CU_basic_show_failures(CU_get_failure_list());
+   printf("\n");
+
+   if (CU_get_number_of_tests_failed() > 0) {
+     return 1;
+   }
+   return 0;
+
 exit:
    CU_cleanup_registry();
    return CU_get_error();


### PR DESCRIPTION
With this commit, failing tests will break the build.

To test this locally, modify the code so that at least one test fails, then run this:
```bash
tools/ci/run_ci.sh --all
```

You should see the failing tests:
```
Run Summary:    Type  Total    Ran Passed Failed Inactive
              suites      6      6    n/a      0        0
               tests     65     65     64      1        0
             asserts    711    711    710      1      n/a

Elapsed time =    0.000 seconds

  1. /home/reto/code/3rd-party/wakaama/tests/block1tests.c:45  - CU_ASSERT_EQUAL(bsize,1)
```

The exit code should be 1:
```bash
$ echo $?
1
```