### PR TITLE
ci: Build all examples as standalone

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,9 @@
-name: C Standards
+name: Compilation only checks
 
 on: [push, pull_request]
 
 jobs:
-  build:
+  standards:
     runs-on: ubuntu-20.04
 
     strategy:
@@ -38,3 +38,35 @@ jobs:
           --c-extensions ${{ matrix.c_extensions }}
       env:
         CC:  ${{ matrix.compiler }}
+
+  standalone-examples:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        example: ["bootstrap_server", "client", "lightclient", "server"]
+
+    steps:
+    - name: Checkout code including full history and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Install dependencies from APT repository
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcunit1-dev wget unzip
+
+    - name: Install CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@master
+
+    - Build examples as stand-alone projects
+      run: |
+        tools/ci/run_ci.sh \
+          --run-clean \
+          --run-build \
+          --source-directory examples/${{ matrix.example }}

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -28,6 +28,7 @@ OPT_CLANG_FORMAT="clang-format-10"
 OPT_SANITIZER=""
 OPT_SCAN_BUILD=""
 OPT_SONARQUBE=""
+OPT_SOURCE_DIRECTORY="${REPO_ROOT_DIR}"
 OPT_TEST_COVERAGE_REPORT=""
 OPT_VERBOSE=0
 OPT_WRAPPER_CMD=""
@@ -54,6 +55,8 @@ Options:
                             (VERSION: 99, 11)
   --clang-format BINARY     Set specific clang-format binary
                             (BINARY: defaults to ${OPT_CLANG_FORMAT})
+  --source-directory PATH   Configure CMake using PATH instead of the
+                            repositories root directory.
   --sanitizer TYPE          Enable sanitizer
                             (TYPE: address leak thread undefined)
   --scan-build BINARY       Enable Clang code analyzer using specified
@@ -73,7 +76,7 @@ Available steps (executed by --all):
   --run-git-blame-ignore   Validate .git-blame-ignore-revs
   --run-clean              Remove all build artifacts
   --run-build              Build all targets
-  --run-tests              Build and execute tests
+  --run-tests              Execute tests (works only for top level project)
 "
 
 function usage() {
@@ -127,7 +130,7 @@ function run_build() {
   # Existing directory needed by SonarQube build-wrapper
   mkdir -p build-wakaama
 
-  ${OPT_WRAPPER_CMD} cmake -GNinja -S . -B build-wakaama ${CMAKE_ARGS}
+  ${OPT_WRAPPER_CMD} cmake -GNinja -S ${OPT_SOURCE_DIRECTORY} -B build-wakaama ${CMAKE_ARGS}
   ${OPT_WRAPPER_CMD} cmake --build build-wakaama
 }
 
@@ -201,6 +204,7 @@ if ! PARSED_OPTS=$(getopt -o vah \
                           -l sanitizer: \
                           -l scan-build: \
                           -l sonarqube: \
+                          -l source-directory: \
                           -l test-coverage: \
                           -l verbose \
                           --name "${SCRIPT_NAME}" -- "$@");
@@ -270,6 +274,10 @@ while true; do
       OPT_SONARQUBE=$2
       # Analyzing works only when code gets actually built
       RUN_CLEAN=1
+      shift 2
+      ;;
+    --source-directory)
+      OPT_SOURCE_DIRECTORY=$2
       shift 2
       ;;
     --test-coverage)


### PR DESCRIPTION
This ensures the examples can be built independently as described in the
readme file.