### PR TITLE
ci: Fix building and running with sanitizers

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -35,13 +35,13 @@ jobs:
 
     - name: Build all binaries
       run: |
-        tools/ci/run_ci.sh --run-build --verbose
+        tools/ci/run_ci.sh --run-build --sanitizer ${{ matrix.sanitizer }}  --verbose
       env:
         CC:  ${{ matrix.compiler }}
 
     - name: Build, execute sanitized unit tests
       run: |
-        tools/ci/run_ci.sh --run-tests --sanitizer ${{ matrix.sanitizer }}
+        tools/ci/run_ci.sh --run-tests
       env:
         CC:  ${{ matrix.compiler }}
 

--- a/data/cbor.c
+++ b/data/cbor.c
@@ -639,7 +639,9 @@ int cbor_serialize(const lwm2m_uri_t *uriP, int size, const lwm2m_data_t *dataP,
             if (*bufferP != NULL) {
                 result = res + dataP->value.asBuffer.length;
                 memcpy(*bufferP, tmp, res);
-                memcpy((*bufferP) + res, dataP->value.asBuffer.buffer, dataP->value.asBuffer.length);
+                if (dataP->value.asBuffer.buffer != NULL) {
+                    memcpy((*bufferP) + res, dataP->value.asBuffer.buffer, dataP->value.asBuffer.length);
+                }
             }
         }
         break;

--- a/data/data.c
+++ b/data/data.c
@@ -880,10 +880,12 @@ int lwm2m_data_append_one(int *sizeP, lwm2m_data_t **dataP, lwm2m_data_type_t ty
         lwm2m_data_t *tmpDataP = lwm2m_data_new(tmpSize);
         if (tmpDataP != NULL) {
             // Shallow copy into new array
-            memcpy(tmpDataP, *dataP, (*sizeP) * sizeof(lwm2m_data_t));
-            // Shallow free old data
-            memset(*dataP, 0, (*sizeP) * sizeof(lwm2m_data_t));
-            lwm2m_data_free(*sizeP, *dataP);
+            if (*dataP != NULL) {
+                memcpy(tmpDataP, *dataP, (*sizeP) * sizeof(lwm2m_data_t));
+                // Shallow free old data
+                memset(*dataP, 0, (*sizeP) * sizeof(lwm2m_data_t));
+                lwm2m_data_free(*sizeP, *dataP);
+            }
             // Set the new one
             tmpDataP[*sizeP].id = id;
             tmpDataP[*sizeP].type = type;

--- a/tests/cbor_tests.c
+++ b/tests/cbor_tests.c
@@ -121,8 +121,9 @@ static void cbor_test_data_expected(const char *uriStr, lwm2m_data_t *dataP, con
             case LWM2M_TYPE_STRING:
             case LWM2M_TYPE_OPAQUE:
                 if (tlvP->type != dataP->type || tlvP->value.asBuffer.length != dataP->value.asBuffer.length ||
-                    memcmp(tlvP->value.asBuffer.buffer, dataP->value.asBuffer.buffer, tlvP->value.asBuffer.length) !=
-                        0) {
+                    (dataP->value.asBuffer.buffer != NULL &&
+                     memcmp(tlvP->value.asBuffer.buffer, dataP->value.asBuffer.buffer, tlvP->value.asBuffer.length) !=
+                         0)) {
                     printf("(Parsing %s from %s differs from original.)\t", id, STR_MEDIA_TYPE(format));
                     CU_TEST(CU_FALSE);
                 }


### PR DESCRIPTION
The sanitizers need to be activated at configuration time of the CMake project. Not when executing the build command.