### PR TITLE
CI: Improve compilation coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: C Standards
+name: Compilation only checks
 
 on: [push, pull_request]
 
@@ -36,5 +36,15 @@ jobs:
           --run-build \
           --c-standard ${{ matrix.c_standard }} \
           --c-extensions ${{ matrix.c_extensions }}
+      env:
+        CC:  ${{ matrix.compiler }}
+
+    - Special case: lwm2mclient with DTLS (tinydtls)
+      run: |
+        tools/ci/run_ci.sh \
+          --run-build \
+          --c-standard ${{ matrix.c_standard }} \
+          --c-extensions ${{ matrix.c_extensions }} \
+          --source-directory examples/client
       env:
         CC:  ${{ matrix.compiler }}

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -39,7 +39,7 @@ jobs:
       env:
         CC:  ${{ matrix.compiler }}
 
-    - name: Build, execute sanititzed unit tests
+    - name: Build, execute sanitized unit tests
       run: |
         tools/ci/run_ci.sh --run-tests --sanitizer ${{ matrix.sanitizer }}
       env:

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ Wakaama is not a library but files to be built with an application.
 Wakaama uses CMake >= 3.13. Look at examples/server/CMakeLists.txt for an
 example of how to include it.
 Several compilation switches are used:
- - LWM2M_BIG_ENDIAN if your target platform uses big-endian format.
- - LWM2M_LITTLE_ENDIAN if your target platform uses little-endian format.
- - LWM2M_CLIENT_MODE to enable LWM2M Client interfaces.
- - LWM2M_SERVER_MODE to enable LWM2M Server interfaces.
- - LWM2M_BOOTSTRAP_SERVER_MODE to enable LWM2M Bootstrap Server interfaces.
+ - Endianness: Exactly one has to be defined.
+   - LWM2M_BIG_ENDIAN if your target platform uses big-endian format.
+   - LWM2M_LITTLE_ENDIAN if your target platform uses little-endian format.
+ - Mode: One or multiple modes have to be defined.
+   - LWM2M_CLIENT_MODE to enable LWM2M Client interfaces.
+   - LWM2M_SERVER_MODE to enable LWM2M Server interfaces.
+   - LWM2M_BOOTSTRAP_SERVER_MODE to enable LWM2M Bootstrap Server interfaces.
  - LWM2M_BOOTSTRAP to enable LWM2M Bootstrap support in a LWM2M Client.
  - LWM2M_SUPPORT_TLV to enable TLV payload support (implicit except for LWM2M 1.1 clients)
  - LWM2M_SUPPORT_JSON to enable JSON payload support (implicit when defining LWM2M_SERVER_MODE)
@@ -62,7 +64,6 @@ Several compilation switches are used:
  - LWM2M_COAP_DEFAULT_BLOCK_SIZE CoAP block size used by CoAP layer when performing block-wise transfers. Possible values: 16, 32, 64, 128, 256, 512 and 1024. Defaults to 1024.
 
 Depending on your platform, you need to define LWM2M_BIG_ENDIAN or LWM2M_LITTLE_ENDIAN.
-LWM2M_CLIENT_MODE and LWM2M_SERVER_MODE can be defined at the same time.
 
 ## Development
 

--- a/core/internals.h
+++ b/core/internals.h
@@ -449,7 +449,8 @@ size_t utils_base64Decode(const char * dataP, size_t dataLen, uint8_t * bufferP,
 #ifdef LWM2M_CLIENT_MODE
 lwm2m_server_t * utils_findServer(lwm2m_context_t * contextP, void * fromSessionH);
 lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP, void * fromSessionH);
-#else
+#endif
+#if defined(LWM2M_SERVER_MODE) || defined(LWM2M_BOOTSTRAP_SERVER_MODE)
 lwm2m_client_t * utils_findClient(lwm2m_context_t * contextP, void * fromSessionH);
 #endif
 

--- a/core/observe.c
+++ b/core/observe.c
@@ -1256,7 +1256,7 @@ int prv_lwm2m_observe_cancel(lwm2m_context_t * contextP,
 
         observationP->status = STATE_DEREG_PENDING;
 
-        int ret = transaction_send(contextP, transactionP);
+        ret = transaction_send(contextP, transactionP);
         if (ret != 0) lwm2m_free(cancelP);
         return ret;
     }

--- a/core/utils.c
+++ b/core/utils.c
@@ -865,7 +865,7 @@ lwm2m_server_t * utils_findBootstrapServer(lwm2m_context_t * contextP,
 #endif
 }
 
-#ifndef LWM2M_CLIENT_MODE
+#if defined(LWM2M_SERVER_MODE) || defined(LWM2M_BOOTSTRAP_SERVER_MODE)
 lwm2m_client_t * utils_findClient(lwm2m_context_t * contextP,
                                   void * fromSessionH)
 {

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -97,6 +97,10 @@ extern "C" {
 #error "LWM2M_BOOTSTRAP and LWM2M_BOOTSTRAP_SERVER_MODE cannot be defined at the same time!"
 #endif
 
+#if !defined(LWM2M_CLIENT_MODE) && !defined(LWM2M_SERVER_MODE) && !defined(LWM2M_BOOTSTRAP_SERVER_MODE)
+#error At least one mode must be defined!
+#endif
+
 /*
  * Platform abstraction functions to be implemented by the user
  */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,15 +9,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../coap/coap.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../data/data.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../examples/shared/shared.cmake)
 
-add_compile_definitions(LWM2M_CLIENT_MODE)
-add_compile_definitions(LWM2M_SUPPORT_TLV)
-add_compile_definitions(LWM2M_SUPPORT_JSON)
-
-if(LWM2M_VERSION VERSION_GREATER "1.0")
-    add_compile_definitions(LWM2M_SUPPORT_SENML_JSON)
-endif()
-
-# Enable all warnings for this test build  
+# Enable certain warnings for all test builds
 add_compile_options(-pedantic -Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wswitch-default)
 
 include_directories(${WAKAAMA_HEADERS_DIR} ${COAP_HEADERS_DIR} ${DATA_HEADERS_DIR} ${WAKAAMA_SOURCES_DIR} ${SHARED_INCLUDE_DIRS})
@@ -27,6 +19,12 @@ file(GLOB SOURCES "*.c")
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${WAKAAMA_SOURCES} ${COAP_SOURCES} ${DATA_SOURCES} ${SHARED_SOURCES})
 target_link_libraries(${PROJECT_NAME} cunit)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE LWM2M_CLIENT_MODE LWM2M_SUPPORT_TLV LWM2M_SUPPORT_JSON)
+
+if(LWM2M_VERSION VERSION_GREATER "1.0")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE LWM2M_SUPPORT_SENML_JSON)
+endif()
 
 if(SANITIZER)
     target_compile_options(${PROJECT_NAME} PRIVATE -fsanitize=${SANITIZER} -fno-sanitize-recover=all)
@@ -38,5 +36,7 @@ if(COVERAGE)
     target_link_options(${PROJECT_NAME} PRIVATE --coverage)
 endif()
 
-# Add our unit tests to it "test" target
+# Add our unit tests to the "test" target
 add_test(NAME ${PROJECT_NAME}_test COMMAND ${PROJECT_NAME})
+
+add_subdirectory(cartesian_compilation)

--- a/tests/cartesian_compilation/CMakeLists.txt
+++ b/tests/cartesian_compilation/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.13)
+
+# Test multiple combinatorial variants of Wakaamas defines
+
+project(cartesian_compilation C)
+
+# Very much not elegant, but could not find a better solution for producing a Cartesian product.
+# Not definig LWM2M_COAP_DEFAULT_BLOCK_SIZE because it gets set unconditionally by wakaama.cmake
+set(target_number 0)
+foreach(LOG IN ITEMS "LWM2M_WITH_LOGS" "")
+    foreach(MODE IN ITEMS
+            "LWM2M_CLIENT_MODE"
+            "LWM2M_SERVER_MODE"
+            "LWM2M_BOOTSTRAP_SERVER_MODE"
+            "LWM2M_CLIENT_MODE;LWM2M_SERVER_MODE;LWM2M_BOOTSTRAP_SERVER_MODE")
+        foreach(VERSION IN ITEMS "LWM2M_VERSION_1_0" "")
+            foreach(BOOTSTRAP IN ITEMS "LWM2M_BOOTSTRAP" "")
+                # LWM2M_BOOTSTRAP can be used only in client mode.
+                if (BOOTSTRAP STREQUAL "LWM2M_BOOTSTRAP" AND NOT MODE STREQUAL "LWM2M_CLIENT_MODE")
+                    continue()
+                endif()
+                foreach(FORMAT IN ITEMS
+                        "LWM2M_SUPPORT_SENML_JSON"
+                        "LWM2M_SUPPORT_JSON" "LWM2M_SUPPORT_TLV"
+                        "LWM2M_SUPPORT_SENML_JSON;LWM2M_SUPPORT_JSON;LWM2M_SUPPORT_TLV")
+                    # LWM2M_SUPPORT_SENML_JSON is valid only for LWM2M version 1.1
+                    if (FORMAT MATCHES "LWM2M_SUPPORT_SENML_JSON" AND VERSION STREQUAL "LWM2M_VERSION_1_0" )
+                        continue()
+                    endif()
+                    add_executable(cartesian_compilation_${target_number}
+                                   ${COAP_SOURCES}
+                                   ${DATA_SOURCES}
+                                   ${SHARED_SOURCES}
+                                   ${WAKAAMA_SOURCES}
+                                   main.c)
+                    foreach(definition IN LISTS BLOCK_SIZE BOOTSTRAP FORMAT LOG MODE VERSION)
+                        target_compile_definitions(cartesian_compilation_${target_number} PRIVATE ${definition})
+                    endforeach()
+                    math(EXPR target_number "${target_number} + 1")
+                endforeach()
+            endforeach()
+        endforeach()
+    endforeach()
+endforeach()

--- a/tests/cartesian_compilation/main.c
+++ b/tests/cartesian_compilation/main.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+#include "liblwm2m.h"
+
+void *lwm2m_connect_server(uint16_t secObjInstID, void *userData) {
+    (void)userData;
+    return (void *)(uintptr_t)secObjInstID;
+}
+
+void lwm2m_close_connection(void *sessionH, void *userData) {
+    (void)sessionH;
+    (void)userData;
+    return;
+}
+
+int main(void) {}

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -28,6 +28,7 @@ OPT_CLANG_FORMAT="clang-format-10"
 OPT_SANITIZER=""
 OPT_SCAN_BUILD=""
 OPT_SONARQUBE=""
+OPT_SOURCE_DIRECTORY="${REPO_ROOT_DIR}"
 OPT_TEST_COVERAGE_REPORT=""
 OPT_VERBOSE=0
 OPT_WRAPPER_CMD=""
@@ -54,6 +55,8 @@ Options:
                             (VERSION: 99, 11)
   --clang-format BINARY     Set specific clang-format binary
                             (BINARY: defaults to ${OPT_CLANG_FORMAT})
+  --source-directory PATH   Configure CMake using PATH instead of the
+                            repositories root directory.
   --sanitizer TYPE          Enable sanitizer
                             (TYPE: address leak thread undefined)
   --scan-build BINARY       Enable Clang code analyzer using specified
@@ -73,7 +76,7 @@ Available steps (executed by --all):
   --run-git-blame-ignore   Validate .git-blame-ignore-revs
   --run-clean              Remove all build artifacts
   --run-build              Build all targets
-  --run-tests              Build and execute tests
+  --run-tests              Execute tests (works only for top level project)
 "
 
 function usage() {
@@ -127,7 +130,7 @@ function run_build() {
   # Existing directory needed by SonarQube build-wrapper
   mkdir -p build-wakaama
 
-  ${OPT_WRAPPER_CMD} cmake -GNinja -S . -B build-wakaama ${CMAKE_ARGS}
+  ${OPT_WRAPPER_CMD} cmake -GNinja -S ${OPT_SOURCE_DIRECTORY} -B build-wakaama ${CMAKE_ARGS}
   ${OPT_WRAPPER_CMD} cmake --build build-wakaama
 }
 
@@ -201,6 +204,7 @@ if ! PARSED_OPTS=$(getopt -o vah \
                           -l sanitizer: \
                           -l scan-build: \
                           -l sonarqube: \
+                          -l source-directory: \
                           -l test-coverage: \
                           -l verbose \
                           --name "${SCRIPT_NAME}" -- "$@");
@@ -270,6 +274,10 @@ while true; do
       OPT_SONARQUBE=$2
       # Analyzing works only when code gets actually built
       RUN_CLEAN=1
+      shift 2
+      ;;
+    --source-directory)
+      OPT_SOURCE_DIRECTORY=$2
       shift 2
       ;;
     --test-coverage)


### PR DESCRIPTION
This builds the tinydtls-enabled example client in CI.

This is the first step in making it easy for #626 to implement some kind of testing.