### PR TITLE
[#618] Fix payload_len handling

### DIFF
--- a/coap/er-coap-13/er-coap-13.c
+++ b/coap/er-coap-13/er-coap-13.c
@@ -1499,8 +1499,7 @@ coap_set_header_size(void *packet, uint32_t size)
 /*-----------------------------------------------------------------------------------*/
 /*- PAYLOAD -------------------------------------------------------------------------*/
 /*-----------------------------------------------------------------------------------*/
-int
-coap_get_payload(void *packet, const uint8_t **payload)
+size_t coap_get_payload(void *packet, const uint8_t **payload)
 {
   coap_packet_t *const coap_pkt = (coap_packet_t *) packet;
 
@@ -1513,8 +1512,7 @@ coap_get_payload(void *packet, const uint8_t **payload)
   }
 }
 
-int
-coap_set_payload(void *packet, const void *payload, size_t length)
+size_t coap_set_payload(void *packet, const void *payload, size_t length)
 {
   coap_packet_t *const coap_pkt = (coap_packet_t *) packet;
 

--- a/coap/er-coap-13/er-coap-13.h
+++ b/coap/er-coap-13/er-coap-13.h
@@ -240,7 +240,7 @@ typedef struct {
   multi_option_t *uri_query;
   uint8_t if_none_match;
 
-  uint16_t payload_len;
+  size_t payload_len;
   uint8_t *payload;
 
 } coap_packet_t;
@@ -383,7 +383,7 @@ int coap_get_header_block(void *packet, uint32_t *num, uint8_t *more, uint16_t *
 int coap_get_header_size(void *packet, uint32_t *size);
 int coap_set_header_size(void *packet, uint32_t size);
 
-int coap_get_payload(void *packet, const uint8_t **payload);
-int coap_set_payload(void *packet, const void *payload, size_t length);
+size_t coap_get_payload(void *packet, const uint8_t **payload);
+size_t coap_set_payload(void *packet, const void *payload, size_t length);
 
 #endif /* COAP_13_H_ */

--- a/coap/transaction.c
+++ b/coap/transaction.c
@@ -493,7 +493,7 @@ void transaction_step(lwm2m_context_t * contextP,
     }
 }
 
-bool transaction_set_payload(lwm2m_transaction_t *transaction, uint8_t *buffer, int length) {
+bool transaction_set_payload(lwm2m_transaction_t *transaction, uint8_t *buffer, size_t length) {
     // copy payload as we might need it beyond scope of the current request / method call (e.g. in case of
     // retransmissions or block transfer)
     uint8_t *transaction_payload = (uint8_t *)lwm2m_malloc(length);

--- a/core/internals.h
+++ b/core/internals.h
@@ -329,7 +329,7 @@ void transaction_remove(lwm2m_context_t * contextP, lwm2m_transaction_t * transa
 bool transaction_handleResponse(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void transaction_step(lwm2m_context_t * contextP, time_t currentTime, time_t * timeoutP);
 bool transaction_free_userData(lwm2m_context_t * context, lwm2m_transaction_t * transaction);
-bool transaction_set_payload(lwm2m_transaction_t *transaction, uint8_t *buffer, int length);
+bool transaction_set_payload(lwm2m_transaction_t *transaction, uint8_t *buffer, size_t length);
 
 // defined in management.c
 uint8_t dm_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, lwm2m_server_t * serverP, coap_packet_t * message, coap_packet_t * response);
@@ -343,7 +343,6 @@ void observe_clear(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
 bool observe_handleNotify(lwm2m_context_t * contextP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);
 void observe_remove(lwm2m_observation_t * observationP);
 lwm2m_observed_t * observe_findByUri(lwm2m_context_t * contextP, lwm2m_uri_t * uriP);
-void applyObservationCallback(lwm2m_observation_t * observation, int status, block_info_t * block_info, lwm2m_media_type_t format, uint8_t * data, int dataLength);
 
 // defined in registration.c
 uint8_t registration_handleRequest(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, void * fromSessionH, coap_packet_t * message, coap_packet_t * response);

--- a/core/management.c
+++ b/core/management.c
@@ -491,16 +491,9 @@ static void prv_resultCallback(lwm2m_context_t * contextP,
     transaction_free_userData(contextP, transacP);
 }
 
-static int prv_makeOperation(lwm2m_context_t * contextP,
-                             uint16_t clientID,
-                             lwm2m_uri_t * uriP,
-                             coap_method_t method,
-                             lwm2m_media_type_t format,
-                             uint8_t * buffer,
-                             int length,
-                             lwm2m_result_callback_t callback,
-                             void * userData)
-{
+static int prv_makeOperation(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP, coap_method_t method,
+                             lwm2m_media_type_t format, uint8_t *buffer, size_t length,
+                             lwm2m_result_callback_t callback, void *userData) {
     lwm2m_client_t * clientP;
     lwm2m_transaction_t * transaction;
     dm_data_t * dataP;
@@ -577,17 +570,9 @@ int lwm2m_dm_read(lwm2m_context_t * contextP,
     return prv_lwm2m_dm_read(contextP, clientID, uriP, callback, userData);
 }
 
-static
-int prv_lwm2m_dm_write(lwm2m_context_t * contextP,
-                   uint16_t clientID,
-                   lwm2m_uri_t * uriP,
-                   lwm2m_media_type_t format,
-                   uint8_t * buffer,
-                   int length,
-                   bool partialUpdate,
-                   lwm2m_result_callback_t callback,
-                   void * userData)
-{
+static int prv_lwm2m_dm_write(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP,
+                              lwm2m_media_type_t format, uint8_t *buffer, size_t length, bool partialUpdate,
+                              lwm2m_result_callback_t callback, void *userData) {
     coap_method_t method = partialUpdate ? COAP_POST : COAP_PUT;
 
     LOG_ARG("clientID: %d, format: %s, length: %d", clientID, STR_MEDIA_TYPE(format), length);
@@ -611,28 +596,14 @@ int prv_lwm2m_dm_write(lwm2m_context_t * contextP,
     }
 }
 
-int lwm2m_dm_write(lwm2m_context_t * contextP,
-                   uint16_t clientID,
-                   lwm2m_uri_t * uriP,
-                   lwm2m_media_type_t format,
-                   uint8_t * buffer,
-                   int length,
-                   bool partialUpdate,
-                   lwm2m_result_callback_t callback,
-                   void * userData)
-{
+int lwm2m_dm_write(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP, lwm2m_media_type_t format,
+                   uint8_t *buffer, size_t length, bool partialUpdate, lwm2m_result_callback_t callback,
+                   void *userData) {
     return prv_lwm2m_dm_write(contextP, clientID, uriP, format, buffer, length, partialUpdate, callback, userData);
 }
 
-int lwm2m_dm_execute(lwm2m_context_t * contextP,
-                     uint16_t clientID,
-                     lwm2m_uri_t * uriP,
-                     lwm2m_media_type_t format,
-                     uint8_t * buffer,
-                     int length,
-                     lwm2m_result_callback_t callback,
-                     void * userData)
-{
+int lwm2m_dm_execute(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP, lwm2m_media_type_t format,
+                     uint8_t *buffer, size_t length, lwm2m_result_callback_t callback, void *userData) {
     LOG_ARG("clientID: %d, format: %s, length: %d", clientID, STR_MEDIA_TYPE(format), length);
     LOG_URI(uriP);
     if (!LWM2M_URI_IS_SET_RESOURCE(uriP))

--- a/core/packet.c
+++ b/core/packet.c
@@ -338,13 +338,13 @@ static int prv_send_new_block1(lwm2m_context_t * contextP, lwm2m_transaction_t *
 {
     lwm2m_transaction_t * next;
     // Done sending block
-    if (block_num * block_size >= previous->payload_len)
+    if (block_num * (size_t)block_size >= previous->payload_len)
         return 0;
 
     next = prv_create_next_block_transaction(previous, contextP->nextMID++);
     if (next == NULL) return COAP_500_INTERNAL_SERVER_ERROR;
 
-    size_t remaining_payload_length = next->payload_len - block_num * block_size;
+    size_t remaining_payload_length = next->payload_len - block_num * (size_t)block_size;
     uint8_t *new_block_start = next->payload + block_num * block_size;
 
     coap_set_header_block1(next->message, block_num, remaining_payload_length > block_size, block_size);
@@ -386,7 +386,7 @@ static int prv_change_to_block1(lwm2m_context_t * contextP, void * sessionH, uin
     
     transaction = prv_get_transaction(contextP, sessionH, mid);
 
-    for (int n = 1; 16 << n <= (int)size ; n++) {
+    for (uint16_t n = 1; 16 << n <= (uint16_t)size; n++) {
         block_size = 16 << n;
     }
 
@@ -473,16 +473,15 @@ static int prv_send_get_next_block2(lwm2m_context_t * contextP,
  * Erbium is Copyright (c) 2013, Institute for Pervasive Computing, ETH Zurich
  * All rights reserved.
  */
-void lwm2m_handle_packet(lwm2m_context_t * contextP,
-                         uint8_t * buffer,
-                         int length,
-                         void * fromSessionH)
-{
+void lwm2m_handle_packet(lwm2m_context_t *contextP, uint8_t *buffer, size_t length, void *fromSessionH) {
     uint8_t coap_error_code = NO_ERROR;
     static coap_packet_t message[1];
     static coap_packet_t response[1];
 
     LOG("Entering");
+    /* The buffer length is uint16_t here, as UDP packet length field is 16 bit.
+     * This might change in the future e.g. for supporting TCP or other transport.
+     */
     coap_error_code = coap_parse_message(message, buffer, (uint16_t)length);
     if (coap_error_code == NO_ERROR)
     {
@@ -854,7 +853,6 @@ void lwm2m_handle_packet(lwm2m_context_t * contextP,
         message_send(contextP, message, fromSessionH);
     }
 }
-
 
 uint8_t message_send(lwm2m_context_t * contextP,
                      coap_packet_t * message,

--- a/core/registration.c
+++ b/core/registration.c
@@ -785,7 +785,7 @@ static uint8_t prv_register(lwm2m_context_t * contextP,
     coap_set_header_uri_query(transaction->message, query);
     coap_set_header_content_type(transaction->message, LWM2M_CONTENT_LINK);
 
-    if (!transaction_set_payload(transaction, payload, payload_length)) {
+    if (!transaction_set_payload(transaction, payload, (size_t)payload_length)) {
         lwm2m_free(payload);
         lwm2m_free(query);
         transaction_free(transaction);
@@ -901,7 +901,7 @@ static int prv_updateRegistration(lwm2m_context_t * contextP,
             return COAP_500_INTERNAL_SERVER_ERROR;
         }
 
-        if (!transaction_set_payload(transaction, payload, payload_length)) {
+        if (!transaction_set_payload(transaction, payload, (size_t)payload_length)) {
             transaction_free(transaction);
             lwm2m_free(payload);
             return COAP_500_INTERNAL_SERVER_ERROR;
@@ -1616,12 +1616,9 @@ static int prv_getId(uint8_t * data,
     return result;
 }
 
-static lwm2m_client_object_t * prv_decodeRegisterPayload(uint8_t * payload,
-                                                         uint16_t payloadLength,
-                                                         lwm2m_media_type_t * format,
-                                                         char ** altPath)
-{
-    uint16_t index;
+static lwm2m_client_object_t *prv_decodeRegisterPayload(uint8_t *payload, size_t payloadLength,
+                                                        lwm2m_media_type_t *format, char **altPath) {
+    size_t index;
     lwm2m_client_object_t * objList;
     bool linkAttrFound;
 

--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -332,16 +332,9 @@ static void prv_send_command(lwm2m_context_t *lwm2mH,
     }
 }
 
-static int prv_bootstrap_callback(lwm2m_context_t * lwm2mH,
-                                  void * sessionH,
-                                  uint8_t status,
-                                  lwm2m_uri_t * uriP,
-                                  char * name,
-                                  lwm2m_media_type_t format,
-                                  uint8_t * data,
-                                  uint16_t dataLength,
-                                  void * userData)
-{
+static int prv_bootstrap_callback(lwm2m_context_t *lwm2mH, void *sessionH, uint8_t status, lwm2m_uri_t *uriP,
+                                  char *name, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
+                                  void *userData) {
     internal_data_t * dataP = (internal_data_t *)userData;
     endpoint_t * endP;
 
@@ -706,7 +699,7 @@ int main(int argc, char *argv[])
         else if (result >= 0)
         {
             uint8_t buffer[MAX_PACKET_SIZE];
-            int numBytes;
+            ssize_t numBytes;
 
             // Packet received
             if (FD_ISSET(data.sock, &readfds))
@@ -745,9 +738,9 @@ int main(int argc, char *argv[])
                         port = saddr->sin6_port;
                     }
 
-                    fprintf(stderr, "%d bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
+                    fprintf(stderr, "%zd bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
 
-                    output_buffer(stderr, buffer, numBytes, 0);
+                    output_buffer(stderr, buffer, (size_t)numBytes, 0);
 
                     connP = connection_find(data.connList, &addr, addrLen);
                     if (connP == NULL)
@@ -760,7 +753,7 @@ int main(int argc, char *argv[])
                     }
                     if (connP != NULL)
                     {
-                        lwm2m_handle_packet(lwm2mH, buffer, numBytes, connP);
+                        lwm2m_handle_packet(lwm2mH, buffer, (size_t)numBytes, connP);
                     }
                 }
             }

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -1321,7 +1321,7 @@ int main(int argc, char *argv[])
         else if (result > 0)
         {
             uint8_t buffer[MAX_PACKET_SIZE];
-            int numBytes;
+            ssize_t numBytes;
 
             /*
              * If an event happens on the socket
@@ -1368,12 +1368,12 @@ int main(int argc, char *argv[])
                         inet_ntop(saddr->sin6_family, &saddr->sin6_addr, s, INET6_ADDRSTRLEN);
                         port = saddr->sin6_port;
                     }
-                    fprintf(stderr, "%d bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
+                    fprintf(stderr, "%zd bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
 
                     /*
                      * Display it in the STDERR
                      */
-                    output_buffer(stderr, buffer, numBytes, 0);
+                    output_buffer(stderr, buffer, (size_t)numBytes, 0);
 
                     connP = connection_find(data.connList, &addr, addrLen);
                     if (connP != NULL)
@@ -1388,7 +1388,7 @@ int main(int argc, char *argv[])
                              printf("error handling message %d\n",result);
                         }
 #else
-                        lwm2m_handle_packet(lwm2mH, buffer, numBytes, connP);
+                        lwm2m_handle_packet(lwm2mH, buffer, (size_t)numBytes, connP);
 #endif
                         conn_s_updateRxStatistic(objArray[7], numBytes, false);
                     }

--- a/examples/lightclient/lightclient.c
+++ b/examples/lightclient/lightclient.c
@@ -510,7 +510,7 @@ int main(int argc, char *argv[])
         else if (result > 0)
         {
             uint8_t buffer[MAX_PACKET_SIZE];
-            int numBytes;
+            ssize_t numBytes;
 
             /*
              * If an event happens on the socket
@@ -545,7 +545,7 @@ int main(int argc, char *argv[])
                         /*
                          * Let liblwm2m respond to the query depending on the context
                          */
-                        lwm2m_handle_packet(lwm2mH, buffer, numBytes, connP);
+                        lwm2m_handle_packet(lwm2mH, buffer, (size_t)numBytes, connP);
                     }
                     else
                     {

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -249,16 +249,9 @@ static void prv_printUri(const lwm2m_uri_t * uriP)
 #endif
 }
 
-static void prv_result_callback(lwm2m_context_t *contextP,
-                                uint16_t clientID,
-                                lwm2m_uri_t * uriP,
-                                int status,
-                                block_info_t * block_info,
-                                lwm2m_media_type_t format,
-                                uint8_t * data,
-                                int dataLength,
-                                void * userData)
-{
+static void prv_result_callback(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP, int status,
+                                block_info_t *block_info, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
+                                void *userData) {
     /* unused parameters */
     (void)contextP;
     (void)userData;
@@ -275,16 +268,9 @@ static void prv_result_callback(lwm2m_context_t *contextP,
     fflush(stdout);
 }
 
-static void prv_notify_callback(lwm2m_context_t *contextP,
-                                uint16_t clientID,
-                                lwm2m_uri_t * uriP,
-                                int count,
-                                block_info_t * block_info,
-                                lwm2m_media_type_t format,
-                                uint8_t * data,
-                                int dataLength,
-                                void * userData)
-{
+static void prv_notify_callback(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP, int count,
+                                block_info_t *block_info, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
+                                void *userData) {
     /* unused parameters */
     (void)contextP;
     (void)userData;
@@ -964,16 +950,9 @@ syntax_error:
     fprintf(stdout, "Syntax error !");
 }
 
-static void prv_monitor_callback(lwm2m_context_t *lwm2mH,
-                                 uint16_t clientID,
-                                 lwm2m_uri_t * uriP,
-                                 int status,
-                                 block_info_t * block_info,
-                                 lwm2m_media_type_t format,
-                                 uint8_t * data,
-                                 int dataLength,
-                                 void * userData)
-{
+static void prv_monitor_callback(lwm2m_context_t *lwm2mH, uint16_t clientID, lwm2m_uri_t *uriP, int status,
+                                 block_info_t *block_info, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
+                                 void *userData) {
     lwm2m_client_t * targetP;
 
     /* unused parameter */
@@ -1009,7 +988,6 @@ static void prv_monitor_callback(lwm2m_context_t *lwm2mH,
     fprintf(stdout, "\r\n> ");
     fflush(stdout);
 }
-
 
 static void prv_quit(lwm2m_context_t *lwm2mH,
                      char * buffer,
@@ -1209,7 +1187,7 @@ int main(int argc, char *argv[])
         else if (result > 0)
         {
             uint8_t buffer[MAX_PACKET_SIZE];
-            int numBytes;
+            ssize_t numBytes;
 
             if (FD_ISSET(sock, &readfds))
             {
@@ -1247,8 +1225,8 @@ int main(int argc, char *argv[])
                         port = saddr->sin6_port;
                     }
 
-                    fprintf(stderr, "%d bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
-                    output_buffer(stderr, buffer, numBytes, 0);
+                    fprintf(stderr, "%zd bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
+                    output_buffer(stderr, buffer, (size_t)numBytes, 0);
 
                     connP = connection_find(connList, &addr, addrLen);
                     if (connP == NULL)
@@ -1261,7 +1239,7 @@ int main(int argc, char *argv[])
                     }
                     if (connP != NULL)
                     {
-                        lwm2m_handle_packet(lwm2mH, buffer, numBytes, connP);
+                        lwm2m_handle_packet(lwm2mH, buffer, (size_t)numBytes, connP);
                     }
                 }
             }

--- a/examples/shared/commandline.c
+++ b/examples/shared/commandline.c
@@ -174,12 +174,8 @@ static void print_indent(FILE * stream,
         fprintf(stream, "    ");
 }
 
-void output_buffer(FILE * stream,
-                   const uint8_t * buffer,
-                   int length,
-                   int indent)
-{
-    int i;
+void output_buffer(FILE *stream, const uint8_t *buffer, size_t length, int indent) {
+    size_t i;
 
     if (length == 0) fprintf(stream, "\n");
 
@@ -304,15 +300,8 @@ void output_tlv(FILE * stream,
 #endif
 }
 
-void output_data(FILE * stream,
-                 block_info_t * block_info,
-                 lwm2m_media_type_t format,
-                 uint8_t * data,
-                 int dataLength,
-                 int indent)
-{
-    int i;
-
+void output_data(FILE *stream, block_info_t *block_info, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
+                 int indent) {
     print_indent(stream, indent);
     if (block_info != NULL) {
         fprintf(stream, "block transfer: size: %d, num: %d, more: %d\n\r", block_info->block_size, block_info->block_num, block_info->block_more);
@@ -320,7 +309,7 @@ void output_data(FILE * stream,
         fprintf(stream, "non block transfer\n\r");
     }
     print_indent(stream, indent);
-    fprintf(stream, "%d bytes received of type ", dataLength);
+    fprintf(stream, "%zu bytes received of type ", dataLength);
 
     switch (format)
     {
@@ -342,8 +331,7 @@ void output_data(FILE * stream,
     case LWM2M_CONTENT_JSON:
         fprintf(stream, "application/vnd.oma.lwm2m+json:\r\n");
         print_indent(stream, indent);
-        for (i = 0 ; i < dataLength ; i++)
-        {
+        for (size_t i = 0; i < dataLength; i++) {
             fprintf(stream, "%c", data[i]);
         }
         fprintf(stream, "\n");
@@ -352,8 +340,7 @@ void output_data(FILE * stream,
     case LWM2M_CONTENT_SENML_JSON:
         fprintf(stream, "application/senml+json:\r\n");
         print_indent(stream, indent);
-        for (i = 0 ; i < dataLength ; i++)
-        {
+        for (size_t i = 0; i < dataLength; i++) {
             fprintf(stream, "%c", data[i]);
         }
         fprintf(stream, "\n");
@@ -362,8 +349,7 @@ void output_data(FILE * stream,
     case LWM2M_CONTENT_LINK:
         fprintf(stream, "application/link-format:\r\n");
         print_indent(stream, indent);
-        for (i = 0 ; i < dataLength ; i++)
-        {
+        for (size_t i = 0; i < dataLength; i++) {
             fprintf(stream, "%c", data[i]);
         }
         fprintf(stream, "\n");

--- a/examples/shared/commandline.h
+++ b/examples/shared/commandline.h
@@ -36,8 +36,9 @@ char* get_end_of_arg(char* buffer);
 char * get_next_arg(char * buffer, char **end);
 int check_end_of_args(char* buffer);
 
-void output_buffer(FILE * stream, const uint8_t * buffer, int length, int indent);
+void output_buffer(FILE *stream, const uint8_t *buffer, size_t length, int indent);
 void output_tlv(FILE * stream, uint8_t * buffer, size_t buffer_len, int indent);
 void dump_tlv(FILE * stream, int size, lwm2m_data_t * dataP, int indent);
-void output_data(FILE * stream, block_info_t * block_info, lwm2m_media_type_t format, uint8_t * buffer, int length, int indent);
+void output_data(FILE *stream, block_info_t *block_info, lwm2m_media_type_t format, uint8_t *buffer, size_t length,
+                 int indent);
 void print_status(FILE * stream, uint8_t status);

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -600,7 +600,9 @@ typedef struct _block_info_t
  *
  * When used with an observe, if 'data' is not nil, 'status' holds the observe counter.
  */
-typedef void (*lwm2m_result_callback_t) (lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, int status, block_info_t * block_info, lwm2m_media_type_t format, uint8_t * data, int dataLength, void * userData);
+typedef void (*lwm2m_result_callback_t)(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP, int status,
+                                        block_info_t *block_info, lwm2m_media_type_t format, uint8_t *data,
+                                        size_t dataLength, void *userData);
 
 /*
  * LWM2M Observations
@@ -706,8 +708,9 @@ struct _lwm2m_transaction_
     void * message;
     uint16_t buffer_len;
     uint8_t * buffer;
-    uint16_t payload_len; // the length of the entire payload, message payload might be smaller in case of a block1 transfer
-    uint8_t * payload; // carries the entire payload accross multiple transactions in case of a block 1 transfer
+    size_t
+        payload_len;  // the length of the entire payload, message payload might be smaller in case of a block1 transfer
+    uint8_t *payload; // carries the entire payload across multiple transactions in case of a block 1 transfer
     lwm2m_transaction_callback_t callback;
     void * userData;
 };
@@ -771,7 +774,9 @@ typedef enum
 // After a lwm2m_bootstrap_delete() or a lwm2m_bootstrap_write(), the callback is called with the status returned by the
 // client, the URI of the operation (may be nil) and name is nil. The callback return value is ignored.
 // If data is present and no preferred format is provided by the client the format will be 0, otherwise it will be set.
-typedef int (*lwm2m_bootstrap_callback_t) (lwm2m_context_t * contextP, void * sessionH, uint8_t status, lwm2m_uri_t * uriP, char * name, lwm2m_media_type_t format, uint8_t * data, uint16_t dataLength, void * userData);
+typedef int (*lwm2m_bootstrap_callback_t)(lwm2m_context_t *contextP, void *sessionH, uint8_t status, lwm2m_uri_t *uriP,
+                                          char *name, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
+                                          void *userData);
 #endif
 
 struct _lwm2m_context_
@@ -811,7 +816,7 @@ void lwm2m_close(lwm2m_context_t * contextP);
 // perform any required pending operation and adjust timeoutP to the maximal time interval to wait in seconds.
 int lwm2m_step(lwm2m_context_t * contextP, time_t * timeoutP);
 // dispatch received data to liblwm2m
-void lwm2m_handle_packet(lwm2m_context_t * contextP, uint8_t * buffer, int length, void * fromSessionH);
+void lwm2m_handle_packet(lwm2m_context_t *contextP, uint8_t *buffer, size_t length, void *fromSessionH);
 
 #ifdef LWM2M_CLIENT_MODE
 // configure the client side with the Endpoint Name, binding, MSISDN (can be nil), alternative path
@@ -843,9 +848,12 @@ void lwm2m_set_monitoring_callback(lwm2m_context_t * contextP, lwm2m_result_call
 // Device Management APIs
 int lwm2m_dm_read(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_result_callback_t callback, void * userData);
 int lwm2m_dm_discover(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_result_callback_t callback, void * userData);
-int lwm2m_dm_write(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, int length, bool partialUpdate, lwm2m_result_callback_t callback, void * userData);
+int lwm2m_dm_write(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP, lwm2m_media_type_t format,
+                   uint8_t *buffer, size_t length, bool partialUpdate, lwm2m_result_callback_t callback,
+                   void *userData);
 int lwm2m_dm_write_attributes(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_attributes_t * attrP, lwm2m_result_callback_t callback, void * userData);
-int lwm2m_dm_execute(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_media_type_t format, uint8_t * buffer, int length, lwm2m_result_callback_t callback, void * userData);
+int lwm2m_dm_execute(lwm2m_context_t *contextP, uint16_t clientID, lwm2m_uri_t *uriP, lwm2m_media_type_t format,
+                     uint8_t *buffer, size_t length, lwm2m_result_callback_t callback, void *userData);
 int lwm2m_dm_create(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, int numData, lwm2m_data_t * dataP, lwm2m_result_callback_t callback, void * userData);
 int lwm2m_dm_delete(lwm2m_context_t * contextP, uint16_t clientID, lwm2m_uri_t * uriP, lwm2m_result_callback_t callback, void * userData);
 


### PR DESCRIPTION
Use size_t/ssize_t to store the message buffer sizes instead of a uint16_t and int types.

This fix allows transactions larger than 65k as discussed in #618.