### PR TITLE
Disable some compiler warnings from tinydtls

### DIFF
--- a/examples/shared/tinydtls.cmake
+++ b/examples/shared/tinydtls.cmake
@@ -85,3 +85,10 @@ set(TINYDTLS_SOURCES ${TINYDTLS_SOURCES} ${TINYDTLS_SOURCES_GENERATED})
 
 # Compile definitions for tinydtls
 set_source_files_properties(${TINYDTLS_SOURCES} PROPERTIES COMPILE_DEFINITIONS WITH_SHA256)
+
+# Disable warnings from tinydtls for examples
+set_source_files_properties(${TINYDTLS_SOURCES} PROPERTIES COMPILE_FLAGS "-Wno-discarded-qualifiers \
+                                                                          -Wno-old-style-declaration \
+                                                                          -Wno-unused-parameter \
+                                                                          -Wno-sign-compare \
+                                                                          -Wno-array-parameter")


### PR DESCRIPTION
Not sure if this is a good idea. But the alternative would be to fix tinydtls.

The code of tinydtls is not under our control. It is also not part of Wakaama and is
only used for some examples.
Disabling these warnings lead the focus on warnings emitted from Wakaama code.