### PR TITLE
Fix memory leak - Bootstrap CoAP temporary payload not deallocated

### DIFF
--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -124,12 +124,25 @@ static void prv_deleteServerList(lwm2m_context_t * context)
 
 static void prv_deleteBootstrapServer(lwm2m_server_t * serverP, void *userData)
 {
-    // TODO should we free location as in prv_deleteServer ?
+    LOG("Entering");
     // TODO should we parse transaction and observation to remove the ones related to this server ?
     if (serverP->sessionH != NULL)
     {
-         lwm2m_close_connection(serverP->sessionH, userData);
+        lwm2m_close_connection(serverP->sessionH, userData);
     }
+    if (NULL != serverP->location)
+    {
+        lwm2m_free(serverP->location);
+    }
+
+    while(serverP->blockData != NULL)
+    {
+        lwm2m_block_data_t * targetP;
+        targetP = serverP->blockData;
+        serverP->blockData = serverP->blockData->next;
+        free_block_data(targetP);
+    }
+
     lwm2m_free(serverP);
 }
 


### PR DESCRIPTION
Fix a memory leak, caused by the temporary CoAP payload data (send by bootstrap server) not deallocated.
See: https://github.com/eclipse/wakaama/issues/701