### PR TITLE
Add test executables for different configurations

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -15,3 +15,13 @@ with section("format"):
 with section("markup"):
   # What character to use for bulleted lists
   bullet_char = '-'
+
+additional_commands = {
+  "add_test_variant": {
+    "kwargs": {
+      "TARGET_NAME": '*',
+      "SOURCE_FILES": '*',
+      "COMPILE_DEFINITIONS": '*',
+    }
+  }
+}

--- a/data/data.c
+++ b/data/data.c
@@ -577,7 +577,7 @@ int lwm2m_data_decode_bool(const lwm2m_data_t * dataP,
         break;
     }
 
-    LOG_ARG("result: %d, value: %s", result, *valueP ? "true" : "false");
+    LOG_ARG("result: %d, value: %s", result, result == 0 ? "undef" : (*valueP ? "true" : "false"));
 
     return result;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.13)
 project(lwm2munittests C)
 
 include(../wakaama.cmake)
+include(tests.cmake)
 
-add_executable(
-    lwm2munittests
+set(TEST_SOURCES
     block1tests.c
     block2tests.c
     cbor_tests.c
@@ -22,30 +22,76 @@ add_executable(
     uritests.c
 )
 
-include(FindPkgConfig)
-pkg_search_module(CUNIT REQUIRED IMPORTED_TARGET cunit)
-target_link_libraries(lwm2munittests PkgConfig::CUNIT)
-
-target_compile_definitions(
-    lwm2munittests PRIVATE LWM2M_CLIENT_MODE LWM2M_SERVER_MODE LWM2M_SUPPORT_TLV LWM2M_SUPPORT_JSON
-                           LWM2M_SUPPORT_SENML_CBOR
+add_test_variant(
+    TARGET_NAME lwm2munittests
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_CLIENT_MODE
 )
 
-# Our tests are designed for POSIX systems
-target_compile_definitions(lwm2munittests PRIVATE _POSIX_C_SOURCE=200809)
+add_test_variant(
+    TARGET_NAME lwm2munittests_client_lwm2m_1_0
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_CLIENT_MODE LWM2M_VERSION_1_0
+)
 
-target_sources_wakaama(lwm2munittests)
-target_sources_shared(lwm2munittests)
+add_test_variant(
+    TARGET_NAME lwm2munittests_client_bootstrap
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_CLIENT_MODE LWM2M_BOOTSTRAP
+)
 
-if(SANITIZER)
-    target_compile_options(lwm2munittests PRIVATE -fsanitize=${SANITIZER} -fno-sanitize-recover=all)
-    target_link_options(lwm2munittests PRIVATE -fsanitize=${SANITIZER} -fno-sanitize-recover=all)
-endif()
+add_test_variant(
+    TARGET_NAME lwm2munittests_server
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_SERVER_MODE LWM2M_WITH_LOGS
+)
 
-if(COVERAGE)
-    target_compile_options(lwm2munittests PRIVATE --coverage)
-    target_link_options(lwm2munittests PRIVATE --coverage)
-endif()
+add_test_variant(
+    TARGET_NAME lwm2munittests_server_formats
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_SERVER_MODE LWM2M_OLD_CONTENT_FORMAT_SUPPORT LWM2M_SUPPORT_SENML_JSON
+)
 
-# Add our unit tests to the "test" target
-add_test(NAME lwm2munittests_test COMMAND lwm2munittests)
+add_test_variant(
+    TARGET_NAME lwm2munittests_bootstrap_server
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_BOOTSTRAP_SERVER_MODE
+)
+
+add_test_variant(
+    TARGET_NAME lwm2munittests_server_and_bootstrap_server
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_SERVER_MODE LWM2M_BOOTSTRAP_SERVER_MODE
+)
+
+add_test_variant(
+    TARGET_NAME lwm2munittests_server_blocksize_16
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_CLIENT_MODE COAP_DEFAULT_BLOCK_SIZE=16
+)
+
+add_test_variant(
+    TARGET_NAME lwm2munittests_server_blocksize_64
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_SERVER_MODE COAP_DEFAULT_BLOCK_SIZE=64
+)
+
+add_test_variant(
+    TARGET_NAME lwm2munittests_server_blocksize_1024
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS LWM2M_SERVER_MODE COAP_DEFAULT_BLOCK_SIZE=1024
+)
+
+add_test_variant(
+    TARGET_NAME lwm2munittests_client_server_bootstrap_all_formats
+    SOURCE_FILES ${TEST_SOURCES}
+    COMPILE_DEFINITIONS
+        LWM2M_CLIENT_MODE
+        LWM2M_SERVER_MODE
+        LWM2M_BOOTSTRAP_SERVER_MODE
+        LWM2M_SERVER_MODE
+        LWM2M_WITH_LOGS
+        LWM2M_OLD_CONTENT_FORMAT_SUPPORT
+        LWM2M_SUPPORT_SENML_JSON
+        COAP_DEFAULT_BLOCK_SIZE=32
+)

--- a/tests/registration_tests.c
+++ b/tests/registration_tests.c
@@ -21,6 +21,8 @@
 #include "liblwm2m.h"
 #include "tests.h"
 
+#ifdef LWM2M_SERVER_MODE
+
 static void init_test_packet(coap_packet_t *message, const char *registration_message, uint8_t *payload,
                              const size_t payload_len) {
     int ret = 0;
@@ -110,3 +112,5 @@ CU_ErrorCode create_registration_test_suit(void) {
 
     return add_tests(pSuite, table);
 }
+
+#endif /* LWM2M_SERVER_MODE */

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -1,0 +1,45 @@
+# Run the unit tests with different configurations (defines)
+# ~~~
+# TARGET_NAME: The name of the test executable target
+# SOURCE_FILES: Source files used for the test
+# COMPILE_DEFINITIONS: Defines set for this test variant
+function(add_test_variant)
+    set(oneValueArgs TARGET_NAME)
+    set(multiValueArgs SOURCE_FILES COMPILE_DEFINITIONS)
+    cmake_parse_arguments(ADD_TEST_VARIANT_ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    add_executable(${ADD_TEST_VARIANT_ARG_TARGET_NAME})
+    target_sources(${ADD_TEST_VARIANT_ARG_TARGET_NAME} PRIVATE ${ADD_TEST_VARIANT_ARG_SOURCE_FILES})
+
+    # link CUnit
+    include(FindPkgConfig)
+    pkg_search_module(CUNIT REQUIRED IMPORTED_TARGET cunit)
+    target_link_libraries(${ADD_TEST_VARIANT_ARG_TARGET_NAME} PkgConfig::CUNIT)
+
+    # Currently we require that TLV and JSON is available in all tests
+    target_compile_definitions(${ADD_TEST_VARIANT_ARG_TARGET_NAME} PRIVATE LWM2M_SUPPORT_TLV LWM2M_SUPPORT_JSON)
+    target_compile_definitions(${ADD_TEST_VARIANT_ARG_TARGET_NAME} PRIVATE ${ADD_TEST_VARIANT_ARG_COMPILE_DEFINITIONS})
+
+    # Our tests are designed for POSIX systems
+    target_compile_definitions(${ADD_TEST_VARIANT_ARG_TARGET_NAME} PRIVATE _POSIX_C_SOURCE=200809)
+
+    target_sources_wakaama(${ADD_TEST_VARIANT_ARG_TARGET_NAME})
+    target_sources_shared(${ADD_TEST_VARIANT_ARG_TARGET_NAME})
+
+    if(SANITIZER)
+        target_compile_options(
+            ${ADD_TEST_VARIANT_ARG_TARGET_NAME} PRIVATE -fsanitize=${SANITIZER} -fno-sanitize-recover=all
+        )
+        target_link_options(
+            ${ADD_TEST_VARIANT_ARG_TARGET_NAME} PRIVATE -fsanitize=${SANITIZER} -fno-sanitize-recover=all
+        )
+    endif()
+
+    if(COVERAGE)
+        target_compile_options(${ADD_TEST_VARIANT_ARG_TARGET_NAME} PRIVATE --coverage)
+        target_link_options(${ADD_TEST_VARIANT_ARG_TARGET_NAME} PRIVATE --coverage)
+    endif()
+
+    # Add our unit tests to the "test" target
+    add_test(NAME ${ADD_TEST_VARIANT_ARG_TARGET_NAME}_test COMMAND ${ADD_TEST_VARIANT_ARG_TARGET_NAME})
+endfunction()

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -44,5 +44,7 @@ CU_ErrorCode create_senml_cbor_suit(void);
 #endif
 CU_ErrorCode create_er_coap_parse_message_suit(void);
 CU_ErrorCode create_list_test_suit(void);
+#ifdef LWM2M_SERVER_MODE
 CU_ErrorCode create_registration_test_suit(void);
+#endif
 #endif /* TESTS_H_ */

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -93,9 +93,10 @@ int main(void) {
 
    if (CUE_SUCCESS != create_list_test_suit())
        goto exit;
-
+#ifdef LWM2M_SERVER_MODE
    if (CUE_SUCCESS != create_registration_test_suit())
        goto exit;
+#endif
 
    CU_basic_set_mode(CU_BRM_VERBOSE);
    CU_basic_run_tests();

--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -153,7 +153,7 @@ function run_build() {
 }
 
 function run_tests() {
-  build-wakaama/tests/lwm2munittests
+  ${OPT_WRAPPER_CMD} cmake --build build-wakaama --target test
 
   mkdir -p "${REPO_ROOT_DIR}/build-wakaama/coverage"
 


### PR DESCRIPTION
The same tests are compiled and ran with different defines to make sure that combinations of different configurations work properly.

Some combinations of defines are added. This can be extended to include other interesting configuration combinations.