### PR TITLE
ci: Update `sonar-scanner` Github action

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -1,6 +1,10 @@
 name: SonarCloud
 
-on: [push]
+on:
+  push:
+    branches: '**'
+  pull_request:
+    branches: '**'
 
 jobs:
   sonarcloud:

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Run SonarCloud Scan
       run: |
-          sonar-scanner \
+          sonar-scanner -X \
           -Dsonar.branch.name="${GITHUB_REF_NAME}" \
           -Dsonar.cfamily.build-wrapper-output=build-wakaama/sonar-cloud-build-wrapper-output \
           -Dsonar.cfamily.cache.enabled=false \
@@ -64,3 +64,4 @@ jobs:
           -Dsonar.sources=.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup SonarScanner
       uses: warchant/setup-sonar-scanner@v7
       with:
-        version: 5.0.1.3006
+        version: 4.1
 
     - name: Install Build Wrapper
       run: |

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -48,6 +48,8 @@ jobs:
 
     - name: Run SonarCloud Scan
       run: |
+          echo -Dsonar.organization=${{ github.repository_owner }}; \
+          echo -Dsonar.projectKey="$(echo ${{ github.repository }} | tr / _)"; \
           sonar-scanner -X \
           -Dsonar.branch.name=master \
           -Dsonar.cfamily.build-wrapper-output=build-wakaama/sonar-cloud-build-wrapper-output \
@@ -59,7 +61,6 @@ jobs:
           -Dsonar.login=${{ secrets.SONAR_TOKEN }} \
           -Dsonar.organization=${{ github.repository_owner }} \
           -Dsonar.projectKey="$(echo ${{ github.repository }} | tr / _)" \
-          -Dsonar.organization=eclipse \
           -Dsonar.sourceEncoding=UTF-8 \
           -Dsonar.sources=.
       env:

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -25,9 +25,9 @@ jobs:
       uses: seanmiddleditch/gha-setup-ninja@master
 
     - name: Setup SonarScanner
-      uses: warchant/setup-sonar-scanner@v3
+      uses: warchant/setup-sonar-scanner@v7
       with:
-        version: 4.6.0.2311
+        version: 5.0.1.3006
 
     - name: Install Build Wrapper
       run: |

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: Run SonarCloud Scan
       run: |
           sonar-scanner -X \
-          -Dsonar.branch.name="${GITHUB_REF_NAME}" \
+          -Dsonar.branch.name=master \
           -Dsonar.cfamily.build-wrapper-output=build-wakaama/sonar-cloud-build-wrapper-output \
           -Dsonar.cfamily.cache.enabled=false \
           -Dsonar.cfamily.gcov.reportsPath=build-wakaama \

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -59,6 +59,7 @@ jobs:
           -Dsonar.login=${{ secrets.SONAR_TOKEN }} \
           -Dsonar.organization=${{ github.repository_owner }} \
           -Dsonar.projectKey="$(echo ${{ github.repository }} | tr / _)" \
+          -Dsonar.organization=eclipse \
           -Dsonar.sourceEncoding=UTF-8 \
           -Dsonar.sources=.
       env:

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -48,9 +48,7 @@ jobs:
 
     - name: Run SonarCloud Scan
       run: |
-          echo -Dsonar.organization=${{ github.repository_owner }}; \
-          echo -Dsonar.projectKey="$(echo ${{ github.repository }} | tr / _)"; \
-          sonar-scanner -X \
+          sonar-scanner \
           -Dsonar.branch.name=master \
           -Dsonar.cfamily.build-wrapper-output=build-wakaama/sonar-cloud-build-wrapper-output \
           -Dsonar.cfamily.cache.enabled=false \
@@ -58,7 +56,6 @@ jobs:
           -Dsonar.cfamily.threads=2 \
           -Dsonar.exclusions="build-wakaama-*/**, .git/**" \
           -Dsonar.host.url=https://sonarcloud.io \
-          -Dsonar.login=${{ secrets.SONAR_TOKEN }} \
           -Dsonar.organization=${{ github.repository_owner }} \
           -Dsonar.projectKey="$(echo ${{ github.repository }} | tr / _)" \
           -Dsonar.sourceEncoding=UTF-8 \


### PR DESCRIPTION
The old version of the `sonar-scanner` depends on
nodejs 14 which is deprecated.