### PR TITLE
Fail build on warning

### DIFF
--- a/core/observe.c
+++ b/core/observe.c
@@ -746,15 +746,12 @@ void observe_step(lwm2m_context_t * contextP,
                     {
                         LOG_ARG("Checking minimal period (%d s)", watcherP->parameters->minPeriod);
 
-                        if ((time_t)(watcherP->lastTime + watcherP->parameters->minPeriod) > currentTime)
-                        {
+                        if ((time_t)(watcherP->lastTime + watcherP->parameters->minPeriod) > currentTime) {
                             // Minimum Period did not elapse yet
                             interval = watcherP->lastTime + watcherP->parameters->minPeriod - currentTime;
                             if (*timeoutP > interval) *timeoutP = interval;
                             notify = false;
-                        }
-                        else
-                        {
+                        } else {
                             LOG("Notify on minimal period");
                             notify = true;
                         }
@@ -768,8 +765,7 @@ void observe_step(lwm2m_context_t * contextP,
                 {
                     LOG_ARG("Checking maximal period (%d s)", watcherP->parameters->maxPeriod);
 
-                    if ((time_t)(watcherP->lastTime + watcherP->parameters->maxPeriod) <= currentTime)
-                    {
+                    if ((time_t)(watcherP->lastTime + watcherP->parameters->maxPeriod) <= currentTime) {
                         LOG("Notify on maximal period");
                         notify = true;
                     }

--- a/core/observe.c
+++ b/core/observe.c
@@ -746,7 +746,7 @@ void observe_step(lwm2m_context_t * contextP,
                     {
                         LOG_ARG("Checking minimal period (%d s)", watcherP->parameters->minPeriod);
 
-                        if (watcherP->lastTime + watcherP->parameters->minPeriod > currentTime)
+                        if ((time_t)(watcherP->lastTime + watcherP->parameters->minPeriod) > currentTime)
                         {
                             // Minimum Period did not elapse yet
                             interval = watcherP->lastTime + watcherP->parameters->minPeriod - currentTime;
@@ -768,7 +768,7 @@ void observe_step(lwm2m_context_t * contextP,
                 {
                     LOG_ARG("Checking maximal period (%d s)", watcherP->parameters->maxPeriod);
 
-                    if (watcherP->lastTime + watcherP->parameters->maxPeriod <= currentTime)
+                    if ((time_t)(watcherP->lastTime + watcherP->parameters->maxPeriod) <= currentTime)
                     {
                         LOG("Notify on maximal period");
                         notify = true;

--- a/data/senml_json.c
+++ b/data/senml_json.c
@@ -178,10 +178,13 @@ static int prv_parseItem(const uint8_t * buffer,
                         }
                         break;
                     case LWM2M_TYPE_FLOAT:
+                        _Pragma("GCC diagnostic push");
+                        _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"");
                         if (baseValue->value.asFloat == 0.0)
                         {
                             baseValue->type = LWM2M_TYPE_UNDEFINED;
                         }
+                        _Pragma("GCC diagnostic pop");
                         break;
                     default:
                         return -1;

--- a/examples/bootstrap_server/bootstrap_info.c
+++ b/examples/bootstrap_server/bootstrap_info.c
@@ -48,7 +48,7 @@ typedef struct
 } read_server_t;
 
 static int prv_find_next_section(FILE * fd,
-                                 char * tag)
+                                 const char * tag)
 {
     char * line;
     size_t length;

--- a/examples/bootstrap_server/bootstrap_info.c
+++ b/examples/bootstrap_server/bootstrap_info.c
@@ -47,9 +47,7 @@ typedef struct
 #endif
 } read_server_t;
 
-static int prv_find_next_section(FILE * fd,
-                                 const char * tag)
-{
+static int prv_find_next_section(FILE *fd, const char *tag) {
     char * line;
     size_t length;
     int found;

--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -80,8 +80,8 @@ void handle_sigint(int signum)
     prv_quit(NULL, NULL, NULL);
 }
 
-void print_usage(char * filename,
-                 char * port)
+void print_usage(const char * filename,
+                 const char * port)
 {
     fprintf(stdout, "Usage: bootstap_server [OPTION]\r\n");
     fprintf(stderr, "Launch a LWM2M Bootstrap Server.\r\n\n");
@@ -333,7 +333,7 @@ static void prv_send_command(lwm2m_context_t *lwm2mH,
 }
 
 static int prv_bootstrap_callback(lwm2m_context_t *lwm2mH, void *sessionH, uint8_t status, lwm2m_uri_t *uriP,
-                                  char *name, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
+                                  const char *name, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
                                   void *userData) {
     internal_data_t * dataP = (internal_data_t *)userData;
     endpoint_t * endP;
@@ -486,7 +486,7 @@ static void prv_bootstrap_client(lwm2m_context_t *lwm2mH,
 {
     internal_data_t * dataP = (internal_data_t *)user_data;
     char * uri;
-    char * name = "";
+    const char * name = "";
     char * end = NULL;
     char * host;
     char * port;
@@ -558,9 +558,9 @@ int main(int argc, char *argv[])
     fd_set readfds;
     struct timeval tv;
     int result;
-    char * port = "5685";
+    const char * port = "5685";
     internal_data_t data;
-    char * filename = "bootstrap_server.ini";
+    const char * filename = "bootstrap_server.ini";
     int opt;
     FILE * fd;
     lwm2m_context_t * lwm2mH;

--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -721,7 +721,7 @@ int main(int argc, char *argv[])
                 else
                 {
                     char s[INET6_ADDRSTRLEN];
-                    in_port_t port;
+                    in_port_t rec_port;
                     connection_t * connP;
 
 					s[0] = 0;
@@ -729,16 +729,16 @@ int main(int argc, char *argv[])
                     {
                         struct sockaddr_in *saddr = (struct sockaddr_in *)&addr;
                         inet_ntop(saddr->sin_family, &saddr->sin_addr, s, INET6_ADDRSTRLEN);
-                        port = saddr->sin_port;
+                        rec_port = saddr->sin_port;
                     }
                     else if (AF_INET6 == addr.ss_family)
                     {
                         struct sockaddr_in6 *saddr = (struct sockaddr_in6 *)&addr;
                         inet_ntop(saddr->sin6_family, &saddr->sin6_addr, s, INET6_ADDRSTRLEN);
-                        port = saddr->sin6_port;
+                        rec_port = saddr->sin6_port;
                     }
 
-                    fprintf(stderr, "%zd bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(port));
+                    fprintf(stderr, "%zd bytes received from [%s]:%hu\r\n", numBytes, s, ntohs(rec_port));
 
                     output_buffer(stderr, buffer, (size_t)numBytes, 0);
 

--- a/examples/bootstrap_server/bootstrap_server.c
+++ b/examples/bootstrap_server/bootstrap_server.c
@@ -80,9 +80,7 @@ void handle_sigint(int signum)
     prv_quit(NULL, NULL, NULL);
 }
 
-void print_usage(const char * filename,
-                 const char * port)
-{
+void print_usage(const char *filename, const char *port) {
     fprintf(stdout, "Usage: bootstap_server [OPTION]\r\n");
     fprintf(stderr, "Launch a LWM2M Bootstrap Server.\r\n\n");
     fprintf(stdout, "Options:\r\n");
@@ -486,7 +484,7 @@ static void prv_bootstrap_client(lwm2m_context_t *lwm2mH,
 {
     internal_data_t * dataP = (internal_data_t *)user_data;
     char * uri;
-    const char * name = "";
+    const char *name = "";
     char * end = NULL;
     char * host;
     char * port;
@@ -558,9 +556,9 @@ int main(int argc, char *argv[])
     fd_set readfds;
     struct timeval tv;
     int result;
-    const char * port = "5685";
+    const char *port = "5685";
     internal_data_t data;
-    const char * filename = "bootstrap_server.ini";
+    const char *filename = "bootstrap_server.ini";
     int opt;
     FILE * fd;
     lwm2m_context_t * lwm2mH;

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -866,7 +866,7 @@ int main(int argc, char *argv[])
     const char * localPort = "56830";
     const char * server = NULL;
     const char * serverPort = LWM2M_STANDARD_PORT_STR;
-    char * name = "testlwm2mclient";
+    const char * name = "testlwm2mclient";
     int lifetime = 300;
     int batterylevelchanging = 0;
     time_t reboot_time = 0;

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -869,7 +869,7 @@ int main(int argc, char *argv[])
     const char * localPort = "56830";
     const char * server = NULL;
     const char * serverPort = LWM2M_STANDARD_PORT_STR;
-    const char * name = "testlwm2mclient";
+    const char *name = "testlwm2mclient";
     int lifetime = 300;
     int batterylevelchanging = 0;
     time_t reboot_time = 0;

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -831,6 +831,9 @@ static void prv_display_objects(lwm2m_context_t *lwm2mH, char *buffer, void *use
             case TEST_OBJECT_ID:
                 display_test_object(object);
                 break;
+            default:
+                fprintf(stdout, "unknown object ID: %" PRIu16 "\n", object->objID);
+                break;
             }
         }
     }

--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -1382,7 +1382,7 @@ int main(int argc, char *argv[])
                          * Let liblwm2m respond to the query depending on the context
                          */
 #ifdef WITH_TINYDTLS
-                        int result = connection_handle_packet(connP, buffer, numBytes);
+                        result = connection_handle_packet(connP, buffer, numBytes);
                         if (0 != result)
                         {
                              printf("error handling message %d\n",result);

--- a/examples/lightclient/lightclient.c
+++ b/examples/lightclient/lightclient.c
@@ -329,7 +329,7 @@ int main(int argc, char *argv[])
     lwm2m_object_t * objArray[OBJ_COUNT];
 
     const char * localPort = "56830";
-    char * name = "testlwm2mclient";
+    const char * name = "testlwm2mclient";
 
     int result;
     int opt;

--- a/examples/lightclient/lightclient.c
+++ b/examples/lightclient/lightclient.c
@@ -329,7 +329,7 @@ int main(int argc, char *argv[])
     lwm2m_object_t * objArray[OBJ_COUNT];
 
     const char * localPort = "56830";
-    const char * name = "testlwm2mclient";
+    const char *name = "testlwm2mclient";
 
     int result;
     int opt;

--- a/examples/lightclient/object_security.c
+++ b/examples/lightclient/object_security.c
@@ -110,7 +110,7 @@ static uint8_t prv_get_value(lwm2m_data_t * dataP,
     case LWM2M_SECURITY_SMS_KEY_PARAM_ID:
         // Here we return an opaque of 6 bytes containing a buggy value
         {
-            const char * value = "12345";
+            const char *value = "12345";
             lwm2m_data_encode_opaque((uint8_t *)value, 6, dataP);
         }
         return COAP_205_CONTENT;
@@ -118,7 +118,7 @@ static uint8_t prv_get_value(lwm2m_data_t * dataP,
     case LWM2M_SECURITY_SMS_SECRET_KEY_ID:
         // Here we return an opaque of 32 bytes containing a buggy value
         {
-            const char * value = "1234567890abcdefghijklmnopqrstu";
+            const char *value = "1234567890abcdefghijklmnopqrstu";
             lwm2m_data_encode_opaque((uint8_t *)value, 32, dataP);
         }
         return COAP_205_CONTENT;

--- a/examples/lightclient/object_security.c
+++ b/examples/lightclient/object_security.c
@@ -110,7 +110,7 @@ static uint8_t prv_get_value(lwm2m_data_t * dataP,
     case LWM2M_SECURITY_SMS_KEY_PARAM_ID:
         // Here we return an opaque of 6 bytes containing a buggy value
         {
-            char * value = "12345";
+            const char * value = "12345";
             lwm2m_data_encode_opaque((uint8_t *)value, 6, dataP);
         }
         return COAP_205_CONTENT;
@@ -118,7 +118,7 @@ static uint8_t prv_get_value(lwm2m_data_t * dataP,
     case LWM2M_SECURITY_SMS_SECRET_KEY_ID:
         // Here we return an opaque of 32 bytes containing a buggy value
         {
-            char * value = "1234567890abcdefghijklmnopqrstu";
+            const char * value = "1234567890abcdefghijklmnopqrstu";
             lwm2m_data_encode_opaque((uint8_t *)value, 32, dataP);
         }
         return COAP_205_CONTENT;

--- a/examples/shared/commandline.c
+++ b/examples/shared/commandline.c
@@ -267,7 +267,7 @@ void output_tlv(FILE * stream,
             uint8_t tmp;
 
             print_indent(stream, indent+2);
-            fprintf(stream, "data (%ld bytes):\r\n", dataLen);
+            fprintf(stream, "data (%zu bytes):\r\n", dataLen);
             output_buffer(stream, (uint8_t*)buffer + length + dataIndex, dataLen, indent+2);
 
             tmp = buffer[length + dataIndex + dataLen];

--- a/examples/shared/commandline.h
+++ b/examples/shared/commandline.h
@@ -23,9 +23,9 @@ typedef void (*command_handler_t) (lwm2m_context_t *lwm2mH, char * args, void * 
 
 typedef struct
 {
-    char *            name;
-    char *            shortDesc;
-    char *            longDesc;
+    const char *            name;
+    const char *            shortDesc;
+    const char *            longDesc;
     command_handler_t callback;
     void *            userData;
 } command_desc_t;

--- a/examples/shared/commandline.h
+++ b/examples/shared/commandline.h
@@ -23,9 +23,9 @@ typedef void (*command_handler_t) (lwm2m_context_t *lwm2mH, char * args, void * 
 
 typedef struct
 {
-    const char *            name;
-    const char *            shortDesc;
-    const char *            longDesc;
+    const char *name;
+    const char *shortDesc;
+    const char *longDesc;
     command_handler_t callback;
     void *            userData;
 } command_desc_t;

--- a/examples/shared/connection.c
+++ b/examples/shared/connection.c
@@ -189,7 +189,7 @@ int connection_send(connection_t *connP,
         return -1;
     }
 
-    fprintf(stderr, "Sending %lu bytes to [%s]:%hu\r\n", length, s, ntohs(port));
+    fprintf(stderr, "Sending %zu bytes to [%s]:%hu\r\n", length, s, ntohs(port));
 
     output_buffer(stderr, buffer, length, 0);
 #endif
@@ -215,13 +215,13 @@ uint8_t lwm2m_buffer_send(void * sessionH,
 
     if (connP == NULL)
     {
-        fprintf(stderr, "#> failed sending %lu bytes, missing connection\r\n", length);
+        fprintf(stderr, "#> failed sending %zu bytes, missing connection\r\n", length);
         return COAP_500_INTERNAL_SERVER_ERROR ;
     }
 
     if (-1 == connection_send(connP, buffer, length))
     {
-        fprintf(stderr, "#> failed sending %lu bytes\r\n", length);
+        fprintf(stderr, "#> failed sending %zu bytes\r\n", length);
         return COAP_500_INTERNAL_SERVER_ERROR ;
     }
 

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -35,7 +35,8 @@ typedef struct _dtls_app_context_
 } dtls_app_context_t;
 
 /********************* Security Obj Helpers **********************/
-char * security_get_uri(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, char * uriBuffer, size_t bufferSize){
+char *security_get_uri(lwm2m_context_t *lwm2mH, lwm2m_object_t *obj, int instanceId, char *uriBuffer,
+                       size_t bufferSize) {
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 0; // security server uri
@@ -74,7 +75,7 @@ int64_t security_get_mode(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int in
     return LWM2M_SECURITY_MODE_NONE;
 }
 
-char * security_get_public_id(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, size_t * length){
+char *security_get_public_id(lwm2m_context_t *lwm2mH, lwm2m_object_t *obj, int instanceId, size_t *length) {
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 3; // public key or id
@@ -99,8 +100,7 @@ char * security_get_public_id(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, in
     }
 }
 
-
-char * security_get_secret_key(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, size_t * length){
+char *security_get_secret_key(lwm2m_context_t *lwm2mH, lwm2m_object_t *obj, int instanceId, size_t *length) {
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 5; // secret key

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -35,7 +35,7 @@ typedef struct _dtls_app_context_
 } dtls_app_context_t;
 
 /********************* Security Obj Helpers **********************/
-char * security_get_uri(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, char * uriBuffer, int bufferSize){
+char * security_get_uri(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, char * uriBuffer, size_t bufferSize){
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 0; // security server uri
@@ -74,7 +74,7 @@ int64_t security_get_mode(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int in
     return LWM2M_SECURITY_MODE_NONE;
 }
 
-char * security_get_public_id(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, int * length){
+char * security_get_public_id(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, size_t * length){
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 3; // public key or id
@@ -100,7 +100,7 @@ char * security_get_public_id(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, in
 }
 
 
-char * security_get_secret_key(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, int * length){
+char * security_get_secret_key(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, size_t * length){
     int size = 1;
     lwm2m_data_t * dataP = lwm2m_data_new(size);
     dataP->id = 5; // secret key
@@ -194,7 +194,7 @@ static int get_psk_info(struct dtls_context_t *ctx,
     switch (type) {
         case DTLS_PSK_IDENTITY:
         {
-            int idLen;
+            size_t idLen;
             char *id2;
             id2 = security_get_public_id(appContext->lwm2mH, cnx->securityObj, cnx->securityInstId, &idLen);
             if (result_length < idLen)
@@ -209,7 +209,7 @@ static int get_psk_info(struct dtls_context_t *ctx,
         }
         case DTLS_PSK_KEY:
         {
-            int keyLen;
+            size_t keyLen;
             char * key;
             key = security_get_secret_key(appContext->lwm2mH, cnx->securityObj, cnx->securityInstId, &keyLen);
 

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -34,8 +34,6 @@ typedef struct _dtls_app_context_
     dtls_connection_t * connList;
 } dtls_app_context_t;
 
-dtls_app_context_t appContext;
-
 /********************* Security Obj Helpers **********************/
 char * security_get_uri(lwm2m_context_t * lwm2mH, lwm2m_object_t * obj, int instanceId, char * uriBuffer, int bufferSize){
     int size = 1;
@@ -197,16 +195,16 @@ static int get_psk_info(struct dtls_context_t *ctx,
         case DTLS_PSK_IDENTITY:
         {
             int idLen;
-            char * id;
-            id = security_get_public_id(appContext->lwm2mH, cnx->securityObj, cnx->securityInstId, &idLen);
+            char *id2;
+            id2 = security_get_public_id(appContext->lwm2mH, cnx->securityObj, cnx->securityInstId, &idLen);
             if (result_length < idLen)
             {
                 printf("cannot set psk_identity -- buffer too small\n");
                 return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
             }
 
-            memcpy(result, id,idLen);
-            lwm2m_free(id);
+            memcpy(result, id2, idLen);
+            lwm2m_free(id2);
             return idLen;
         }
         case DTLS_PSK_KEY:
@@ -292,6 +290,7 @@ static dtls_handler_t cb = {
 };
 
 dtls_context_t * get_dtls_context(lwm2m_context_t * lwm2mH, dtls_connection_t * connList) {
+    static dtls_app_context_t appContext;
     appContext.lwm2mH = lwm2mH;
     appContext.connList = connList;
     if (dtlsContext == NULL) {

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -462,16 +462,16 @@ dtls_connection_t * connection_create(dtls_connection_t * connList,
     if (uri == NULL) return NULL;
 
     // parse uri in the form "coaps://[host]:[port]"
-    char * defaultport;
+    char defaultport[5];
     if (0 == strncmp(uri, "coaps://", strlen("coaps://")))
     {
         host = uri+strlen("coaps://");
-        defaultport = COAPS_PORT;
+        strncpy(defaultport, COAPS_PORT, 5);
     }
     else if (0 == strncmp(uri, "coap://", strlen("coap://")))
     {
         host = uri+strlen("coap://");
-        defaultport = COAP_PORT;
+        strncpy(defaultport, COAP_PORT, 5);
     }
     else
     {

--- a/examples/shared/dtlsconnection.c
+++ b/examples/shared/dtlsconnection.c
@@ -640,13 +640,13 @@ uint8_t lwm2m_buffer_send(void * sessionH,
 
     if (connP == NULL)
     {
-        fprintf(stderr, "#> failed sending %lu bytes, missing connection\r\n", length);
+        fprintf(stderr, "#> failed sending %zu bytes, missing connection\r\n", length);
         return COAP_500_INTERNAL_SERVER_ERROR ;
     }
 
     if (-1 == connection_send(connP, buffer, length))
     {
-        fprintf(stderr, "#> failed sending %lu bytes\r\n", length);
+        fprintf(stderr, "#> failed sending %zu bytes\r\n", length);
         return COAP_500_INTERNAL_SERVER_ERROR ;
     }
 

--- a/examples/shared/tinydtls.cmake
+++ b/examples/shared/tinydtls.cmake
@@ -81,6 +81,7 @@ endif()
 # Add tinydtls sources to an existing target.
 function(target_sources_tinydtls target)
     target_sources(${target} PRIVATE ${TINYDTLS_SOURCES} ${TINYDTLS_SOURCES_GENERATED})
+    set_source_files_properties(${TINYDTLS_SOURCES} PROPERTIES COMPILE_FLAGS -Wno-cast-align)
     target_compile_definitions(${target} PRIVATE WITH_SHA256 SHA2_USE_INTTYPES_H)
     target_include_directories(${target} PRIVATE ${TINYDTLS_SOURCES_DIR})
 endfunction()

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -765,7 +765,7 @@ typedef enum
 // client, the URI of the operation (may be nil) and name is nil. The callback return value is ignored.
 // If data is present and no preferred format is provided by the client the format will be 0, otherwise it will be set.
 typedef int (*lwm2m_bootstrap_callback_t)(lwm2m_context_t *contextP, void *sessionH, uint8_t status, lwm2m_uri_t *uriP,
-                                          char *name, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
+                                          const char *name, lwm2m_media_type_t format, uint8_t *data, size_t dataLength,
                                           void *userData);
 #endif
 

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -128,6 +128,7 @@ add_compile_options(
 add_compile_options(
     -Werror=discarded-qualifiers
     -Werror=incompatible-pointer-types
+    -Werror=shadow
     -Werror=strict-prototypes
 )
 

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -122,6 +122,9 @@ add_compile_options(
     -Wwrite-strings
     -Werror=absolute-value
     -pedantic
+
+    # Reduce noise: Unused parameters are common in this ifdef-littered code-base, but of no danger
+    -Wno-unused-parameter
 )
 
 # Turn certain warnings into errors

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -109,7 +109,7 @@ function(target_sources_shared target)
     target_include_directories(${target} PUBLIC ${WAKAAMA_EXAMPLE_SHARED_DIRECTORY})
 endfunction()
 
-# Warn about problematic code (not yet enforced)
+# Enforce a certain level of hygiene
 add_compile_options(
     -Waggregate-return
     -Wall
@@ -120,24 +120,17 @@ add_compile_options(
     -Wshadow
     -Wswitch-default
     -Wwrite-strings
-    -Werror=absolute-value
     -pedantic
 
     # Reduce noise: Unused parameters are common in this ifdef-littered code-base, but of no danger
     -Wno-unused-parameter
     # Reduce noise: Too many false positives
     -Wno-uninitialized
-)
 
-# Turn certain warnings into errors
-add_compile_options(
-    -Werror=discarded-qualifiers
-    -Werror=incompatible-pointer-types
-    -Werror=float-equal
-    -Werror=shadow
-    -Werror=sign-compare
-    -Werror=strict-prototypes
-    -Werror=switch-default
+     # Turn (most) warnings into errors
+    -Werror
+    # Disabled because of existing, non-trivially fixable code
+    -Wno-error=cast-align
 )
 
 # The maximum buffer size that is provided for resource responses and must be respected due to the limited IP buffer.

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -126,6 +126,7 @@ add_compile_options(
 
 # Turn certain warnings into errors
 add_compile_options(
+    -Werror=discarded-qualifiers
     -Werror=strict-prototypes
 )
 

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -129,6 +129,7 @@ add_compile_options(
     -Werror=discarded-qualifiers
     -Werror=incompatible-pointer-types
     -Werror=shadow
+    -Werror=sign-compare
     -Werror=strict-prototypes
     -Werror=switch-default
 )

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -125,6 +125,8 @@ add_compile_options(
 
     # Reduce noise: Unused parameters are common in this ifdef-littered code-base, but of no danger
     -Wno-unused-parameter
+    # Reduce noise: Too many false positives
+    -Wno-uninitialized
 )
 
 # Turn certain warnings into errors

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -128,6 +128,7 @@ add_compile_options(
 add_compile_options(
     -Werror=discarded-qualifiers
     -Werror=incompatible-pointer-types
+    -Werror=float-equal
     -Werror=shadow
     -Werror=sign-compare
     -Werror=strict-prototypes

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -127,6 +127,7 @@ add_compile_options(
 # Turn certain warnings into errors
 add_compile_options(
     -Werror=discarded-qualifiers
+    -Werror=incompatible-pointer-types
     -Werror=strict-prototypes
 )
 

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -130,6 +130,7 @@ add_compile_options(
     -Werror=incompatible-pointer-types
     -Werror=shadow
     -Werror=strict-prototypes
+    -Werror=switch-default
 )
 
 # The maximum buffer size that is provided for resource responses and must be respected due to the limited IP buffer.


### PR DESCRIPTION
Fix or work around warnings in existing code base. Enforce warning free build in CI.

Probably best reviewed commit-by-commit, due to the reformatting required by clang-format.