### PR TITLE
Allow registration message without Resource Type

### DIFF
--- a/core/registration.c
+++ b/core/registration.c
@@ -1357,9 +1357,9 @@ static int prv_parseLinkAttributes(uint8_t * data,
     uint16_t index;
     uint16_t pathStart;
     uint16_t pathLength;
-    bool isValid;
+    uint8_t rtValCount;
 
-    isValid = false;
+    rtValCount = 0;
 
     // Expecting application/link-format (RFC6690)
     // leading space were removed before. Remove trailing spaces.
@@ -1404,20 +1404,18 @@ static int prv_parseLinkAttributes(uint8_t * data,
         result = prv_splitLinkAttribute(data + index, length - index, &keyStart, &keyLength, &valueStart, &valueLength);
         if (result == 0) return 0;
 
-        if (keyLength == REG_ATTR_TYPE_KEY_LEN
-         && 0 == lwm2m_strncmp(REG_ATTR_TYPE_KEY, (char*)data + index + keyStart, keyLength))
-        {
-            if (isValid == true) return 0; // declared twice
+        if (keyLength == REG_ATTR_TYPE_KEY_LEN &&
+            0 == lwm2m_strncmp(REG_ATTR_TYPE_KEY, (char *)data + index + keyStart, keyLength)) {
             if (valueLength != REG_ATTR_TYPE_VALUE_LEN
              || 0 != lwm2m_strncmp(REG_ATTR_TYPE_VALUE, (char*)data + index + valueStart, valueLength))
             {
                 return 0;
             }
-            isValid = true;
-        }
-        else if (keyLength == REG_ATTR_CONTENT_KEY_LEN
-              && 0 == lwm2m_strncmp(REG_ATTR_CONTENT_KEY, (char*)data + index + keyStart, keyLength))
-        {
+            ++rtValCount;
+            if (rtValCount > 1)
+                return 0; // declared twice (or more times)
+        } else if (keyLength == REG_ATTR_CONTENT_KEY_LEN &&
+                   0 == lwm2m_strncmp(REG_ATTR_CONTENT_KEY, (char *)data + index + keyStart, keyLength)) {
             if (*format != LWM2M_CONTENT_TLV) return 0; // declared twice
             if (valueLength == REG_ATTR_CONTENT_JSON_LEN
              && 0 == lwm2m_strncmp(REG_ATTR_CONTENT_JSON, (char*)data + index + valueStart, valueLength))
@@ -1446,7 +1444,8 @@ static int prv_parseLinkAttributes(uint8_t * data,
         index += result;
     }
 
-    if (isValid == false) return 0;
+    if (rtValCount > 1)
+        return 0;
 
     if (pathLength != 0)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
     block2tests.c
     convert_numbers_test.c
     er_coap_coap_parse_message.c
+    registration_tests.c
     list_tests.c
     senml_json_tests.c
     tests.h
@@ -20,7 +21,9 @@ add_executable(
 )
 
 target_link_libraries(lwm2munittests cunit)
-target_compile_definitions(lwm2munittests PRIVATE LWM2M_CLIENT_MODE LWM2M_SUPPORT_TLV LWM2M_SUPPORT_JSON)
+target_compile_definitions(
+    lwm2munittests PRIVATE LWM2M_CLIENT_MODE LWM2M_SERVER_MODE LWM2M_SUPPORT_TLV LWM2M_SUPPORT_JSON
+)
 
 # Our tests are designed for POSIX systems
 target_compile_definitions(lwm2munittests PRIVATE _POSIX_C_SOURCE=200809)

--- a/tests/registration_tests.c
+++ b/tests/registration_tests.c
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ *
+ * Copyright (c) 2023 GARDENA GmbH
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * The Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *   Lukas Woodtli, GARDENA GmbH - Please refer to git log
+ *
+ *******************************************************************************/
+
+#include "CUnit/CUnit.h"
+#include "internals.h"
+#include "liblwm2m.h"
+#include "tests.h"
+
+static void init_test_packet(coap_packet_t *message, const char *registration_message, uint8_t *payload,
+                             const size_t payload_len) {
+    int ret = 0;
+
+    memset(message, 0, sizeof(coap_packet_t));
+    message->code = COAP_POST;
+    ret = coap_set_header_uri_query(message, "lwm2m=1.1&ep=abc");
+    CU_ASSERT(ret > 0);
+
+    memcpy(payload, registration_message, payload_len);
+    message->payload = payload;
+    message->payload_len = payload_len;
+
+    message->content_type = (coap_content_type_t)LWM2M_CONTENT_LINK;
+}
+
+void init_uri(lwm2m_uri_t *const uri) {
+    memset(uri, 0, sizeof(*uri));
+    uri->objectId = LWM2M_MAX_ID;
+}
+
+static int call_test_function(const char *reg_msg, const size_t reg_msg_len) {
+    int ret;
+
+    uint8_t user_data[1] = {0};
+    lwm2m_context_t *context = lwm2m_init(user_data);
+
+    lwm2m_uri_t uri;
+    init_uri(&uri);
+    coap_packet_t message;
+
+    uint8_t payload[reg_msg_len];
+    init_test_packet(&message, reg_msg, payload, reg_msg_len);
+
+    coap_packet_t response;
+    memset(&response, 0, sizeof(coap_packet_t));
+
+    ret = registration_handleRequest(context, &uri, NULL, &message, &response);
+
+    free_multi_option(message.uri_query);
+    free_multi_option(response.location_path);
+
+    lwm2m_close(context);
+
+    return ret;
+}
+
+static void test_registration_with_rt(void) {
+    static const char *registration_message = "</>;rt=\"oma.lwm2m\";ct=110,</28180>;ver=0.4,</28152>;ver=0.2,"
+                                              "</30000>;ver=0.1,</28181>;ver=0.2,</28183>;ver=0.1,"
+                                              "</28182>;ver=0.2,</1>,</3>;ver=1.0,</4>;ver=1.2,</5>;ver=1.0 ";
+    int ret = call_test_function(registration_message, strlen(registration_message));
+    CU_ASSERT_EQUAL(ret, COAP_201_CREATED);
+}
+
+static void test_registration_without_rt(void) {
+    static const char *registration_message = "</>;ct=110,</28180>;ver=0.4,</28152>;ver=0.2,"
+                                              "</30000>;ver=0.1,</28181>;ver=0.2,</28183>;ver=0.1,"
+                                              "</28182>;ver=0.2,</1>,</3>;ver=1.0,</4>;ver=1.2,</5>;ver=1.0 ";
+    int ret = call_test_function(registration_message, strlen(registration_message));
+    CU_ASSERT_EQUAL(ret, COAP_201_CREATED);
+}
+
+static void test_registration_with_two_rt(void) {
+    static const char *registration_message =
+        "</>;rt=\"oma.lwm2m\";rt=\"oma.lwm2m\";ct=110,</28180>;ver=0.4,</28152>;ver=0.2,"
+        "</30000>;ver=0.1,</28181>;ver=0.2,</28183>;ver=0.1,"
+        "</28182>;ver=0.2,</1>,</3>;ver=1.0,</4>;ver=1.2,</5>;ver=1.0 ";
+    int ret = call_test_function(registration_message, strlen(registration_message));
+    CU_ASSERT_EQUAL(ret, COAP_400_BAD_REQUEST);
+}
+
+static struct TestTable table[] = {
+    {"test_registration_with_rt", test_registration_with_rt},
+    {"test_registration_without_rt", test_registration_without_rt},
+    {"test_registration_with_tww_rt", test_registration_with_two_rt},
+    {NULL, NULL},
+};
+
+CU_ErrorCode create_registration_test_suit(void) {
+    CU_pSuite pSuite = NULL;
+
+    pSuite = CU_add_suite("Suite_list", NULL, NULL);
+    if (NULL == pSuite) {
+        return CU_get_error();
+    }
+
+    return add_tests(pSuite, table);
+}

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -38,5 +38,5 @@ CU_ErrorCode create_senml_json_suit(void);
 #endif
 CU_ErrorCode create_er_coap_parse_message_suit(void);
 CU_ErrorCode create_list_test_suit(void);
-
+CU_ErrorCode create_registration_test_suit(void);
 #endif /* TESTS_H_ */

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -84,6 +84,9 @@ int main(void) {
    if (CUE_SUCCESS != create_list_test_suit())
        goto exit;
 
+   if (CUE_SUCCESS != create_registration_test_suit())
+       goto exit;
+
    CU_basic_set_mode(CU_BRM_VERBOSE);
    CU_basic_run_tests();
    CU_basic_show_failures(CU_get_failure_list());

--- a/wakaama.cmake
+++ b/wakaama.cmake
@@ -121,13 +121,11 @@ add_compile_options(
     -Wswitch-default
     -Wwrite-strings
     -pedantic
-
     # Reduce noise: Unused parameters are common in this ifdef-littered code-base, but of no danger
     -Wno-unused-parameter
     # Reduce noise: Too many false positives
     -Wno-uninitialized
-
-     # Turn (most) warnings into errors
+    # Turn (most) warnings into errors
     -Werror
     # Disabled because of existing, non-trivially fixable code
     -Wno-error=cast-align


### PR DESCRIPTION
Registration messages without `rt="oma.lwm2m"` should be accepted as valid request.