### PR TITLE
Renamed uri_toString(...) to lwm2m_uriToString(...) in order to make it public

### DIFF
--- a/core/discover.c
+++ b/core/discover.c
@@ -421,7 +421,7 @@ int discover_serialize(lwm2m_context_t * contextP,
         }
     }
 
-    baseUriLen = uri_toString(uriP, baseUriStr, URI_MAX_STRING_LEN, NULL);
+    baseUriLen = lwm2m_uriToString(uriP, baseUriStr, URI_MAX_STRING_LEN, NULL);
     if (baseUriLen < 0) return -1;
 
     for (index = 0; index < size && head < PRV_LINK_BUFFER_SIZE; index++)

--- a/core/internals.h
+++ b/core/internals.h
@@ -268,15 +268,6 @@ typedef struct
     lwm2m_context_t *       contextP;
 } observation_data_t;
 
-typedef enum
-{
-    URI_DEPTH_NONE,
-    URI_DEPTH_OBJECT,
-    URI_DEPTH_OBJECT_INSTANCE,
-    URI_DEPTH_RESOURCE,
-    URI_DEPTH_RESOURCE_INSTANCE
-} uri_depth_t;
-
 #ifdef LWM2M_BOOTSTRAP_SERVER_MODE
 typedef struct
 {
@@ -298,7 +289,6 @@ typedef enum
 // defined in uri.c
 lwm2m_request_type_t uri_decode(char * altPath, multi_option_t *uriPath, uint8_t code, lwm2m_uri_t *uriP);
 int uri_getNumber(uint8_t * uriString, size_t uriLength);
-int uri_toString(const lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, uri_depth_t * depthP);
 
 // defined in objects.c
 uint8_t object_readData(lwm2m_context_t * contextP, lwm2m_uri_t * uriP, int * sizeP, lwm2m_data_t ** dataP);

--- a/core/uri.c
+++ b/core/uri.c
@@ -286,10 +286,10 @@ int lwm2m_stringToUri(const char * buffer,
     return head;
 }
 
-int uri_toString(const lwm2m_uri_t * uriP,
-                 uint8_t * buffer,
-                 size_t bufferLen,
-                 uri_depth_t * depthP)
+int lwm2m_uriToString(const lwm2m_uri_t * uriP,
+                      uint8_t * buffer,
+                      size_t bufferLen,
+                      uri_depth_t * depthP)
 {
     size_t head = 0;
     uri_depth_t depth = URI_DEPTH_NONE;

--- a/data/json.c
+++ b/data/json.c
@@ -1007,7 +1007,7 @@ int json_serialize(lwm2m_uri_t * uriP,
     }
 #endif
 
-    baseUriLen = uri_toString(uriP, baseUriStr, URI_MAX_STRING_LEN, &baseLevel);
+    baseUriLen = lwm2m_uriToString(uriP, baseUriStr, URI_MAX_STRING_LEN, &baseLevel);
     if (baseUriLen < 0) return -1;
 
     num = json_findAndCheckData(uriP, baseLevel, size, tlvP, &targetP, &rootLevel);

--- a/data/senml_json.c
+++ b/data/senml_json.c
@@ -1088,7 +1088,7 @@ int senml_json_serialize(const lwm2m_uri_t * uriP,
     LOG_URI(uriP);
     if (size != 0 && tlvP == NULL) return -1;
 
-    baseUriLen = uri_toString(uriP, baseUriStr, URI_MAX_STRING_LEN, &baseLevel);
+    baseUriLen = lwm2m_uriToString(uriP, baseUriStr, URI_MAX_STRING_LEN, &baseLevel);
     if (baseUriLen < 0) return -1;
     if (baseUriLen > 1
      && baseLevel != URI_DEPTH_RESOURCE

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -300,6 +300,15 @@ typedef struct
 #endif
 } lwm2m_uri_t;
 
+typedef enum
+{
+    URI_DEPTH_NONE,
+    URI_DEPTH_OBJECT,
+    URI_DEPTH_OBJECT_INSTANCE,
+    URI_DEPTH_RESOURCE,
+    URI_DEPTH_RESOURCE_INSTANCE
+} uri_depth_t;
+
 #define LWM2M_URI_RESET(uri) memset((uri), 0xFF, sizeof(lwm2m_uri_t))
 
 #define LWM2M_STRING_ID_MAX_LEN 6
@@ -309,6 +318,7 @@ typedef struct
 // Valid URIs: /1, /1/, /1/2, /1/2/, /1/2/3
 // Invalid URIs: /, //, //2, /1//, /1//3, /1/2/3/, /1/2/3/4
 int lwm2m_stringToUri(const char * buffer, size_t buffer_len, lwm2m_uri_t * uriP);
+int lwm2m_uriToString(const lwm2m_uri_t * uriP, uint8_t * buffer, size_t bufferLen, uri_depth_t * depthP);
 
 /*
  * The lwm2m_data_t is used to store LWM2M resource values in a hierarchical way.

--- a/tests/uritests.c
+++ b/tests/uritests.c
@@ -259,13 +259,13 @@ static void test_uri_to_string(void)
     int result;
     char buffer[URI_MAX_STRING_LEN];
 
-    result = uri_toString(NULL, (uint8_t*)buffer, sizeof(buffer), &depth);
+    result = lwm2m_uriToString(NULL, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 0)
     CU_ASSERT_EQUAL(depth, URI_DEPTH_NONE)
     CU_ASSERT_EQUAL(lwm2m_stringToUri(buffer, result, &uri2), result)
 
     LWM2M_URI_RESET(&uri);
-    result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
+    result = lwm2m_uriToString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 1)
     CU_ASSERT_EQUAL(depth, URI_DEPTH_NONE)
     CU_ASSERT_NSTRING_EQUAL(buffer, "/", result)
@@ -278,7 +278,7 @@ static void test_uri_to_string(void)
 #endif
 
     uri.objectId = 1;
-    result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
+    result = lwm2m_uriToString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 2)
     CU_ASSERT_EQUAL(depth, URI_DEPTH_OBJECT)
     CU_ASSERT_NSTRING_EQUAL(buffer, "/1", result)
@@ -292,7 +292,7 @@ static void test_uri_to_string(void)
     CU_ASSERT_EQUAL(uri2.objectId, uri.objectId)
 
     uri.instanceId = 2;
-    result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
+    result = lwm2m_uriToString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 4)
     CU_ASSERT_EQUAL(depth, URI_DEPTH_OBJECT_INSTANCE)
     CU_ASSERT_NSTRING_EQUAL(buffer, "/1/2", result)
@@ -307,7 +307,7 @@ static void test_uri_to_string(void)
     CU_ASSERT_EQUAL(uri2.instanceId, uri.instanceId)
 
     uri.resourceId = 3;
-    result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
+    result = lwm2m_uriToString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, 6)
     CU_ASSERT_EQUAL(depth, URI_DEPTH_RESOURCE)
     CU_ASSERT_NSTRING_EQUAL(buffer, "/1/2/3", result)
@@ -324,7 +324,7 @@ static void test_uri_to_string(void)
 
 #ifndef LWM2M_VERSION_1_0
     uri.resourceInstanceId = 4;
-    result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
+    result = lwm2m_uriToString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(depth, URI_DEPTH_RESOURCE_INSTANCE)
     CU_ASSERT_EQUAL(result, 8)
     CU_ASSERT_NSTRING_EQUAL(buffer, "/1/2/3/4", result)
@@ -346,7 +346,7 @@ static void test_uri_to_string(void)
 #ifndef LWM2M_VERSION_1_0
     uri.resourceInstanceId = LWM2M_MAX_ID - 1;
 #endif
-    result = uri_toString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
+    result = lwm2m_uriToString(&uri, (uint8_t*)buffer, sizeof(buffer), &depth);
     CU_ASSERT_EQUAL(result, URI_MAX_STRING_LEN)
 #ifdef LWM2M_VERSION_1_0
     CU_ASSERT_EQUAL(depth, URI_DEPTH_RESOURCE)
@@ -375,7 +375,7 @@ static void test_uri_to_string(void)
 static struct TestTable table[] = {
         { "test of uri_decode()", test_uri_decode },
         { "test of lwm2m_stringToUri()", test_string_to_uri },
-        { "test of uri_toString()", test_uri_to_string },
+        { "test of lwm2m_uriToString()", test_uri_to_string },
         { NULL, NULL },
 };
 


### PR DESCRIPTION
I often had to convert a `lwm2m_uri_t` object to string, so I made the `uri_toString(...)` function public and renamed it to `lwm2m_uriToString(...)`