### PR TITLE
ci: Add CodeQL code scanning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: '**'
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '20 14 * * 1'
+
+jobs:
+  codeql:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code including full history and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Install dependencies from APT repository
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcunit1-dev wget unzip
+
+    - name: Install CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@master
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: cpp
+
+    - name: Build all binaries
+      run: tools/ci/run_ci.sh --build
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
A standard setup of [CodeQL](https://github.com/github/codeql-action/). While not yielding as many findings as Clang Static Analyzer or SonarQube, it might still give us some valuable, extra static code analysis. The results get nicely integrated in the security tab of the GitHub repository.

While I have never used CodeQL before, I expect the maintenance of this tool to be quite low. So far it has yielded just one, legit, finding. I have not resolved it yet as it nicely shows the purpose/capability of this analyzer.