### PR TITLE
ci: Fix standalone examples

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
     - name: Install Ninja
       uses: seanmiddleditch/gha-setup-ninja@master
 
-    - Build examples as stand-alone projects
+    - name: Build examples as stand-alone projects
       run: |
         tools/ci/run_ci.sh \
           --run-clean \


### PR DESCRIPTION
This slipped in because "name:" is absolutely required, but when missing, does not prevent
GitHub from displaying a "all-good" CI-tick.