### PR TITLE
ci: Install build tools from apt package manager

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,13 +22,7 @@ jobs:
     - name: Install dependencies from APT repository
       run: |
         sudo apt-get update
-        sudo apt-get install libcunit1-dev wget unzip
-
-    - name: Install CMake
-      uses: lukka/get-cmake@latest
-
-    - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+        sudo apt-get install cmake libcunit1-dev ninja-build unzip wget
 
     - name: Build all binaries
       run: |
@@ -56,13 +50,7 @@ jobs:
     - name: Install dependencies from APT repository
       run: |
         sudo apt-get update
-        sudo apt-get install libcunit1-dev wget unzip
-
-    - name: Install CMake
-      uses: lukka/get-cmake@latest
-
-    - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+        sudo apt-get install cmake libcunit1-dev ninja-build unzip wget
 
     - name: Build examples as stand-alone projects
       run: |

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -25,13 +25,7 @@ jobs:
     - name: Install dependencies from APT repository
       run: |
         sudo apt-get update
-        sudo apt-get install libcunit1-dev wget unzip
-
-    - name: Install CMake
-      uses: lukka/get-cmake@latest
-
-    - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+        sudo apt-get install cmake libcunit1-dev ninja-build unzip wget
 
     - name: Build all binaries
       run: |

--- a/.github/workflows/clang-static-analyzer.yaml
+++ b/.github/workflows/clang-static-analyzer.yaml
@@ -16,13 +16,7 @@ jobs:
     - name: Install dependencies from APT repository
       run:  |
         sudo apt-get update
-        sudo apt-get install clang-tools-14 libcunit1-dev wget unzip
-
-    - name: Install CMake
-      uses: lukka/get-cmake@latest
-
-    - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+        sudo apt-get install clang-tools-14 cmake libcunit1-dev ninja-build unzip wget
 
     - name: Run Clang Static Analyzer
       run: tools/ci/run_ci.sh --run-build --scan-build scan-build-14

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,13 +22,7 @@ jobs:
     - name: Install dependencies from APT repository
       run: |
         sudo apt-get update
-        sudo apt-get install libcunit1-dev wget unzip
-
-    - name: Install CMake
-      uses: lukka/get-cmake@latest
-
-    - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+        sudo apt-get install cmake libcunit1-dev ninja-build unzip wget
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,13 +16,7 @@ jobs:
     - name: Install dependencies from APT repository
       run:  |
         sudo apt-get update
-        sudo apt-get install gcovr libcunit1-dev wget unzip
-
-    - name: Install CMake
-      uses: lukka/get-cmake@latest
-
-    - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+        sudo apt-get install cmake gcovr libcunit1-dev ninja-build unzip wget
 
     - name: Collect test coverage data
       run: |


### PR DESCRIPTION
Use apt to install cmake and ninja-build instead of using third party Github actions.