### PR TITLE
ci: Fix the collection of coverage information

### DIFF
--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -161,7 +161,7 @@ function run_tests() {
   fi
 
   #see https://github.com/koalaman/shellcheck/wiki/SC2089
-  gcovr_opts=(-r "${REPO_ROOT_DIR}/build-wakaama" \
+  gcovr_opts=(-r "${REPO_ROOT_DIR}/" \
     --keep `: # Needed for SonarQube` \
     --exclude "${REPO_ROOT_DIR}"/examples \
     --exclude "${REPO_ROOT_DIR}"/tests)


### PR DESCRIPTION
Informations from the source files were missing in the coverage report. Therefore `gcovr` is started from the root directory of the project.