### PR TITLE
ci: Pin version of `gitlint`

### DIFF
--- a/tools/requirements-compliance.txt
+++ b/tools/requirements-compliance.txt
@@ -1,4 +1,4 @@
 cmake-format
-gitlint
+gitlint~=0.19
 pylint
 -r ../tests/integration/requirements.txt


### PR DESCRIPTION
Older versions of `gitlint` don't know the configuration option `regex-style-search` that we require.