### PR TITLE
Enforce prototypes on functions

### DIFF
--- a/coap/er-coap-13/er-coap-13.c
+++ b/coap/er-coap-13/er-coap-13.c
@@ -463,7 +463,7 @@ coap_get_variable(const uint8_t *buffer, size_t length, const char *name, const 
 
 /*-----------------------------------------------------------------------------------*/
 uint16_t
-coap_get_mid()
+coap_get_mid(void)
 {
   return ++current_mid;
 }

--- a/core/packet.c
+++ b/core/packet.c
@@ -123,7 +123,7 @@ bool lwm2m_set_coap_block_size(const uint16_t coap_block_size_arg) {
     return false;
 }
 
-uint16_t lwm2m_get_coap_block_size() { return coap_block_size; }
+uint16_t lwm2m_get_coap_block_size(void) { return coap_block_size; }
 
 static void handle_reset(lwm2m_context_t * contextP,
                          void * fromSessionH,

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -776,8 +776,7 @@ static void update_bootstrap_info(lwm2m_client_state_t * previousBootstrapState,
     }
 }
 
-static void close_backup_object(void)
-{
+static void close_backup_object(void) {
     int i;
     for (i = 0; i < BACKUP_OBJECT_COUNT; i++) {
         if (NULL != backupObjectArray[i]) {

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -776,7 +776,7 @@ static void update_bootstrap_info(lwm2m_client_state_t * previousBootstrapState,
     }
 }
 
-static void close_backup_object()
+static void close_backup_object(void)
 {
     int i;
     for (i = 0; i < BACKUP_OBJECT_COUNT; i++) {

--- a/examples/client/object_device.c
+++ b/examples/client/object_device.c
@@ -631,8 +631,7 @@ void display_device_object(lwm2m_object_t * object)
     }
 }
 
-lwm2m_object_t * get_object_device(void)
-{
+lwm2m_object_t *get_object_device(void) {
     /*
      * The get_object_device function create the object itself and return a pointer to the structure that represent it.
      */

--- a/examples/client/object_device.c
+++ b/examples/client/object_device.c
@@ -631,7 +631,7 @@ void display_device_object(lwm2m_object_t * object)
     }
 }
 
-lwm2m_object_t * get_object_device()
+lwm2m_object_t * get_object_device(void)
 {
     /*
      * The get_object_device function create the object itself and return a pointer to the structure that represent it.

--- a/examples/client/system_api.c
+++ b/examples/client/system_api.c
@@ -55,9 +55,6 @@ void init_value_change(lwm2m_context_t * lwm2m)
 {
 }
 
-void system_reboot(void)
-{
-    exit(1);
-}
+void system_reboot(void) { exit(1); }
 
 #endif

--- a/examples/client/system_api.c
+++ b/examples/client/system_api.c
@@ -55,7 +55,7 @@ void init_value_change(lwm2m_context_t * lwm2m)
 {
 }
 
-void system_reboot()
+void system_reboot(void)
 {
     exit(1);
 }

--- a/examples/lightclient/object_device.c
+++ b/examples/lightclient/object_device.c
@@ -262,8 +262,7 @@ static uint8_t prv_device_execute(lwm2m_context_t * contextP,
     return COAP_405_METHOD_NOT_ALLOWED;
 }
 
-lwm2m_object_t * get_object_device(void)
-{
+lwm2m_object_t *get_object_device(void) {
     /*
      * The get_object_device function create the object itself and return a pointer to the structure that represent it.
      */

--- a/examples/lightclient/object_device.c
+++ b/examples/lightclient/object_device.c
@@ -262,7 +262,7 @@ static uint8_t prv_device_execute(lwm2m_context_t * contextP,
     return COAP_405_METHOD_NOT_ALLOWED;
 }
 
-lwm2m_object_t * get_object_device()
+lwm2m_object_t * get_object_device(void)
 {
     /*
      * The get_object_device function create the object itself and return a pointer to the structure that represent it.

--- a/examples/lightclient/object_security.c
+++ b/examples/lightclient/object_security.c
@@ -199,8 +199,7 @@ static uint8_t prv_security_read(lwm2m_context_t * contextP,
     return result;
 }
 
-lwm2m_object_t * get_security_object(void)
-{
+lwm2m_object_t *get_security_object(void) {
     lwm2m_object_t * securityObj;
 
     securityObj = (lwm2m_object_t *)lwm2m_malloc(sizeof(lwm2m_object_t));

--- a/examples/lightclient/object_security.c
+++ b/examples/lightclient/object_security.c
@@ -199,7 +199,7 @@ static uint8_t prv_security_read(lwm2m_context_t * contextP,
     return result;
 }
 
-lwm2m_object_t * get_security_object()
+lwm2m_object_t * get_security_object(void)
 {
     lwm2m_object_t * securityObj;
 

--- a/examples/lightclient/object_server.c
+++ b/examples/lightclient/object_server.c
@@ -432,8 +432,7 @@ static uint8_t prv_server_create(lwm2m_context_t * contextP,
     return result;
 }
 
-lwm2m_object_t * get_server_object(void)
-{
+lwm2m_object_t *get_server_object(void) {
     lwm2m_object_t * serverObj;
 
     serverObj = (lwm2m_object_t *)lwm2m_malloc(sizeof(lwm2m_object_t));

--- a/examples/lightclient/object_server.c
+++ b/examples/lightclient/object_server.c
@@ -432,7 +432,7 @@ static uint8_t prv_server_create(lwm2m_context_t * contextP,
     return result;
 }
 
-lwm2m_object_t * get_server_object()
+lwm2m_object_t * get_server_object(void)
 {
     lwm2m_object_t * serverObj;
 

--- a/tests/block1tests.c
+++ b/tests/block1tests.c
@@ -149,7 +149,7 @@ static struct TestTable table[] = {
     {NULL, NULL},
 };
 
-CU_ErrorCode create_block1_suit() {
+CU_ErrorCode create_block1_suit(void) {
     CU_pSuite pSuite = NULL;
     pSuite = CU_add_suite("Suite_block1", NULL, NULL);
 

--- a/tests/block2tests.c
+++ b/tests/block2tests.c
@@ -98,7 +98,7 @@ static struct TestTable table[] = {
     {NULL, NULL},
 };
 
-CU_ErrorCode create_block2_suit() {
+CU_ErrorCode create_block2_suit(void) {
     CU_pSuite pSuite = NULL;
     pSuite = CU_add_suite("Suite_block2", NULL, NULL);
 

--- a/tests/convert_numbers_test.c
+++ b/tests/convert_numbers_test.c
@@ -462,16 +462,13 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_convert_numbers_suit(void)
-{
-   CU_pSuite pSuite = NULL;
+CU_ErrorCode create_convert_numbers_suit(void) {
+    CU_pSuite pSuite = NULL;
 
-   pSuite = CU_add_suite("Suite_ConvertNumbers", NULL, NULL);
-   if (NULL == pSuite) {
-      return CU_get_error();
-   }
+    pSuite = CU_add_suite("Suite_ConvertNumbers", NULL, NULL);
+    if (NULL == pSuite) {
+        return CU_get_error();
+    }
 
-   return add_tests(pSuite, table);
+    return add_tests(pSuite, table);
 }
-
-

--- a/tests/convert_numbers_test.c
+++ b/tests/convert_numbers_test.c
@@ -462,7 +462,7 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_convert_numbers_suit()
+CU_ErrorCode create_convert_numbers_suit(void)
 {
    CU_pSuite pSuite = NULL;
 

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -26,16 +26,16 @@ struct TestTable {
 };
 
 CU_ErrorCode add_tests(CU_pSuite pSuite, struct TestTable* testTable);
-CU_ErrorCode create_uri_suit();
-CU_ErrorCode create_tlv_suit();
-CU_ErrorCode create_object_read_suit();
-CU_ErrorCode create_convert_numbers_suit();
-CU_ErrorCode create_tlv_json_suit();
-CU_ErrorCode create_block1_suit();
+CU_ErrorCode create_uri_suit(void);
+CU_ErrorCode create_tlv_suit(void);
+CU_ErrorCode create_object_read_suit(void);
+CU_ErrorCode create_convert_numbers_suit(void);
+CU_ErrorCode create_tlv_json_suit(void);
+CU_ErrorCode create_block1_suit(void);
 CU_ErrorCode create_block2_suit(void);
 #ifdef LWM2M_SUPPORT_SENML_JSON
-CU_ErrorCode create_senml_json_suit();
+CU_ErrorCode create_senml_json_suit(void);
 #endif
-CU_ErrorCode create_er_coap_parse_message_suit();
+CU_ErrorCode create_er_coap_parse_message_suit(void);
 
 #endif /* TESTS_H_ */

--- a/tests/tlv_json_lwm2m_data_test.c
+++ b/tests/tlv_json_lwm2m_data_test.c
@@ -449,16 +449,13 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_tlv_json_suit(void)
-{
-   CU_pSuite pSuite = NULL;
+CU_ErrorCode create_tlv_json_suit(void) {
+    CU_pSuite pSuite = NULL;
 
-   pSuite = CU_add_suite("Suite_TLV_JSON", NULL, NULL);
-   if (NULL == pSuite) {
-      return CU_get_error();
-   }
+    pSuite = CU_add_suite("Suite_TLV_JSON", NULL, NULL);
+    if (NULL == pSuite) {
+        return CU_get_error();
+    }
 
-   return add_tests(pSuite, table);
+    return add_tests(pSuite, table);
 }
-
-

--- a/tests/tlv_json_lwm2m_data_test.c
+++ b/tests/tlv_json_lwm2m_data_test.c
@@ -449,7 +449,7 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_tlv_json_suit()
+CU_ErrorCode create_tlv_json_suit(void)
 {
    CU_pSuite pSuite = NULL;
 

--- a/tests/tlvtests.c
+++ b/tests/tlvtests.c
@@ -46,17 +46,15 @@ static void test_tlv_free(void)
    lwm2m_data_free(10, dataP);
 }
 
-static void test_decodeTLV(void)
-{
+static void test_decodeTLV(void) {
     uint8_t data1[] = {0xC3, 55, 1, 2, 3};
-    uint8_t data2[] = {0x28, 2, 3, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-    uint8_t data3[0x194] = {0x90, 33, 1, 0x90 };
+    uint8_t data2[] = {0x28, 2, 3, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    uint8_t data3[0x194] = {0x90, 33, 1, 0x90};
     lwm2m_data_type_t type;
     uint16_t id = 0;
-    size_t   index = 0;
-    size_t   length = 0;
+    size_t index = 0;
+    size_t length = 0;
     int result;
-
 
     result = lwm2m_decode_TLV(data1, sizeof(data1) - 1, &type, &id, &index, &length);
     CU_ASSERT_EQUAL(result, 0)
@@ -89,12 +87,13 @@ static void test_decodeTLV(void)
     CU_ASSERT_EQUAL(length, 0x190)
 }
 
-static void test_tlv_parse(void)
-{
+static void test_tlv_parse(void) {
     // Resource 55 {1, 2, 3}
     uint8_t data1[] = {0xC3, 55, 1, 2, 3};
     // Instance 0x203 {Resource 55 {1, 2, 3}, Resource 66 {4, 5, 6, 7, 8, 9, 10, 11, 12 } }
-    uint8_t data2[] = {0x28, 2, 3, 17, 0xC3, 55, 1, 2, 3, 0xC8, 66, 9, 4, 5, 6, 7, 8, 9, 10, 11, 12, };
+    uint8_t data2[] = {
+        0x28, 2, 3, 17, 0xC3, 55, 1, 2, 3, 0xC8, 66, 9, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    };
     // Instance 11 {MultiResource 11 {ResourceInstance 0 {1, 2, 3}, ResourceInstance 1 {4, 5, 6, 7, 8, 9, ... } }
     uint8_t data3[174] = {0x08, 11, 171, 0x88, 77, 168, 0x43, 0, 1, 2, 3, 0x48, 1, 160, 4, 5, 6, 7, 8, 9};
     int result;
@@ -157,17 +156,14 @@ static void test_tlv_parse(void)
     lwm2m_data_free(result, dataP);
 }
 
-static void test_tlv_serialize(void)
-{
+static void test_tlv_serialize(void) {
     int result;
     lwm2m_data_t *dataP;
     lwm2m_data_t *tlvSubP;
     lwm2m_data_t *tlvRscInstP;
     uint8_t data1[] = {1, 2, 3, 4};
     uint8_t data2[170] = {5, 6, 7, 8};
-    uint8_t* buffer;
-
-
+    uint8_t *buffer;
 
     tlvSubP = lwm2m_data_new(2);
     CU_ASSERT_PTR_NOT_NULL_FATAL(tlvSubP)
@@ -494,16 +490,13 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_tlv_suit(void)
-{
-   CU_pSuite pSuite = NULL;
+CU_ErrorCode create_tlv_suit(void) {
+    CU_pSuite pSuite = NULL;
 
-   pSuite = CU_add_suite("Suite_TLV", NULL, NULL);
-   if (NULL == pSuite) {
-      return CU_get_error();
-   }
+    pSuite = CU_add_suite("Suite_TLV", NULL, NULL);
+    if (NULL == pSuite) {
+        return CU_get_error();
+    }
 
-   return add_tests(pSuite, table);
+    return add_tests(pSuite, table);
 }
-
-

--- a/tests/tlvtests.c
+++ b/tests/tlvtests.c
@@ -46,7 +46,7 @@ static void test_tlv_free(void)
    lwm2m_data_free(10, dataP);
 }
 
-static void test_decodeTLV()
+static void test_decodeTLV(void)
 {
     uint8_t data1[] = {0xC3, 55, 1, 2, 3};
     uint8_t data2[] = {0x28, 2, 3, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -89,7 +89,7 @@ static void test_decodeTLV()
     CU_ASSERT_EQUAL(length, 0x190)
 }
 
-static void test_tlv_parse()
+static void test_tlv_parse(void)
 {
     // Resource 55 {1, 2, 3}
     uint8_t data1[] = {0xC3, 55, 1, 2, 3};
@@ -157,7 +157,7 @@ static void test_tlv_parse()
     lwm2m_data_free(result, dataP);
 }
 
-static void test_tlv_serialize()
+static void test_tlv_serialize(void)
 {
     int result;
     lwm2m_data_t *dataP;
@@ -494,7 +494,7 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_tlv_suit()
+CU_ErrorCode create_tlv_suit(void)
 {
    CU_pSuite pSuite = NULL;
 

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -50,29 +50,28 @@ CU_ErrorCode add_tests(CU_pSuite pSuite, struct TestTable* testTable)
     return CUE_SUCCESS;
 }
 
-int main(void)
-{
-   /* initialize the CUnit test registry */
-   if (CUE_SUCCESS != CU_initialize_registry())
-      return CU_get_error();
+int main(void) {
+    /* initialize the CUnit test registry */
+    if (CUE_SUCCESS != CU_initialize_registry())
+        return CU_get_error();
 
-   if (CUE_SUCCESS != create_block1_suit())
-      goto exit;
+    if (CUE_SUCCESS != create_block1_suit())
+        goto exit;
 
-   if (CUE_SUCCESS != create_block2_suit())
-       goto exit;
+    if (CUE_SUCCESS != create_block2_suit())
+        goto exit;
 
-   if (CUE_SUCCESS != create_convert_numbers_suit())
-      goto exit;
+    if (CUE_SUCCESS != create_convert_numbers_suit())
+        goto exit;
 
-   if (CUE_SUCCESS != create_tlv_json_suit())
-      goto exit;
+    if (CUE_SUCCESS != create_tlv_json_suit())
+        goto exit;
 
-   if (CUE_SUCCESS != create_tlv_suit())
-      goto exit;
+    if (CUE_SUCCESS != create_tlv_suit())
+        goto exit;
 
-   if (CUE_SUCCESS != create_uri_suit())
-      goto exit;
+    if (CUE_SUCCESS != create_uri_suit())
+        goto exit;
 
 #ifdef LWM2M_SUPPORT_SENML_JSON
    if (CUE_SUCCESS != create_senml_json_suit())

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -50,7 +50,7 @@ CU_ErrorCode add_tests(CU_pSuite pSuite, struct TestTable* testTable)
     return CUE_SUCCESS;
 }
 
-int main()
+int main(void)
 {
    /* initialize the CUnit test registry */
    if (CUE_SUCCESS != CU_initialize_registry())

--- a/tests/uritests.c
+++ b/tests/uritests.c
@@ -379,15 +379,13 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_uri_suit(void)
-{
-   CU_pSuite pSuite = NULL;
+CU_ErrorCode create_uri_suit(void) {
+    CU_pSuite pSuite = NULL;
 
-   pSuite = CU_add_suite("Suite_URI", NULL, NULL);
-   if (NULL == pSuite) {
-      return CU_get_error();
-   }
+    pSuite = CU_add_suite("Suite_URI", NULL, NULL);
+    if (NULL == pSuite) {
+        return CU_get_error();
+    }
 
-   return add_tests(pSuite, table);
+    return add_tests(pSuite, table);
 }
-

--- a/tests/uritests.c
+++ b/tests/uritests.c
@@ -379,7 +379,7 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_uri_suit()
+CU_ErrorCode create_uri_suit(void)
 {
    CU_pSuite pSuite = NULL;
 

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -124,6 +124,11 @@ add_compile_options(
     -pedantic
 )
 
+# Turn certain warnings into errors
+add_compile_options(
+    -Werror=strict-prototypes
+)
+
 # The maximum buffer size that is provided for resource responses and must be respected due to the limited IP buffer.
 # Larger data must be handled by the resource and will be sent chunk-wise through a TCP stream or CoAP blocks. Block
 # size is set to 1024 bytes if not specified otherwise to avoid block transfers in common use cases.


### PR DESCRIPTION
This is the first warning we actually enforce. Hopefully, many more will follow.

There are two commits: One for the functional changes, another one required by the code formatting rules. Probably best to review commit-by-commit.