### PR TITLE
ci: Default to clang-format-12

### DIFF
--- a/.github/workflows/compliance.yaml
+++ b/.github/workflows/compliance.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Install compliance tools
       run: |
         sudo apt update
-        sudo apt -qy --no-install-recommends install clang-format-10
+        sudo apt -qy --no-install-recommends install clang-format-12
         pip3 install -r tools/requirements-compliance.txt
 
     - name: Check commits with gitlint

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Several preprocessor definitions are supported:
   - Version control system: Git (and a GitHub account)
   - Git commit message linter: gitlint
   - Build system: ninja
-  - C code formatting: clang-format, version 10
+  - C code formatting: clang-format, version 12
   - CMake list files formatting: cmake-format, version 0.6.13
   - Unit testing: CUnit
 
 On Ubuntu 20.04, used in CI, the dependencies can be installed as such:
-- `apt install build-essential clang-format clang-format-10 clang-tools-10 cmake gcovr git libcunit1-dev ninja-build python3-pip`
+- `apt install build-essential clang-format clang-format-12 clang-tools-12 cmake gcovr git libcunit1-dev ninja-build python3-pip`
 - `pip3 install -r tools/requirements-compliance.txt`
 
 ### Code formatting
@@ -103,9 +103,9 @@ The style is based on the LLVM style, but with 4 instead of 2 spaces indentation
 characters per line.
 
 To check if your code matches the expected style, the following commands are helpful:
- - `git clang-format-10 --diff`: Show what needs to be changed to match the expected code style
- - `git clang-format-10`: Apply all needed changes directly
- - `git clang-format-10 --commit master`: Fix code style for all changes since master
+ - `git clang-format-12 --diff`: Show what needs to be changed to match the expected code style
+ - `git clang-format-12`: Apply all needed changes directly
+ - `git clang-format-12 --commit master`: Fix code style for all changes since master
 
 If existing code gets reformatted, this must be done in a separate commit. Its commit id has to be added to the file
 `.git-blame-ignore-revs` and committed in yet another commit.

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -24,7 +24,7 @@ OPT_BRANCH_SOURCE=
 OPT_BRANCH_TARGET=master
 OPT_C_EXTENSIONS=""
 OPT_C_STANDARD=""
-OPT_CLANG_FORMAT="clang-format-10"
+OPT_CLANG_FORMAT="clang-format-12"
 OPT_SANITIZER=""
 OPT_SCAN_BUILD=""
 OPT_SONARQUBE=""
@@ -90,6 +90,8 @@ function usage() {
 
 function run_clang_format() {
   local patch_file
+
+  command "git-${OPT_CLANG_FORMAT}"
 
   patch_file="$(mktemp -t clang-format-patch.XXX)"
   # shellcheck disable=SC2064


### PR DESCRIPTION
Use `clang-format-12` for CI runs. Ubuntu 22.04 LTS does not package `clang-format-10` anymore. Both Ubuntu 22.04 LTS and 20.04 LTS ship `clang-format-12`.