### PR TITLE
Made srand(...) and rand() platform independent

### DIFF
--- a/core/liblwm2m.c
+++ b/core/liblwm2m.c
@@ -68,7 +68,7 @@ lwm2m_context_t * lwm2m_init(void * userData)
     {
         memset(contextP, 0, sizeof(lwm2m_context_t));
         contextP->userData = userData;
-        srand((int)lwm2m_gettime());
+        srand(lwm2m_seed());
         contextP->nextMID = rand();
     }
 

--- a/examples/shared/platform.c
+++ b/examples/shared/platform.c
@@ -67,6 +67,16 @@ time_t lwm2m_gettime(void)
     return time(NULL);
 }
 
+int lwm2m_seed(void) {
+    /*
+     * Return a seed for random number generation, the seed must be a
+     * different number at every boot and unpredictable, time(NULL) may not be
+     * a reliable source as a seed.
+     * See: https://github.com/eclipse/wakaama/pull/711
+     */
+    return time(NULL);
+}
+
 void lwm2m_printf(const char * format, ...)
 {
     va_list ap;

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -118,6 +118,8 @@ int lwm2m_strcasecmp(const char * str1, const char * str2);
 // In case of error, this must return a negative value.
 // Per POSIX specifications, time_t is a signed integer.
 time_t lwm2m_gettime(void);
+// Get a seed (which must not repeat when the device reboots) for generating a random number
+int lwm2m_seed(void);
 
 #ifdef LWM2M_WITH_LOGS
 // Same usage as C89 printf()


### PR DESCRIPTION
The `srand(...)` and `rand()` functions are not available on all embedded platforms, so they were replaced with `lwm2m_srand(...)` and `lwm2m_rand()` to make these calls platform independent.