### PR TITLE
ci: Fix multiarch builds

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -35,4 +35,9 @@ jobs:
                 wget \
                 ;
         run: |
+          # Mark submodule as safe directory to prevent error because of code
+          # getting built by root (inside QEMU) but checked out by a non-root
+          # user (host system).
+          git config --global --add safe.directory "${PWD}/examples/shared/tinydtls"
+
           tools/ci/run_ci.sh --run-build --run-tests


### PR DESCRIPTION
Simply disabling the relevant security feature [1] because we do not benefit from it.

[1] https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9