### PR TITLE
Enable COAP logs from cmake

### DIFF
--- a/coap/er-coap-13/er-coap-13.c
+++ b/coap/er-coap-13/er-coap-13.c
@@ -47,12 +47,10 @@
 
 #include "er-coap-13.h"
 
-#include "liblwm2m.h" /* for lwm2m_malloc() and lwm2m_free() */
+#include "liblwm2m.h" /* for lwm2m_malloc(), lwm2m_free() and lwm2m_coap_printf() */
 
-#define DEBUG 0
-#if DEBUG
-#include <stdio.h>
-#define PRINTF(...) printf(__VA_ARGS__)
+#ifdef LWM2M_WITH_COAP_LOGS
+#define PRINTF(...) lwm2m_coap_printf(__VA_ARGS__)
 #define PRINT6ADDR(addr) PRINTF("[%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x]", ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], ((uint8_t *)addr)[4], ((uint8_t *)addr)[5], ((uint8_t *)addr)[6], ((uint8_t *)addr)[7], ((uint8_t *)addr)[8], ((uint8_t *)addr)[9], ((uint8_t *)addr)[10], ((uint8_t *)addr)[11], ((uint8_t *)addr)[12], ((uint8_t *)addr)[13], ((uint8_t *)addr)[14], ((uint8_t *)addr)[15])
 #define PRINTLLADDR(lladdr) PRINTF("[%02x:%02x:%02x:%02x:%02x:%02x]",(lladdr)->addr[0], (lladdr)->addr[1], (lladdr)->addr[2], (lladdr)->addr[3],(lladdr)->addr[4], (lladdr)->addr[5])
 #else

--- a/examples/shared/platform.c
+++ b/examples/shared/platform.c
@@ -77,3 +77,14 @@ void lwm2m_printf(const char * format, ...)
 
     va_end(ap);
 }
+
+void lwm2m_coap_printf(const char * format, ...)
+{
+    va_list ap;
+
+    va_start(ap, format);
+
+    vfprintf(stderr, format, ap);
+
+    va_end(ap);
+}

--- a/include/liblwm2m.h
+++ b/include/liblwm2m.h
@@ -124,6 +124,11 @@ time_t lwm2m_gettime(void);
 void lwm2m_printf(const char * format, ...);
 #endif
 
+#ifdef LWM2M_WITH_COAP_LOGS
+// Same usage as C89 printf()
+void lwm2m_coap_printf(const char * format, ...);
+#endif
+
 typedef struct _lwm2m_context_ lwm2m_context_t;
 
 // communication layer


### PR DESCRIPTION
It is now possible to enable COAP logs via the cmake file, without having to edit the `coap/er-coap-13/er-coap-13.c` file.
Also usually the `printf(...)` function is not available with embedded platforms, so it has been replaced with `lwm2m_coap_printf(...)` which must be defined in the `platform.c` file.