### PR TITLE
Update/cleanup cmake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 # QtCreator
 build-*
 
+# CLion
+.idea
+cmake-build-*
+
 # In source build
 Makefile
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required(VERSION 3.13)
 
 project(wakaama C)
 

--- a/coap/coap.cmake
+++ b/coap/coap.cmake
@@ -7,4 +7,5 @@ set(COAP_HEADERS_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(COAP_SOURCES
     ${COAP_SOURCES_DIR}/transaction.c
     ${COAP_SOURCES_DIR}/block.c
-    ${COAP_SOURCES_DIR}/er-coap-13/er-coap-13.c)
+    ${COAP_SOURCES_DIR}/er-coap-13/er-coap-13.c
+)

--- a/core/wakaama.cmake
+++ b/core/wakaama.cmake
@@ -1,4 +1,4 @@
-# Provides WAKAAMA_SOURCES_DIR and WAKAAMA_SOURCES and WAKAAMA_DEFINITIONS variables.
+# Provides WAKAAMA_SOURCES_DIR and WAKAAMA_SOURCES variables.
 # Add LWM2M_WITH_LOGS to compile definitions to enable logging.
 # Set LWM2M_LITTLE_ENDIAN to FALSE or TRUE according to your destination platform or leave
 # it unset to determine endianess automatically.
@@ -19,11 +19,12 @@ set(WAKAAMA_SOURCES
     ${WAKAAMA_SOURCES_DIR}/management.c
     ${WAKAAMA_SOURCES_DIR}/observe.c
     ${WAKAAMA_SOURCES_DIR}/discover.c
-    ${WAKAAMA_SOURCES_DIR}/internals.h)
+    ${WAKAAMA_SOURCES_DIR}/internals.h
+)
 
 # This will not work for multi project cmake generators like the Visual Studio Generator
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-   set(WAKAAMA_DEFINITIONS ${WAKAAMA_DEFINITIONS} -DLWM2M_WITH_LOGS)
+    add_compile_definitions(LWM2M_WITH_LOGS)
 endif()
 
 # Automatically determine endianess. This can be overwritten by setting LWM2M_LITTLE_ENDIAN
@@ -32,17 +33,18 @@ if(NOT DEFINED LWM2M_LITTLE_ENDIAN)
     include(TestBigEndian)
     TEST_BIG_ENDIAN(LWM2M_BIG_ENDIAN)
     if (LWM2M_BIG_ENDIAN)
-         set(LWM2M_LITTLE_ENDIAN FALSE)
+        set(LWM2M_LITTLE_ENDIAN FALSE)
     else()
-         set(LWM2M_LITTLE_ENDIAN TRUE)
+        set(LWM2M_LITTLE_ENDIAN TRUE)
     endif()
 endif()
+
 if (LWM2M_LITTLE_ENDIAN)
-    set(WAKAAMA_DEFINITIONS ${WAKAAMA_DEFINITIONS} -DLWM2M_LITTLE_ENDIAN)
+    add_compile_definitions(LWM2M_LITTLE_ENDIAN)
 endif()
 
 # Set the LWM2M version
 set(LWM2M_VERSION "1.1" CACHE STRING "LWM2M version for client and max LWM2M version for server.")
 if(LWM2M_VERSION VERSION_EQUAL "1.0")
-    set(WAKAAMA_DEFINITIONS ${WAKAAMA_DEFINITIONS} -DLWM2M_VERSION_1_0)
+    add_compile_definitions(LWM2M_VERSION_1_0)
 endif()

--- a/data/data.cmake
+++ b/data/data.cmake
@@ -9,4 +9,5 @@ set(DATA_SOURCES
     ${DATA_SOURCES_DIR}/tlv.c
     ${DATA_SOURCES_DIR}/json.c
     ${DATA_SOURCES_DIR}/senml_json.c
-    ${DATA_SOURCES_DIR}/json_common.c)
+    ${DATA_SOURCES_DIR}/json_common.c
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.13)
 
 add_compile_definitions(_POSIX_C_SOURCE=200809)
 add_compile_options(-pedantic)

--- a/examples/bootstrap_server/CMakeLists.txt
+++ b/examples/bootstrap_server/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required(VERSION 3.13)
 
-project (bootstrap_server C)
+project(bootstrap_server C)
 
 if(DTLS)
-    message(FATAL_ERROR "DTLS option is not supported." )
+    message(FATAL_ERROR "DTLS option is not supported.")
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../../core/wakaama.cmake)
@@ -11,23 +11,18 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../coap/coap.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../../data/data.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/shared.cmake)
 
-add_definitions(-DLWM2M_BOOTSTRAP_SERVER_MODE)
-add_definitions(${SHARED_DEFINITIONS} ${WAKAAMA_DEFINITIONS})
+add_compile_definitions(LWM2M_BOOTSTRAP_SERVER_MODE)
 
-include_directories (${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
+include_directories(${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
 
 SET(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/bootstrap_server.c
     ${CMAKE_CURRENT_LIST_DIR}/bootstrap_info.c
     ${CMAKE_CURRENT_LIST_DIR}/bootstrap_info.h
-    )
+)
 
-SET(AUXILIARY_FILES
-    ${CMAKE_CURRENT_LIST_DIR}/bootstrap_server.ini)
+SET(AUXILIARY_FILES ${CMAKE_CURRENT_LIST_DIR}/bootstrap_server.ini)
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${AUXILIARY_FILES} ${WAKAAMA_SOURCES} ${COAP_SOURCES} ${DATA_SOURCES} ${SHARED_SOURCES})
-
-# Add WITH_LOGS to debug variant
-set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:WITH_LOGS>)
 
 SOURCE_GROUP(wakaama FILES ${WAKAAMA_SOURCES})

--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required(VERSION 3.13)
 
-project (lwm2mclient C)
+project(lwm2mclient C)
 
 option(DTLS "Enable DTLS" OFF)
 
@@ -9,18 +9,18 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../coap/coap.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../../data/data.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/shared.cmake)
 
-add_definitions(-DLWM2M_CLIENT_MODE -DLWM2M_BOOTSTRAP)
-if(LWM2M_VERSION VERSION_GREATER "1.0") 
-    add_definitions(-DLWM2M_SUPPORT_SENML_JSON)
+add_compile_definitions(LWM2M_CLIENT_MODE)
+add_compile_definitions(LWM2M_BOOTSTRAP)
+
+if(LWM2M_VERSION VERSION_GREATER "1.0")
+    add_compile_definitions(LWM2M_SUPPORT_SENML_JSON)
 else()
-    add_definitions(-DLWM2M_SUPPORT_JSON)
+    add_compile_definitions(LWM2M_SUPPORT_JSON)
 endif()
 
 if(LWM2M_RAW_BLOCK1_REQUESTS)
-    add_definitions(-DLWM2M_RAW_BLOCK1_REQUESTS)
+    add_compile_definitions(LWM2M_RAW_BLOCK1_REQUESTS)
 endif()
-
-add_definitions(${SHARED_DEFINITIONS} ${WAKAAMA_DEFINITIONS})
 
 include_directories (${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
 
@@ -37,11 +37,8 @@ SET(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/object_connectivity_stat.c
     ${CMAKE_CURRENT_LIST_DIR}/object_access_control.c
     ${CMAKE_CURRENT_LIST_DIR}/object_test.c
-    )
+)
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${WAKAAMA_SOURCES} ${COAP_SOURCES} ${DATA_SOURCES} ${SHARED_SOURCES})
-
-# Add WITH_LOGS to debug variant
-set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:WITH_LOGS>)
 
 SOURCE_GROUP(wakaama FILES ${WAKAAMA_SOURCES})

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -806,7 +806,7 @@ static void update_bootstrap_info(lwm2m_client_state_t * previousBootstrapState,
         switch(context->state)
         {
             case STATE_BOOTSTRAPPING:
-#ifdef WITH_LOGS
+#ifdef LWM2M_WITH_LOGS
                 fprintf(stdout, "[BOOTSTRAP] backup security and server objects\r\n");
 #endif
                 prv_backup_objects(context);
@@ -1277,7 +1277,7 @@ int main(int argc, char *argv[])
             fprintf(stderr, "lwm2m_step() failed: 0x%X\r\n", result);
             if(previousState == STATE_BOOTSTRAPPING)
             {
-#ifdef WITH_LOGS
+#ifdef LWM2M_WITH_LOGS
                 fprintf(stdout, "[BOOTSTRAP] restore security and server objects\r\n");
 #endif
                 prv_restore_objects(lwm2mH);

--- a/examples/lightclient/CMakeLists.txt
+++ b/examples/lightclient/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required(VERSION 3.13)
 
-project (lightclient C)
+project(lightclient C)
 
 if(DTLS)
     message(FATAL_ERROR "DTLS option is not supported." )
@@ -11,14 +11,13 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../coap/coap.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../../data/data.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/shared.cmake)
 
-add_definitions(-DLWM2M_CLIENT_MODE)
+add_compile_definitions(LWM2M_CLIENT_MODE)
+
 if(LWM2M_VERSION VERSION_GREATER "1.0")
-    add_definitions(-DLWM2M_SUPPORT_SENML_JSON)
+    add_compile_definitions(LWM2M_SUPPORT_SENML_JSON)
 endif()
 
-add_definitions(${SHARED_DEFINITIONS} ${WAKAAMA_DEFINITIONS})
-
-include_directories (${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
+include_directories(${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
 
 SET(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/lightclient.c
@@ -26,11 +25,8 @@ SET(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/object_server.c
     ${CMAKE_CURRENT_LIST_DIR}/object_device.c
     ${CMAKE_CURRENT_LIST_DIR}/object_test.c
-    )
+)
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${WAKAAMA_SOURCES} ${COAP_SOURCES} ${DATA_SOURCES} ${SHARED_SOURCES})
-
-# Add WITH_LOGS to debug variant
-set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:WITH_LOGS>)
 
 SOURCE_GROUP(wakaama FILES ${WAKAAMA_SOURCES})

--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required(VERSION 3.13)
 
-project (lwm2mserver C)
+project(lwm2mserver C)
 
 if(DTLS)
-    message(FATAL_ERROR "DTLS option is not supported." )
+    message(FATAL_ERROR "DTLS option is not supported.")
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../../core/wakaama.cmake)
@@ -11,18 +11,14 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../coap/coap.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../../data/data.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../shared/shared.cmake)
 
-add_definitions(-DLWM2M_SERVER_MODE)
-add_definitions(${SHARED_DEFINITIONS} ${WAKAAMA_DEFINITIONS})
+add_compile_definitions(LWM2M_SERVER_MODE)
 
-include_directories (${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
+include_directories(${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
 
 SET(SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/lwm2mserver.c
-    )
+)
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${WAKAAMA_SOURCES} ${COAP_SOURCES} ${DATA_SOURCES} ${SHARED_SOURCES})
-
-# Add WITH_LOGS to debug variant
-set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:WITH_LOGS>)
 
 SOURCE_GROUP(wakaama FILES ${WAKAAMA_SOURCES})

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -1037,7 +1037,6 @@ void print_usage(void)
     fprintf(stdout, "\r\n");
 }
 
-
 int main(int argc, char *argv[])
 {
     int sock;

--- a/examples/shared/connection.c
+++ b/examples/shared/connection.c
@@ -168,7 +168,7 @@ int connection_send(connection_t *connP,
     int nbSent;
     size_t offset;
 
-#ifdef WITH_LOGS
+#ifdef LWM2M_WITH_LOGS
     char s[INET6_ADDRSTRLEN];
     in_port_t port;
 

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -137,7 +137,7 @@ int send_data(dtls_connection_t *connP,
     int nbSent;
     size_t offset;
 
-#ifdef WITH_LOGS
+#ifdef LWM2M_WITH_LOGS
     char s[INET6_ADDRSTRLEN];
     in_port_t port;
 

--- a/examples/shared/shared.cmake
+++ b/examples/shared/shared.cmake
@@ -5,27 +5,29 @@ set(SHARED_SOURCES_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(SHARED_SOURCES 
     ${SHARED_SOURCES_DIR}/commandline.c
     ${SHARED_SOURCES_DIR}/platform.c
-	${SHARED_SOURCES_DIR}/memtrace.c)
+    ${SHARED_SOURCES_DIR}/memtrace.c
+)
 
 if(DTLS)
     include(${CMAKE_CURRENT_LIST_DIR}/tinydtls.cmake)
 
     set(SHARED_SOURCES
-	    ${SHARED_SOURCES}
-		${TINYDTLS_SOURCES}
-		${SHARED_SOURCES_DIR}/dtlsconnection.c)
-    
-	set(SHARED_INCLUDE_DIRS
-		${SHARED_SOURCES_DIR} 
-		${TINYDTLS_SOURCES_DIR})
-    
-	set(SHARED_DEFINITIONS -DWITH_TINYDTLS)
+        ${SHARED_SOURCES}
+        ${TINYDTLS_SOURCES}
+        ${SHARED_SOURCES_DIR}/dtlsconnection.c
+    )
+
+    set(SHARED_INCLUDE_DIRS
+        ${SHARED_SOURCES_DIR}
+        ${TINYDTLS_SOURCES_DIR}
+    )
+
+    add_compile_definitions(WITH_TINYDTLS)
 else()
     set(SHARED_SOURCES
-		${SHARED_SOURCES} 
-		${SHARED_SOURCES_DIR}/connection.c)
+        ${SHARED_SOURCES}
+        ${SHARED_SOURCES_DIR}/connection.c
+    )
 
     set(SHARED_INCLUDE_DIRS ${SHARED_SOURCES_DIR})
 endif()
-
-

--- a/examples/shared/tinydtls.cmake
+++ b/examples/shared/tinydtls.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required (VERSION 3.0)
-
 # List source files
 set(TINYDTLS_SOURCES_DIR ${CMAKE_CURRENT_LIST_DIR}/tinydtls)
 set(TINYDTLS_SOURCES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required (VERSION 3.13)
+cmake_minimum_required(VERSION 3.13)
 
-project (lwm2munittests C)
+project(lwm2munittests C)
 
 add_compile_definitions(_POSIX_C_SOURCE=200809)
 
@@ -9,15 +9,18 @@ include(${CMAKE_CURRENT_LIST_DIR}/../coap/coap.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../data/data.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../examples/shared/shared.cmake)
 
-add_definitions(-DLWM2M_CLIENT_MODE -DLWM2M_SUPPORT_TLV -DLWM2M_SUPPORT_JSON)
-if(LWM2M_VERSION VERSION_GREATER "1.0")
-    add_definitions(-DLWM2M_SUPPORT_SENML_JSON)
-endif()
-add_definitions(${SHARED_DEFINITIONS} ${WAKAAMA_DEFINITIONS})
-# Enable all warnings for this test build  
-add_definitions(-pedantic -Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default)
+add_compile_definitions(LWM2M_CLIENT_MODE)
+add_compile_definitions(LWM2M_SUPPORT_TLV)
+add_compile_definitions(LWM2M_SUPPORT_JSON)
 
-include_directories (${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
+if(LWM2M_VERSION VERSION_GREATER "1.0")
+    add_compile_definitions(LWM2M_SUPPORT_SENML_JSON)
+endif()
+
+# Enable all warnings for this test build  
+add_compile_options(-pedantic -Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default)
+
+include_directories(${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
 set_source_files_properties(${DATA_SOURCES_DIR}/senml_json.c PROPERTIES COMPILE_FLAGS -Wno-float-equal)
 
 file(GLOB SOURCES "*.c")


### PR DESCRIPTION
This is a pre-work/cleanup to make the CoAP block-size configurable during build time (via cmake variable) in a future PR.
 - Replace redundant WITH_LOG since it was only rarely used and we have LWM2M_WITH_LOG.
 - Replace add_definitions with modern alternatives.
 - Set a common minimal required cmake version.

I bumped the cmake version in all files to 3.13 to support all required features and to be consistent (3.13 is currently available in Debian stable, so still quite conservative). Also tried to make the formatting a bit more homogeneous.
