### PR TITLE
ci: Replace outdated codeql actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
       uses: seanmiddleditch/gha-setup-ninja@master
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: cpp
 
@@ -39,4 +39,4 @@ jobs:
       run: tools/ci/run_ci.sh --run-build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
As reported by @parmi93, version v1 of the CodeQL Action is no longer updated and supported.

More information: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

This PR will update to CodeQL Action v2.

This will partially address #721 