### PR TITLE
[GH-494] ci: Build and test on multiple GNU/Linux architectures

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -1,0 +1,46 @@
+name: Foreign architectures
+
+on: [push, pull_request]
+
+jobs:
+  multiarch:
+    runs-on: ubuntu-20.04
+    env:
+       cmake_version: 3.20.0
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["armv6", "armv7", "aarch64", "s390x", "ppc64le"]
+    steps:
+    - name: Checkout code including full history and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+    - name: Build and test
+      uses: uraimo/run-on-arch-action@v2.0.9
+      id: runcmd
+      with:
+        arch: ${{ matrix.arch }}
+        distro: buster
+        githubToken: ${{ github.token }}
+        install: |
+          apt update
+          apt -qy --no-install-recommends install libcunit1-dev ninja-build unzip wget build-essential
+          # Workaround because of https://gitlab.kitware.com/cmake/cmake/-/issues/20568
+          # Please remove once CMake 3.19 or newer is available in the repository
+          apt -qy --no-install-recommends install dirmngr gpg gpg-agent
+          echo deb-src http://archive.raspbian.org/raspbian buster main contrib non-free >> /etc/apt/sources.list
+          apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9165938D90FDDD2E
+          apt update
+          apt -qy --no-install-recommends build-dep cmake
+          wget https://github.com/Kitware/CMake/releases/download/v${{ env.cmake_version }}/cmake-${{ env.cmake_version }}.tar.gz
+          tar xf cmake-${{ env.cmake_version }}.tar.gz
+          cd cmake-${{ env.cmake_version }}
+          ./bootstrap -- -DCMAKE_USE_OPENSSL=OFF -DBUILD_TESTING=OFF
+          make -j $(nproc)
+          make install
+          cd ..
+          rm -r cmake-${{ env.cmake_version }} cmake-${{ env.cmake_version }}.tar.gz
+        run: |
+          tools/ci/run_ci.sh --build --run-tests

--- a/core/wakaama.cmake
+++ b/core/wakaama.cmake
@@ -41,6 +41,8 @@ endif()
 
 if (LWM2M_LITTLE_ENDIAN)
     add_compile_definitions(LWM2M_LITTLE_ENDIAN)
+else()
+    add_compile_definitions(LWM2M_BIG_ENDIAN)
 endif()
 
 # Set the LWM2M version

--- a/tests/convert_numbers_test.c
+++ b/tests/convert_numbers_test.c
@@ -89,10 +89,10 @@ static void test_utils_textToUInt(void)
 static void test_utils_textToFloat(void)
 {
     size_t i;
+    double res;
 
     for (i = 0 ; i < sizeof(floats)/sizeof(floats[0]) ; i++)
     {
-        double res;
         int converted;
 
         converted = utils_textToFloat((const uint8_t*)floats_text[i], strlen(floats_text[i]), &res, false);
@@ -109,6 +109,10 @@ static void test_utils_textToFloat(void)
             printf("Entry #%zu, \"%s\" could not be converted to \"%f\"-> fail\n", i, floats_text[i], floats[i]);
         }
     }
+
+    const char *float_with_text = "1.0-followed-by-text";
+    CU_ASSERT(utils_textToFloat((const uint8_t *)float_with_text, strlen(float_with_text), &res, true));
+    CU_ASSERT_DOUBLE_EQUAL(res, 1.0, 1.0/1000000.0);
 }
 
 static void test_utils_textToFloatExponential(void)

--- a/tests/convert_numbers_test.c
+++ b/tests/convert_numbers_test.c
@@ -115,6 +115,16 @@ static void test_utils_textToFloat(void)
     CU_ASSERT_DOUBLE_EQUAL(res, 1.0, 1.0/1000000.0);
 }
 
+static void test_utils_textToFloatNegativeTests(void)
+{
+    double res;
+
+    CU_ASSERT_FALSE(utils_textToFloat((const uint8_t *)"", 0, &res, true));
+
+    const char *not_a_float = "not-a-float";
+    CU_ASSERT_FALSE(utils_textToFloat((const uint8_t *)not_a_float, strlen(not_a_float), &res, true));
+}
+
 static void test_utils_textToFloatExponential(void)
 {
     size_t i;
@@ -142,6 +152,17 @@ static void test_utils_textToFloatExponential(void)
             printf("%zu \"%s\" -> fail\n", i, floats_exponential[i]);
         }
     }
+}
+
+static void test_utils_textToFloatUnwantedExponential(void)
+{
+    double res;
+    const char *with_exponential_e = "6.667e-11";
+
+    CU_ASSERT_FALSE(utils_textToFloat((const uint8_t *)with_exponential_e, strlen(with_exponential_e), &res, false));
+
+    const char *with_exponential_E = "2.2250738585072E-308";
+    CU_ASSERT_FALSE(utils_textToFloat((const uint8_t *)with_exponential_E, strlen(with_exponential_E), &res, false));
 }
 
 static void test_utils_textToObjLink(void)
@@ -411,7 +432,9 @@ static struct TestTable table[] = {
         { "test of utils_textToInt()", test_utils_textToInt },
         { "test of utils_textToUInt()", test_utils_textToUInt },
         { "test of utils_textToFloat()", test_utils_textToFloat },
+        { "test of utils_textToFloat(negative)", test_utils_textToFloatNegativeTests },
         { "test of utils_textToFloat(exponential)", test_utils_textToFloatExponential },
+        { "test of utils_textToFloat(unwanted exponential)", test_utils_textToFloatUnwantedExponential },
         { "test of utils_textToObjLink()", test_utils_textToObjLink },
         { "test of utils_intToText()", test_utils_intToText },
         { "test of utils_uintToText()", test_utils_uintToText },

--- a/tests/convert_numbers_test.c
+++ b/tests/convert_numbers_test.c
@@ -102,11 +102,11 @@ static void test_utils_textToFloat(void)
         {
             CU_ASSERT_DOUBLE_EQUAL(res, floats[i], floats[i]/1000000.0);
             if(fabs(res - floats[i]) > fabs(floats[i]/1000000.0))
-                printf("%zu \"%s\" -> fail (%f)\n", i, floats_text[i], res);
+                printf("Entry #%zu, \"%s\" -> fail (%f)\n", i, floats_text[i], res);
         }
         else
         {
-            printf("%zu \"%s\" -> fail\n", i, floats_text[i]);
+            printf("Entry #%zu, \"%s\" could not be converted to \"%f\"-> fail\n", i, floats_text[i], floats[i]);
         }
     }
 }


### PR DESCRIPTION
Foundation for coverage of non-amd64 GNU/Linux architectures in our CI. Not using qemu-user directly on Ubuntu 20.04 as it is missing support for certain architectures which are supported by Debian (armv6/armel, mipsel, and others).

Some unit tests where failing on aarch64, s390x and ppc64le before. Fixed it by rewriting utils_textToFloat(). See commit messages for details.

Please note:
* Due to [incompatibilities of CMake 3.16, which is bundled with Debian Buster, and QEMU](https://gitlab.kitware.com/cmake/cmake/-/issues/20568), which executes the Docker containers with the foreign architectures, updating to CMake version 3.19 or newer is needed. As KitWare only offers prebuilt binaries for x86_64 and aarch64, we need to build CMake from source, which takes a long time (~90 minutes). Luckily, the resulting docker image will be cached and subsequent runs (on the same GitHub account) run much faster.

At a later point, I intend to also add GNU/Linux on MIPSel and, if possible, ARMv5. Before this can happen however, those architectures must be added to https://github.com/uraimo/run-on-arch-action first.