### PR TITLE
Fix memory leak if the client fails to register with the server

### DIFF
--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -173,6 +173,9 @@ void prv_deleteTransactionList(lwm2m_context_t * context)
 
         transaction = context->transactionList;
         context->transactionList = context->transactionList->next;
+        if(transaction->callback) {
+            transaction->callback(context, transaction, NULL);
+        }
         transaction_free(transaction);
     }
 }


### PR DESCRIPTION
[registration_data_t](https://github.com/eclipse/wakaama/blob/snapshots/2023-03-31/core/registration.c#L631) is not feed if the server does not respond to the connection message or the user decides to quit the (Wakaama) client before the server respond.
See: https://github.com/eclipse/wakaama/issues/693