### PR TITLE
examples: use getline() to read commands

### DIFF
--- a/examples/client/lwm2mclient.c
+++ b/examples/client/lwm2mclient.c
@@ -1407,15 +1407,18 @@ int main(int argc, char *argv[])
              */
             else if (FD_ISSET(STDIN_FILENO, &readfds))
             {
-                numBytes = read(STDIN_FILENO, buffer, MAX_PACKET_SIZE - 1);
+                char *line = NULL;
+                size_t bufLen = 0;
+
+                numBytes = getline(&line, &bufLen, stdin);
 
                 if (numBytes > 1)
                 {
-                    buffer[numBytes] = 0;
+                    line[numBytes] = 0;
                     /*
                      * We call the corresponding callback of the typed command passing it the buffer for further arguments
                      */
-                    handle_command(lwm2mH, commands, (char*)buffer);
+                    handle_command(lwm2mH, commands, line);
                 }
                 if (g_quit == 0)
                 {
@@ -1426,6 +1429,8 @@ int main(int argc, char *argv[])
                 {
                     fprintf(stdout, "\r\n");
                 }
+
+                lwm2m_free(line);
             }
         }
     }

--- a/examples/server/lwm2mserver.c
+++ b/examples/server/lwm2mserver.c
@@ -1245,12 +1245,15 @@ int main(int argc, char *argv[])
             }
             else if (FD_ISSET(STDIN_FILENO, &readfds))
             {
-                numBytes = read(STDIN_FILENO, buffer, MAX_PACKET_SIZE - 1);
+                char *line = NULL;
+                size_t bufLen = 0;
+
+                numBytes = getline(&line, &bufLen, stdin);
 
                 if (numBytes > 1)
                 {
-                    buffer[numBytes] = 0;
-                    handle_command(lwm2mH, commands, (char*)buffer);
+                    line[numBytes] = 0;
+                    handle_command(lwm2mH, commands, line);
                     fprintf(stdout, "\r\n");
                 }
                 if (g_quit == 0)
@@ -1262,6 +1265,8 @@ int main(int argc, char *argv[])
                 {
                     fprintf(stdout, "\r\n");
                 }
+
+                lwm2m_free(line);
             }
         }
     }


### PR DESCRIPTION
examples: use getline() to read commands

The previous approach works only if the terminal is operating in cannonical mode (input available line-by-line), which is not always true. getline() ensures that commands are always read correctly.

With this change commands work properly on Apache NuttX