### PR TITLE
Move cmake toplevel includes to subdirectories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.13)
 
 project(wakaama C)
 
-include(wakaama.cmake)
-
 add_subdirectory(examples)
 
 # Enable "test" target

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 
 project(lwm2munittests C)
 
+include(../wakaama.cmake)
+
 add_executable(
     lwm2munittests
     block1tests.c


### PR DESCRIPTION
Move the `wakaama.cmake` includes to the sub-directories and add the missing include in tests.

This is needed to use `tests/CMakeLists.txt` standalone.

Steps to reproduce:
```
cd tests
cmake -GNinja -B build-tests .
```