### PR TITLE
fix: errors in transaction handling

### DIFF
--- a/coap/transaction.c
+++ b/coap/transaction.c
@@ -122,6 +122,10 @@ static int prv_checkFinished(lwm2m_transaction_t * transacP,
     uint8_t* token;
     coap_packet_t * transactionMessage = (coap_packet_t *) transacP->message;
 
+    if (transactionMessage->mid != receivedMessage->mid) {
+        return false;
+    }
+
     if (COAP_DELETE < transactionMessage->code)
     {
         // response

--- a/core/packet.c
+++ b/core/packet.c
@@ -224,13 +224,17 @@ static lwm2m_transaction_t * prv_get_transaction(lwm2m_context_t * contextP, voi
     lwm2m_transaction_t * transaction;
 
     transaction = contextP->transactionList;
-    while (transaction != NULL
-           && lwm2m_session_is_equal(sessionH, transaction->peerH, contextP->userData) == false
-           && transaction->mID != mid)
-    {
+    while (transaction != NULL && (lwm2m_session_is_equal(sessionH, transaction->peerH, contextP->userData) == false ||
+                                   transaction->mID != mid)) {
         transaction = transaction->next;
     }
-    return transaction;
+
+    if (transaction != NULL &&
+        (lwm2m_session_is_equal(sessionH, transaction->peerH, contextP->userData) == true && transaction->mID == mid)) {
+        return transaction;
+    }
+
+    return NULL;
 }
 
 // limited clone of transaction to be used by block transfers


### PR DESCRIPTION
- `prv_get_transaction` did return non-matching transaction if only one
  transaction was in the list or only session or mid did match
- `prv_checkFinished` did not check if the mid did match, resulting in a wrong
  transaction to be removed in `transaction_handleResponse`