### PR TITLE
lwm2m_handle_packet trying to free a NULL payload pointer

### DIFF
--- a/core/packet.c
+++ b/core/packet.c
@@ -641,7 +641,10 @@ void lwm2m_handle_packet(lwm2m_context_t *contextP, uint8_t *buffer, size_t leng
 
                 coap_error_code = message_send(contextP, response, fromSessionH);
 
-                lwm2m_free(payload);
+                if(payload != NULL)
+                {
+                    lwm2m_free(payload);
+                }
                 response->payload = NULL;
                 response->payload_len = 0;
             }


### PR DESCRIPTION
lwm2m_handle_packet frees the payload on line 644 without taking into consideration that the payload may not exist, for example in case the client has to send a message without payload (which often happens during the bootstrap phase and connection to the LwM2M server).
See: https://github.com/eclipse/wakaama/issues/707