### PR TITLE
ci: Update and simplify multiarch builds

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -5,8 +5,6 @@ on: [push, pull_request]
 jobs:
   multiarch:
     runs-on: ubuntu-20.04
-    env:
-       cmake_version: 3.20.0
     strategy:
       fail-fast: false
       matrix:
@@ -18,29 +16,14 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Build and test
-      uses: uraimo/run-on-arch-action@v2.0.9
+      uses: uraimo/run-on-arch-action@v2.1.1
       id: runcmd
       with:
         arch: ${{ matrix.arch }}
-        distro: buster
+        distro: bullseye
         githubToken: ${{ github.token }}
         install: |
           apt update
-          apt -qy --no-install-recommends install libcunit1-dev ninja-build unzip wget build-essential
-          # Workaround because of https://gitlab.kitware.com/cmake/cmake/-/issues/20568
-          # Please remove once CMake 3.19 or newer is available in the repository
-          apt -qy --no-install-recommends install dirmngr gpg gpg-agent
-          echo deb-src http://archive.raspbian.org/raspbian buster main contrib non-free >> /etc/apt/sources.list
-          apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9165938D90FDDD2E
-          apt update
-          apt -qy --no-install-recommends build-dep cmake
-          wget https://github.com/Kitware/CMake/releases/download/v${{ env.cmake_version }}/cmake-${{ env.cmake_version }}.tar.gz
-          tar xf cmake-${{ env.cmake_version }}.tar.gz
-          cd cmake-${{ env.cmake_version }}
-          ./bootstrap -- -DCMAKE_USE_OPENSSL=OFF -DBUILD_TESTING=OFF
-          make -j $(nproc)
-          make install
-          cd ..
-          rm -r cmake-${{ env.cmake_version }} cmake-${{ env.cmake_version }}.tar.gz
+          apt -qy --no-install-recommends install libcunit1-dev ninja-build unzip wget build-essential cmake
         run: |
           tools/ci/run_ci.sh --run-build --run-tests


### PR DESCRIPTION
The CMake version 3.18.4 binary from Debian Bullseye seems to work and
speeds up the builds greatly.