### PR TITLE
ci: Fix SonarCloud

### DIFF
--- a/tools/ci/run_ci.sh
+++ b/tools/ci/run_ci.sh
@@ -153,7 +153,7 @@ function run_build() {
 }
 
 function run_tests() {
-  ${OPT_WRAPPER_CMD} cmake --build build-wakaama --target test
+  cmake --build build-wakaama --target test
 
   mkdir -p "${REPO_ROOT_DIR}/build-wakaama/coverage"
 


### PR DESCRIPTION
The output of the sonar build wrapper was
overwritten when the tests where ran with
the wrapper. The wrapper is needed during
the build. But not for running the tests.