### PR TITLE
CI: Add gitlint

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -1,0 +1,23 @@
+name: Compliance
+
+on: pull_request
+
+jobs:
+  check-gitlint:
+    name: Run gitlint
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code including full history
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install gitlint
+      run: |
+        pip3 install gitlint
+
+    - name: Check commits with checkpatch
+      run: |
+        git branch -a
+        tools/ci/run_ci.sh --branch-target origin/${{ github.base_ref }} --run-gitlint

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,12 @@
+[general]
+ignore-fixup-commits=false
+
+[title-must-not-contain-word]
+words=wip,fixup
+
+# Enforce at least 20 characters (default value) in every commit body
+[body-min-length]
+
+# Tags do not count towards the body length
+[ignore-body-lines]
+regex=^Signed-off-by


### PR DESCRIPTION
This is a fairly default configuration, which, among other stuff, checks for the subject line being 72 or less characters is required by the Eclipse project handbook.

Non-default rules:
- Enforce at least 20 characters in the commit body
- Disallow the word "fixup" in the title messages. Intended to prevent accidents like d31d026.

In case any of those rules get in the way, use the "gitlint-ignore" tag in the commit message to suppress gitlint findings for this specific commit. To configure a rule permanently, adapt .gitlint.

The GitHub Action runs only on PRs, not after each push. The idea is to prevent annoyance when working on code, using WIP or other non-compliant commit messages.

Ideas to test this PR locally:
- Create a new branch (derived from this one), add some good, some sloppy commits, then run `tools/ci/run_ci.sh --run-gitlint` on it
- Run the checker on the last 100 commits: `tools/ci/run_ci.sh --run-gitlint --branch-source HEAD --branch-target HEAD~100`