### PR TITLE
Fix payload buffer use after free

### DIFF
--- a/coap/transaction.c
+++ b/coap/transaction.c
@@ -256,6 +256,7 @@ void transaction_free(lwm2m_transaction_t * transacP)
     {
        coap_free_header(transacP->message);
        lwm2m_free(transacP->message);
+       transacP->message = NULL;
     }
 
     if (transacP->payload) {
@@ -263,7 +264,11 @@ void transaction_free(lwm2m_transaction_t * transacP)
         transacP->payload = NULL;
     }
 
-    if (transacP->buffer) lwm2m_free(transacP->buffer);
+    if (transacP->buffer) {
+        lwm2m_free(transacP->buffer);
+        transacP->buffer = NULL;
+    }
+
     lwm2m_free(transacP);
 }
 

--- a/core/bootstrap.c
+++ b/core/bootstrap.c
@@ -1224,7 +1224,10 @@ int lwm2m_bootstrap_write(lwm2m_context_t * contextP,
 
     coap_set_header_content_type(transaction->message, format);
 
-    transaction_set_payload(transaction, buffer, length);
+    if (!transaction_set_payload(transaction, buffer, length)) {
+        transaction_free(transaction);
+        return COAP_500_INTERNAL_SERVER_ERROR;
+    }
 
     dataP = (bs_data_t *)lwm2m_malloc(sizeof(bs_data_t));
     if (dataP == NULL)

--- a/core/internals.h
+++ b/core/internals.h
@@ -329,7 +329,7 @@ void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transa
 bool transaction_handleResponse(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 bool transaction_free_userData(lwm2m_context_t * context, lwm2m_transaction_t * transaction);
-void transaction_set_payload(lwm2m_transaction_t * transaction, uint8_t * buffer, int length);
+bool transaction_set_payload(lwm2m_transaction_t *transaction, uint8_t *buffer, int length);
 
 // defined in management.c
 uint8_t dm_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);

--- a/core/management.c
+++ b/core/management.c
@@ -520,8 +520,11 @@ static int prv_makeOperation(lwm2m_context_t * contextP,
         coap_set_header_content_type(transaction->message, format);
         
         // TODO: Take care of fragmentation
- 
-        transaction_set_payload(transaction, buffer, length);
+
+        if (!transaction_set_payload(transaction, buffer, length)) {
+            transaction_free(transaction);
+            return COAP_500_INTERNAL_SERVER_ERROR;
+        }
     }
 
     if (callback != NULL)

--- a/core/management.c
+++ b/core/management.c
@@ -518,9 +518,6 @@ static int prv_makeOperation(lwm2m_context_t * contextP,
     else if (buffer != NULL)
     {
         coap_set_header_content_type(transaction->message, format);
-        
-        // TODO: Take care of fragmentation
-
         if (!transaction_set_payload(transaction, buffer, length)) {
             transaction_free(transaction);
             return COAP_500_INTERNAL_SERVER_ERROR;

--- a/core/packet.c
+++ b/core/packet.c
@@ -321,8 +321,14 @@ static lwm2m_transaction_t * prv_create_next_block_transaction(lwm2m_transaction
     {
         coap_set_header_if_none_match(clone->message);
     }
-    
-    clone->payload = transaction->payload;
+
+    uint8_t *cloned_transaction_payload = (uint8_t *)lwm2m_malloc(transaction->payload_len);
+    if (cloned_transaction_payload == NULL) {
+        return NULL;
+    }
+    memcpy(cloned_transaction_payload, transaction->payload, transaction->payload_len);
+
+    clone->payload = cloned_transaction_payload;
     clone->payload_len = transaction->payload_len;
     clone->callback = transaction->callback;
     clone->userData = transaction->userData;

--- a/core/registration.c
+++ b/core/registration.c
@@ -785,7 +785,12 @@ static uint8_t prv_register(lwm2m_context_t * contextP,
     coap_set_header_uri_query(transaction->message, query);
     coap_set_header_content_type(transaction->message, LWM2M_CONTENT_LINK);
 
-    transaction_set_payload(transaction, payload, payload_length);
+    if (!transaction_set_payload(transaction, payload, payload_length)) {
+        lwm2m_free(payload);
+        lwm2m_free(query);
+        transaction_free(transaction);
+        return COAP_503_SERVICE_UNAVAILABLE;
+    }
 
     registration_data_t * dataP = (registration_data_t *) lwm2m_malloc(sizeof(registration_data_t));
     if (dataP == NULL){
@@ -894,7 +899,12 @@ static int prv_updateRegistration(lwm2m_context_t * contextP,
             lwm2m_free(payload);
             return COAP_500_INTERNAL_SERVER_ERROR;
         }
-        transaction_set_payload(transaction, payload, payload_length);
+
+        if (!transaction_set_payload(transaction, payload, payload_length)) {
+            transaction_free(transaction);
+            lwm2m_free(payload);
+            return COAP_500_INTERNAL_SERVER_ERROR;
+        }
     }
 
     registration_data_t * dataP = (registration_data_t *) lwm2m_malloc(sizeof(registration_data_t));

--- a/core/registration.c
+++ b/core/registration.c
@@ -796,6 +796,7 @@ static uint8_t prv_register(lwm2m_context_t * contextP,
     if (dataP == NULL){
         lwm2m_free(payload);
         lwm2m_free(query);
+        transaction_free(transaction);
         return COAP_503_SERVICE_UNAVAILABLE;
     }
 
@@ -909,6 +910,7 @@ static int prv_updateRegistration(lwm2m_context_t * contextP,
 
     registration_data_t * dataP = (registration_data_t *) lwm2m_malloc(sizeof(registration_data_t));
     if (dataP == NULL){
+        transaction_free(transaction);
         lwm2m_free(payload);
         return COAP_500_INTERNAL_SERVER_ERROR;
     }


### PR DESCRIPTION
The caller of a method (e.g. `lwm2m_dm_write`) could have free'd the buffer after
the method completes (assuming that he retains ownership of allocated memory).
But the payload buffer is used by wakaama even beyond the scope of the method /
current transaction. This happens for block transfers but could also happen in
case of re-transmissions. For such cases, it is necessary for wakaama to copy
the payload for the transaction.