### PR TITLE
fix: errors in transaction handling

### DIFF
--- a/coap/transaction.c
+++ b/coap/transaction.c
@@ -122,6 +122,10 @@ static int prv_checkFinished(lwm2m_transaction_t * transacP,
     uint8_t* token;
     coap_packet_t * transactionMessage = (coap_packet_t *) transacP->message;
 
+    if (transactionMessage->mid != receivedMessage->mid) {
+        return false;
+    }
+
     if (COAP_DELETE < transactionMessage->code)
     {
         // response

--- a/core/packet.c
+++ b/core/packet.c
@@ -230,6 +230,12 @@ static lwm2m_transaction_t * prv_get_transaction(lwm2m_context_t * contextP, voi
     {
         transaction = transaction->next;
     }
+
+    if (transaction != NULL && lwm2m_session_is_equal(sessionH, transaction->peerH, contextP->userData) == false &&
+        transaction->mID != mid) {
+        return NULL;
+    }
+
     return transaction;
 }
 


### PR DESCRIPTION
- ` prv_get_transaction` did return non-matching transaction if only one
  transaction was in the list
- `prv_checkFinished` did not check if the `mid` did match, resulting in a wrong
  transaction to be removed in `transaction_handleResponse`