### PR TITLE
ci: Fail if cmake-format finds problem

### DIFF
--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -125,6 +125,7 @@ function run_cmake_format() {
   # ensures we can run cmake-format on all CMake files at any time.
   if ! git ls-files '*CMakeLists.txt' '*.cmake' | xargs cmake-format --check; then
     echo 'Please run cmake-format on all (changed) CMake files.'
+    exit 1
   fi
 }
 


### PR DESCRIPTION
If cmake-format found an error it was silently
dropped in CI. Now the `run_ci.sh` scripts returns an error in case of failure.