### PR TITLE
testing: Fix functions with missing `void` argument

### DIFF
--- a/tests/cbor_tests.c
+++ b/tests/cbor_tests.c
@@ -1187,7 +1187,7 @@ static struct TestTable table[] = {
     {"test of cbor_test_83()", cbor_test_83}, {NULL, NULL},
 };
 
-CU_ErrorCode create_cbor_suit() {
+CU_ErrorCode create_cbor_suit(void) {
     CU_pSuite pSuite = NULL;
 
     pSuite = CU_add_suite("Suite_CBOR", NULL, NULL);

--- a/tests/senml_cbor_tests.c
+++ b/tests/senml_cbor_tests.c
@@ -819,7 +819,7 @@ static struct TestTable table[] = {
     {"test of senml_cbor_test_31()", senml_cbor_test_31}, {NULL, NULL},
 };
 
-CU_ErrorCode create_senml_cbor_suit() {
+CU_ErrorCode create_senml_cbor_suit(void) {
     CU_pSuite pSuite = NULL;
 
     pSuite = CU_add_suite("Suite_SenML_CBOR", NULL, NULL);

--- a/tests/senml_json_tests.c
+++ b/tests/senml_json_tests.c
@@ -683,16 +683,15 @@ static struct TestTable table[] = {
         { NULL, NULL },
 };
 
-CU_ErrorCode create_senml_json_suit()
-{
-   CU_pSuite pSuite = NULL;
+CU_ErrorCode create_senml_json_suit(void) {
+    CU_pSuite pSuite = NULL;
 
-   pSuite = CU_add_suite("Suite_SenML_JSON", NULL, NULL);
-   if (NULL == pSuite) {
-      return CU_get_error();
-   }
+    pSuite = CU_add_suite("Suite_SenML_JSON", NULL, NULL);
+    if (NULL == pSuite) {
+        return CU_get_error();
+    }
 
-   return add_tests(pSuite, table);
+    return add_tests(pSuite, table);
 }
 
 #endif


### PR DESCRIPTION
The `void` argument was present in the declaration but not in the definition.