### PR TITLE
ci: Avoid gitlint warning I3

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 ignore-fixup-commits=false
+regex-style-search=True
 
 [title-must-not-contain-word]
 words=wip,fixup


### PR DESCRIPTION
The ignore-body-lines regex also works for re.search(). Resolving the warning by opting-in to the new behavior.

Relevant links:
 - https://jorisroovers.com/gitlint/configuration/#regex-style-search
 - https://github.com/jorisroovers/gitlint/issues/254